### PR TITLE
SLCORE-27 Add progress to update process

### DIFF
--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/client/api/common/CanceledException.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/client/api/common/CanceledException.java
@@ -19,11 +19,6 @@
  */
 package org.sonarsource.sonarlint.core.client.api.common;
 
-public class SonarLintException extends RuntimeException {
-  public SonarLintException() {
-    super();
-  }
-  public SonarLintException(String msg, Throwable cause) {
-    super(msg, cause);
-  }
+public class CanceledException extends SonarLintException {
+
 }

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
@@ -20,12 +20,12 @@
 package org.sonarsource.sonarlint.core.client.api.connected;
 
 import java.util.Map;
-import java.util.concurrent.CancellationException;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 import org.sonarsource.sonarlint.core.client.api.common.LogOutput;
+import org.sonarsource.sonarlint.core.client.api.common.CanceledException;
 import org.sonarsource.sonarlint.core.client.api.common.ProgressMonitor;
 import org.sonarsource.sonarlint.core.client.api.common.RuleDetails;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.AnalysisResults;
@@ -100,7 +100,7 @@ public interface ConnectedSonarLintEngine {
    * @since 2.0
    * @throws UnsupportedOperationException for standalone mode
    * @throws UnsupportedServerException if server version is too low
-   * @throws CancellationException if the update task was cancelled
+   * @throws CanceledException if the update task was cancelled
    */
   GlobalUpdateStatus update(ServerConfiguration serverConfig, @Nullable ProgressMonitor monitor);
   

--- a/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
@@ -55,7 +55,7 @@ public final class ConnectedSonarLintEngineImpl implements ConnectedSonarLintEng
   private StorageGlobalContainer globalContainer;
   private final ReadWriteLock rwl = new ReentrantReadWriteLock();
   private final List<StateListener> listeners = new CopyOnWriteArrayList<>();
-  private State state = State.UNKNOW;
+  private volatile State state = State.UNKNOW;
   private LogOutput logOutput = null;
 
   public ConnectedSonarLintEngineImpl(ConnectedGlobalConfiguration globalConfig) {

--- a/core/src/main/java/org/sonarsource/sonarlint/core/util/ProgressWrapper.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/util/ProgressWrapper.java
@@ -19,11 +19,10 @@
  */
 package org.sonarsource.sonarlint.core.util;
 
+import org.sonarsource.sonarlint.core.client.api.common.CanceledException;
 import org.sonarsource.sonarlint.core.client.api.common.ProgressMonitor;
 
 import javax.annotation.Nullable;
-
-import java.util.concurrent.CancellationException;
 
 public class ProgressWrapper {
   private ProgressMonitor handler;
@@ -39,7 +38,7 @@ public class ProgressWrapper {
   public void checkCancel() {
     if (handler.isCanceled()) {
       handler.setMessage("Cancelling");
-      throw new CancellationException();
+      throw new CanceledException();
     }
   }
 


### PR DESCRIPTION
java.util.concurrent.CancellationException gets wrapped, making it hard to catch it in client code.
We should probably not wrap java.util exceptions, but that would complicate too much the wrapping.