### PR TITLE
Optimize access to failed analysis files

### DIFF
--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/client/api/util/TextSearchIndex.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/client/api/util/TextSearchIndex.java
@@ -21,7 +21,6 @@ package org.sonarsource.sonarlint.core.client.api.util;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/DefaultAnalysisResult.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/analysis/DefaultAnalysisResult.java
@@ -19,16 +19,15 @@
  */
 package org.sonarsource.sonarlint.core.container.analysis;
 
-import java.nio.file.Path;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.sonarsource.sonarlint.core.client.api.common.analysis.AnalysisResults;
 import org.sonarsource.sonarlint.core.client.api.common.analysis.ClientInputFile;
 
 public class DefaultAnalysisResult implements AnalysisResults {
-  private Map<Path, ClientInputFile> failedAnalysisFiles = new HashMap<>();
+  private Set<ClientInputFile> failedAnalysisFiles = new LinkedHashSet<>();
   private int fileCount;
 
   public DefaultAnalysisResult setFileCount(int fileCount) {
@@ -37,7 +36,7 @@ public class DefaultAnalysisResult implements AnalysisResults {
   }
 
   public void addFailedAnalysisFile(ClientInputFile inputFile) {
-    failedAnalysisFiles.put(inputFile.getPath(), inputFile);
+    failedAnalysisFiles.add(inputFile);
   }
 
   @Override
@@ -47,7 +46,7 @@ public class DefaultAnalysisResult implements AnalysisResults {
 
   @Override
   public Collection<ClientInputFile> failedAnalysisFiles() {
-    return failedAnalysisFiles.values();
+    return failedAnalysisFiles;
   }
 
 }


### PR DESCRIPTION
I'm gonna assume that ClientInputFile either implements property hashcode/equals, or  there is a single instance per file (with different path). The goal is to have quick .contains() tests.