### PR TITLE
SLCORE-221 Whitelist XML

### DIFF
--- a/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginCacheLoader.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginCacheLoader.java
@@ -38,7 +38,7 @@ import org.sonarsource.sonarlint.core.plugin.cache.PluginCache;
 public class PluginCacheLoader {
 
   private static final ImmutableSet<String> PLUGIN_WHITELIST = ImmutableSet.of("xoo", "java", "javascript", "php", "python", "cobol", "abap", "plsql", "swift",
-    "rpg", "cpp", "pli", "typescript", "web", "kotlin", "ruby", "sonarscala");
+    "rpg", "cpp", "pli", "typescript", "web", "kotlin", "ruby", "sonarscala", "xml");
   private static final String IMPLEMENTED_SQ_API = "7.3";
 
   private static final Logger LOG = Loggers.get(PluginCacheLoader.class);

--- a/core/src/main/resources/plugins_min_versions.txt
+++ b/core/src/main/resources/plugins_min_versions.txt
@@ -16,3 +16,5 @@ web=2.6
 kotlin=1.2.1
 ruby=1.2.1
 scala=1.2.1
+# FIXME last release is 1.5 and next released version is 2.0, there is no 1.6
+xml=1.6

--- a/core/src/main/resources/plugins_stream_support.txt
+++ b/core/src/main/resources/plugins_stream_support.txt
@@ -14,3 +14,5 @@ web=3.0
 kotlin=1.1
 ruby=1.1
 scala=1.2.1
+# FIXME last release is 1.5 and next released version is 2.0, there is no 1.6
+xml=1.6

--- a/its/tests/projects/sample-xml/src/foo.xml
+++ b/its/tests/projects/sample-xml/src/foo.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<foo>
+  <bar>RAAAAAAAAAAAAAAAAAAAAAaaaaaaaaaaaaaaaaaAAAAAAAAAAAaaaaaaaaaaaaaaaaAAaaaaaaaaaaaaaaAAAAAAAAAAAAAaaaaaaaaaAAAAAAAGNAROK</bar>
+</foo>

--- a/its/tests/src/test/java/its/ConnectedModeTest.java
+++ b/its/tests/src/test/java/its/ConnectedModeTest.java
@@ -104,6 +104,7 @@ public class ConnectedModeTest extends AbstractConnectedTest {
   private static final String PROJECT_KEY_KOTLIN = "sample-kotlin";
   private static final String PROJECT_KEY_RUBY = "sample-ruby";
   private static final String PROJECT_KEY_SCALA = "sample-scala";
+  private static final String PROJECT_KEY_XML = "sample-xml";
 
   @ClassRule
   public static ExternalResource resource = new ExternalResource() {
@@ -122,6 +123,9 @@ public class ConnectedModeTest extends AbstractConnectedTest {
         .addPlugin(MavenLocation.of("org.sonarsource.slang", "sonar-ruby-plugin", "LATEST_RELEASE"))
         .addPlugin(MavenLocation.of("org.sonarsource.slang", "sonar-scala-plugin", "LATEST_RELEASE"))
         .addPlugin(MavenLocation.of("org.sonarsource.html", "sonar-html-plugin", "LATEST_RELEASE"))
+        // FIXME this is not a released version but the artifact from sonar-xml master
+        // corresponding to the commit enabling support of sonarlint
+        .addPlugin(MavenLocation.of("org.sonarsource.xml", "sonar-xml-plugin", "2.0.0.1974"))
         .addPlugin(FileLocation.of("../plugins/global-extension-plugin/target/global-extension-plugin.jar"))
         .addPlugin(FileLocation.of("../plugins/custom-sensor-plugin/target/custom-sensor-plugin.jar"))
         .addPlugin(FileLocation.of("../plugins/javascript-custom-rules/target/javascript-custom-rules-plugin.jar"))
@@ -138,7 +142,8 @@ public class ConnectedModeTest extends AbstractConnectedTest {
         .restoreProfileAtStartup(FileLocation.ofClasspath("/web-sonarlint.xml"))
         .restoreProfileAtStartup(FileLocation.ofClasspath("/kotlin-sonarlint.xml"))
         .restoreProfileAtStartup(FileLocation.ofClasspath("/ruby-sonarlint.xml"))
-        .restoreProfileAtStartup(FileLocation.ofClasspath("/scala-sonarlint.xml"));
+        .restoreProfileAtStartup(FileLocation.ofClasspath("/scala-sonarlint.xml"))
+        .restoreProfileAtStartup(FileLocation.ofClasspath("/xml-sonarlint.xml"));
 
       ORCHESTRATOR = orchestratorBuilder.build();
       ORCHESTRATOR.start();
@@ -197,6 +202,7 @@ public class ConnectedModeTest extends AbstractConnectedTest {
     ORCHESTRATOR.getServer().provisionProject(PROJECT_KEY_RUBY, "Sample Ruby");
     ORCHESTRATOR.getServer().provisionProject(PROJECT_KEY_KOTLIN, "Sample Kotlin");
     ORCHESTRATOR.getServer().provisionProject(PROJECT_KEY_SCALA, "Sample Scala");
+    ORCHESTRATOR.getServer().provisionProject(PROJECT_KEY_XML, "Sample XML");
 
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT_KEY_JAVA, "java", "SonarLint IT Java");
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT_KEY_JAVA_PACKAGE, "java", "SonarLint IT Java Package");
@@ -211,6 +217,7 @@ public class ConnectedModeTest extends AbstractConnectedTest {
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT_KEY_RUBY, "ruby", "SonarLint IT Ruby");
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT_KEY_KOTLIN, "kotlin", "SonarLint IT Kotlin");
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT_KEY_SCALA, "scala", "SonarLint IT Scala");
+    ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT_KEY_XML, "xml", "SonarLint IT XML");
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT_KEY_GLOBAL_EXTENSION, "global", "SonarLint IT Global Extension");
 
     // Build project to have bytecode
@@ -281,10 +288,10 @@ public class ConnectedModeTest extends AbstractConnectedTest {
   @Test
   public void downloadProjects() {
     updateGlobal();
-    assertThat(engine.allProjectsByKey()).hasSize(14);
+    assertThat(engine.allProjectsByKey()).hasSize(15);
     ORCHESTRATOR.getServer().provisionProject("foo-bar", "Foo");
-    assertThat(engine.downloadAllProjects(getServerConfig(), null)).hasSize(15).containsKeys("foo-bar", PROJECT_KEY_JAVA, PROJECT_KEY_PHP);
-    assertThat(engine.allProjectsByKey()).hasSize(15).containsKeys("foo-bar", PROJECT_KEY_JAVA, PROJECT_KEY_PHP);
+    assertThat(engine.downloadAllProjects(getServerConfig(), null)).hasSize(16).containsKeys("foo-bar", PROJECT_KEY_JAVA, PROJECT_KEY_PHP);
+    assertThat(engine.allProjectsByKey()).hasSize(16).containsKeys("foo-bar", PROJECT_KEY_JAVA, PROJECT_KEY_PHP);
   }
 
   @Test
@@ -768,6 +775,16 @@ public class ConnectedModeTest extends AbstractConnectedTest {
 
     SaveIssueListener issueListener = new SaveIssueListener();
     engine.analyze(createAnalysisConfiguration(PROJECT_KEY_SCALA, PROJECT_KEY_SCALA, "src/Hello.scala"), issueListener, null, null);
+    assertThat(issueListener.getIssues()).hasSize(1);
+  }
+
+  @Test
+  public void analysisXml() throws Exception {
+    updateGlobal();
+    updateProject(PROJECT_KEY_XML);
+
+    SaveIssueListener issueListener = new SaveIssueListener();
+    engine.analyze(createAnalysisConfiguration(PROJECT_KEY_XML, PROJECT_KEY_XML, "src/foo.xml"), issueListener, null, null);
     assertThat(issueListener.getIssues()).hasSize(1);
   }
 

--- a/its/tests/src/test/resources/xml-sonarlint.xml
+++ b/its/tests/src/test/resources/xml-sonarlint.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<profile>
+  <name>SonarLint IT XML</name>
+  <language>xml</language>
+  <rules>
+    <rule>
+      <repositoryKey>xml</repositoryKey>
+      <!-- Lines should not be too long (120 char) -->
+      <key>S103</key>
+      <priority>MAJOR</priority>
+    </rule>
+  </rules>
+</profile>


### PR DESCRIPTION
Relates to [SONARXML-71](https://jira.sonarsource.com/browse/SONARXML-71) and associated PR: https://github.com/SonarSource/sonar-xml/pull/110
Requires fix #237
Changes are split in 2 commits:

* 1st commit to whitelist XML. This one will allow the XML plugin to have valid ITs testing compatibility.
* 2nd commit adds ITs relying on unreleased version of SonarXML.