### PR TITLE
SLCORE-266 Optimize file matching algorithm

### DIFF
--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/FileMatcher.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/FileMatcher.java
@@ -26,6 +26,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.util.ReversePathTree;
 
@@ -33,12 +35,14 @@ import static java.util.Collections.reverseOrder;
 
 public class FileMatcher {
 
-  public Result match(List<Path> sqRelativePaths, List<Path> ideRelativePaths) {
+  public Result match(List<Path> serverRelativePaths, List<Path> ideRelativePaths) {
     ReversePathTree reversePathTree = new ReversePathTree();
 
     Map<Result, Double> resultScores = new LinkedHashMap<>();
 
-    sqRelativePaths.forEach(reversePathTree::index);
+    // No need to index server files if no ide path ends with the same filename
+    Set<Path> ideFilenames = ideRelativePaths.stream().map(idePath -> idePath.getFileName()).collect(Collectors.toSet());
+    serverRelativePaths.stream().filter(sqPath -> ideFilenames.contains(sqPath.getFileName())).forEach(reversePathTree::index);
 
     for (Path ide : ideRelativePaths) {
       ReversePathTree.Match match = reversePathTree.findLongestSuffixMatches(ide);

--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/FileMatcher.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/storage/FileMatcher.java
@@ -41,7 +41,7 @@ public class FileMatcher {
     Map<Result, Double> resultScores = new LinkedHashMap<>();
 
     // No need to index server files if no ide path ends with the same filename
-    Set<Path> ideFilenames = ideRelativePaths.stream().map(idePath -> idePath.getFileName()).collect(Collectors.toSet());
+    Set<Path> ideFilenames = ideRelativePaths.stream().map(Path::getFileName).collect(Collectors.toSet());
     serverRelativePaths.stream().filter(sqPath -> ideFilenames.contains(sqPath.getFileName())).forEach(reversePathTree::index);
 
     for (Path ide : ideRelativePaths) {

--- a/core/src/main/java/org/sonarsource/sonarlint/core/util/ReversePathTree.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/util/ReversePathTree.java
@@ -24,7 +24,7 @@ import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -96,7 +96,7 @@ public class ReversePathTree {
         singleChildValue = new OptimizedNode();
         return singleChildValue;
       } else if (children == null) {
-        children = new LinkedHashMap<>();
+        children = new HashMap<>();
         children.put(singleChildKey, singleChildValue);
         OptimizedNode value = new OptimizedNode();
         children.put(name, value);

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/storage/FileMatcherTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/storage/FileMatcherTest.java
@@ -27,7 +27,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -127,7 +129,8 @@ public class FileMatcherTest {
     assertThat(match.sqPrefix()).isEqualTo(Paths.get("sq/news"));
   }
 
-  // @Disabled("Only used to investigate performance issues like SLE-344")
+  @Disabled("Only used to investigate performance issues like SLE-344")
+  @Ignore
   @Test
   public void performance_test() throws Exception {
     int depthFactor = 10;

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/storage/FileMatcherTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/storage/FileMatcherTest.java
@@ -21,6 +21,9 @@ package org.sonarsource.sonarlint.core.container.storage;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -122,6 +125,47 @@ public class FileMatcherTest {
     assertThat(match.idePrefix()).isEqualTo(Paths.get("local/sub"));
     // sq/news is preferred to sq/products because of lexicographic order
     assertThat(match.sqPrefix()).isEqualTo(Paths.get("sq/news"));
+  }
+
+  // @Disabled("Only used to investigate performance issues like SLE-344")
+  @Test
+  public void performance_test() throws Exception {
+    int depthFactor = 10;
+    int sqNbPerFolder = 10;
+    int sqDepth = 5;
+    int ideNbPerFolder = 10;
+    int ideDepth = 3;
+    List<Path> idePaths = generateChildren(Paths.get("local/sub/src/main/java/com/mycompany/myapp/foo/bar"), ideNbPerFolder, depthFactor, ideDepth * depthFactor);
+    System.out.println("IDE file count: " + idePaths.size());
+    assertThat(idePaths).hasSize((int) Math.pow(ideNbPerFolder, ideDepth + 1));
+    List<Path> sqPaths = generateChildren(Paths.get("sq/src/main/java/com/mycompany/myapp/foo/bar"), sqNbPerFolder, depthFactor, sqDepth * depthFactor);
+    System.out.println("SQ file count: " + sqPaths.size());
+    assertThat(sqPaths).hasSize((int) Math.pow(sqNbPerFolder, sqDepth + 1));
+    Instant start = Instant.now();
+    FileMatcher.Result match = fileMatcher.match(sqPaths, idePaths);
+    System.out.println(Duration.between(start, Instant.now()).toMillis() + "ms ellapsed");
+    assertThat(match.idePrefix()).isEqualTo(Paths.get("local/sub/src/main/java/com/mycompany/myapp/foo/bar"));
+    // sq/folder0/[...]/folder0 is preferred to other sq/folderx because of lexicographic order
+    assertThat(match.sqPrefix()).isEqualTo(Paths.get(
+      "sq/src/main/java/com/mycompany/myapp/foo/bar/folder0/extra49/extra48/extra47/extra46/extra45/extra44/extra43/extra42/extra41/folder0/extra39/extra38/extra37/extra36/extra35/extra34/extra33/extra32/extra31"));
+  }
+
+  private List<Path> generateChildren(Path parent, int count, int everyDepth, int depth) {
+    List<Path> result = new ArrayList<>();
+    if (depth == 0) {
+      for (int i = 0; i < count; i++) {
+        result.add(parent.resolve("file" + i + ".txt"));
+      }
+    } else if (depth % everyDepth == 0) {
+      for (int i = 0; i < count; i++) {
+        Path current = parent.resolve("folder" + i);
+        result.addAll(generateChildren(current, count, everyDepth, depth - 1));
+      }
+    } else {
+      Path current = parent.resolve("extra" + depth);
+      result.addAll(generateChildren(current, count, everyDepth, depth - 1));
+    }
+    return result;
   }
 
   @Test

--- a/core/src/test/java/org/sonarsource/sonarlint/core/util/ReversePathTreeTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/util/ReversePathTreeTest.java
@@ -28,6 +28,16 @@ public class ReversePathTreeTest {
   private ReversePathTree tree = new ReversePathTree();
 
   @Test
+  public void should_return_matching_prefix() {
+    tree.index(Paths.get("A/src/main/java/File.java"));
+
+    ReversePathTree.Match match = tree.findLongestSuffixMatches(Paths.get("B/src/main/java/File.java"));
+
+    assertThat(match.matchLen()).isEqualTo(4);
+    assertThat(match.matchPrefixes()).containsExactly(Paths.get("A"));
+  }
+
+  @Test
   public void should_return_matching_prefixes() {
     tree.index(Paths.get("project1/src/main/java/File.java"));
     tree.index(Paths.get("project2/src/main/java/File.java"));

--- a/core/src/test/java/org/sonarsource/sonarlint/core/util/ReversePathTreeTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/util/ReversePathTreeTest.java
@@ -46,7 +46,7 @@ public class ReversePathTreeTest {
     ReversePathTree.Match match = tree.findLongestSuffixMatches(Paths.get("src/main/java/File.java"));
 
     assertThat(match.matchLen()).isEqualTo(4);
-    assertThat(match.matchPrefixes()).containsExactly(Paths.get("project1"), Paths.get("project2"));
+    assertThat(match.matchPrefixes()).containsExactlyInAnyOrder(Paths.get("project1"), Paths.get("project2"));
   }
 
   @Test


### PR DESCRIPTION
Two optimizations:
* since in real life projects, many folders will have only one child, optimize the `Node` for the "one child" case
* use `Path` as key instead of converting back and forth `String` (minor)

Performance measures on my computer (Linux jdk 1.8.0_231), using test `FileMatcherTest#performance_test` (1M SQ files, 10k project files, very deep folders)
* before: ~20s, max heap: 3750Mb
![before](https://user-images.githubusercontent.com/281596/77348229-626b8b00-6d39-11ea-806e-185ac26fd760.png)

* after: ~9s, max heap: 2250Mb
![after](https://user-images.githubusercontent.com/281596/77348246-67303f00-6d39-11ea-88ec-0df8c867d971.png)
