### PR TITLE
Use different caches per job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,10 +40,7 @@ stages:
         fetchDepth: 1
       - task: Cache@2
         inputs:
-          key: 'maven | "$(Agent.OS)" | **/pom.xml'
-          restoreKeys: |
-            maven | "$(Agent.OS)"
-            maven
+          key: 'build | maven | "$(Agent.OS)" | **/pom.xml, !its/**'
           path: $(MAVEN_CACHE_FOLDER)
         displayName: Cache Maven local repo
       - task: DownloadSecureFile@1
@@ -117,10 +114,7 @@ stages:
         fetchDepth: 1
       - task: Cache@2
         inputs:
-          key: 'maven | "$(Agent.OS)" | **/pom.xml'
-          restoreKeys: |
-            maven | "$(Agent.OS)"
-            maven
+          key: 'validate_win | maven | "$(Agent.OS)" | **/pom.xml, !its/**'
           path: $(MAVEN_CACHE_FOLDER)
         displayName: Cache Maven local repo
       - task: DownloadSecureFile@1
@@ -154,10 +148,7 @@ stages:
         fetchDepth: 1
       - task: Cache@2
         inputs:
-          key: 'maven | "$(Agent.OS)" | **/pom.xml'
-          restoreKeys: |
-            maven | "$(Agent.OS)"
-            maven
+          key: 'validate_linux | maven | "$(Agent.OS)" | **/pom.xml, !its/**'
           path: $(MAVEN_CACHE_FOLDER)
         displayName: Cache Maven local repo
       - task: DownloadSecureFile@1
@@ -187,10 +178,7 @@ stages:
       steps:
       - task: Cache@2
         inputs:
-          key: 'maven | "$(Agent.OS)" | **/pom.xml'
-          restoreKeys: |
-            maven | "$(Agent.OS)"
-            maven
+          key: 'sq | maven | "$(Agent.OS)" | **/pom.xml, !its/**'
           path: $(MAVEN_CACHE_FOLDER)
         displayName: Cache Maven local repo
       - task: DownloadSecureFile@1
@@ -252,10 +240,7 @@ stages:
         fetchDepth: 1
       - task: Cache@2
         inputs:
-          key: 'maven | "$(Agent.OS)" | **/pom.xml'
-          restoreKeys: |
-            maven | "$(Agent.OS)"
-            maven
+          key: 'its | "$(SQ_VERSION)" | maven | "$(Agent.OS)" | **/pom.xml'
           path: $(MAVEN_CACHE_FOLDER)
         displayName: Cache Maven local repo
       - task: DownloadSecureFile@1


### PR DESCRIPTION
We don't want to share the same cache between different jobs of the pipeline, because the content will not be the same depending on the Maven goal that is executed.
