### PR TITLE
move methods to core since they are used in VSCode LS also

### DIFF
--- a/core/src/main/java/org/sonarsource/sonarlint/core/util/StringUtils.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/util/StringUtils.java
@@ -111,4 +111,16 @@ public class StringUtils {
     }
     return sb.toString();
   }
+
+  public static boolean equalsIgnoringTrailingSlash(String aString, String anotherString) {
+    return withTrailingSlash(aString).equals(withTrailingSlash(anotherString));
+  }
+
+  private static String withTrailingSlash(String str) {
+    if (!str.endsWith("/")) {
+      return str + '/';
+    }
+    return str;
+  }
+
 }

--- a/core/src/test/java/org/sonarsource/sonarlint/core/util/StringUtilsTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/util/StringUtilsTest.java
@@ -20,6 +20,7 @@
 package org.sonarsource.sonarlint.core.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonarsource.sonarlint.core.util.StringUtils.equalsIgnoringTrailingSlash;
 import static org.sonarsource.sonarlint.core.util.StringUtils.isEmpty;
 
 import org.junit.Test;
@@ -68,4 +69,20 @@ public class StringUtilsTest {
   public void test_whitespace_string_is_not_empty() {
     assertThat(isEmpty("  ")).isFalse();
   }
+
+  @Test
+  public void test_equalsIgnoringTrailingSlash_same_strings_different_trails() {
+    assertThat(equalsIgnoringTrailingSlash("too", "too/")).isTrue();
+  }
+
+  @Test
+  public void test_equalsIgnoringTrailingSlash_different() {
+    assertThat(equalsIgnoringTrailingSlash("tto", "too/")).isFalse();
+  }
+
+  @Test
+  public void test_equalsIgnoringTrailingSlash_same_strings_same_trails() {
+    assertThat(equalsIgnoringTrailingSlash("too", "too")).isTrue();
+  }
+
 }


### PR DESCRIPTION
equalsIgnoringTrailingSlash() method is used in VSCode language server also now