### PR TITLE
SLCORE-198 Workaround for 10k limit

### DIFF
--- a/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/update/IssueDownloader.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/container/connected/update/IssueDownloader.java
@@ -153,6 +153,8 @@ public class IssueDownloader {
   }
 
   private static String getIssuesUrl(String key) {
-    return "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&componentKeys=" + StringUtils.urlEncode(key);
+    // As a small workaround to the 10k limit, we sort on status, descending, in order to have resolved issues first (FP/WF)
+    return "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&s=STATUS&asc=false&componentKeys="
+      + StringUtils.urlEncode(key);
   }
 }

--- a/core/src/test/java/org/sonarsource/sonarlint/core/container/connected/update/IssueDownloaderTests.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/container/connected/update/IssueDownloaderTests.java
@@ -88,7 +88,8 @@ class IssueDownloaderTests {
       response.writeTo(byteStream);
       try (InputStream inputStream = new ByteArrayInputStream(byteStream.toByteArray())) {
         WsClientTestUtils.addResponse(wsClient,
-          "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&componentKeys=" + key + "&ps=500&p=1", inputStream);
+          "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&s=STATUS&asc=false&componentKeys=" + key + "&ps=500&p=1",
+          inputStream);
       }
     }
 
@@ -134,7 +135,8 @@ class IssueDownloaderTests {
       response.writeTo(byteStream);
       try (InputStream inputStream = new ByteArrayInputStream(byteStream.toByteArray())) {
         WsClientTestUtils.addResponse(wsClient,
-          "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&componentKeys=" + key + "&ps=500&p=1", inputStream);
+          "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&s=STATUS&asc=false&componentKeys=" + key + "&ps=500&p=1",
+          inputStream);
       }
     }
 
@@ -148,7 +150,7 @@ class IssueDownloaderTests {
     SonarLintWsClient wsClient = WsClientTestUtils.createMock();
     String key = "dummyKey";
     WsClientTestUtils.addFailedResponse(wsClient,
-      "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&componentKeys=" + key + "&ps=500&p=1", 503, "");
+      "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&s=STATUS&asc=false&componentKeys=" + key + "&ps=500&p=1", 503, "");
 
     IssueDownloader issueDownloader = new IssueDownloader(wsClient, issueStorePaths);
     IllegalStateException thrown = assertThrows(IllegalStateException.class, () -> issueDownloader.download(key, projectConfiguration, PROGRESS));


### PR DESCRIPTION
Attempt to mitigate the 10k issues limit. I have not tested end to end, only verified that RESOLVED issues are coming first on this big SonarCloud project:
https://sonarcloud.io/api/issues/search?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=CODE_SMELL,BUG,VULNERABILITY&componentKeys=shipilev_jdk&organization=shipilev&s=STATUS&asc=false

Not sure it is very easy to add an integration test, because it is hard to control the order of issues.