### PR TITLE
Remove ITs checking XML issues are raised by the Java analyzer

### DIFF
--- a/its/tests/projects/sample-java-custom/pom.xml
+++ b/its/tests/projects/sample-java-custom/pom.xml
@@ -6,11 +6,6 @@
   <version>1.0-SNAPSHOT</version>
   <name>Sample Java</name>
   <description>Sample project for ITs</description>
-  
-  <properties>
-    <!-- Create an issue for test analysisJavaPomXml -->
-    <old.version>${pom.version}</old.version>
-  </properties>
 
   <build>
     <plugins>

--- a/its/tests/projects/sample-java/pom.xml
+++ b/its/tests/projects/sample-java/pom.xml
@@ -6,11 +6,6 @@
   <version>1.0-SNAPSHOT</version>
   <name>Sample Java</name>
   <description>Sample project for ITs</description>
-  
-  <properties>
-    <!-- Create an issue for test analysisJavaPomXml -->
-    <old.version>${pom.version}</old.version>
-  </properties>
 
   <build>
     <plugins>

--- a/its/tests/src/test/java/its/ConnectedModeTest.java
+++ b/its/tests/src/test/java/its/ConnectedModeTest.java
@@ -565,17 +565,6 @@ public class ConnectedModeTest extends AbstractConnectedTest {
   }
 
   @Test
-  public void analysisJavaPomXml() throws Exception {
-    updateGlobal();
-    updateProject(PROJECT_KEY_JAVA);
-
-    SaveIssueListener issueListener = new SaveIssueListener();
-    engine.analyze(createAnalysisConfiguration(PROJECT_KEY_JAVA, PROJECT_KEY_JAVA, "pom.xml"), issueListener, null, null);
-
-    assertThat(issueListener.getIssues()).hasSize(1);
-  }
-
-  @Test
   public void analysisTemplateRule() throws Exception {
     SearchRequest searchReq = new SearchRequest();
     searchReq.setQualityProfile("SonarLint IT Java");

--- a/its/tests/src/test/java/its/SonarCloudTest.java
+++ b/its/tests/src/test/java/its/SonarCloudTest.java
@@ -424,17 +424,6 @@ public class SonarCloudTest extends AbstractConnectedTest {
   }
 
   @Test
-  public void analysisJavaPomXml() throws Exception {
-    updateGlobal();
-    updateProject(projectKey(PROJECT_KEY_JAVA));
-
-    SaveIssueListener issueListener = new SaveIssueListener();
-    engine.analyze(createAnalysisConfiguration(projectKey(PROJECT_KEY_JAVA), PROJECT_KEY_JAVA, "pom.xml"), issueListener, null, null);
-
-    assertThat(issueListener.getIssues()).hasSize(1);
-  }
-
-  @Test
   public void analysisUseEmptyQualityProfile() throws Exception {
     updateGlobal();
     updateProject(projectKey(PROJECT_KEY_JAVA_EMPTY));

--- a/its/tests/src/test/resources/java-sonarlint.xml
+++ b/its/tests/src/test/resources/java-sonarlint.xml
@@ -15,12 +15,6 @@
       <key>S2325</key>
       <priority>MAJOR</priority>
     </rule>
-    <!-- Deprecated pom properties -->
-    <rule>
-      <repositoryKey>java</repositoryKey>
-      <key>S3421</key>
-      <priority>MAJOR</priority>
-    </rule>
 
     <!-- Keep for pre 6.0 sonar-java version -->
     <rule>
@@ -33,12 +27,6 @@
     <rule>
       <repositoryKey>squid</repositoryKey>
       <key>S2325</key>
-      <priority>MAJOR</priority>
-    </rule>
-    <!-- Deprecated pom properties -->
-    <rule>
-      <repositoryKey>squid</repositoryKey>
-      <key>S3421</key>
       <priority>MAJOR</priority>
     </rule>
   </rules>


### PR DESCRIPTION
They have been moved to the XML plugin. We already have separate tests for Java and XML rules