### PR TITLE
Re-enable SonarCloud ITs after 6.6 release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,6 +225,10 @@ stages:
       displayName: Run ITs
       strategy:
         matrix:
+          SonarCloud:
+            SQ_VERSION: 'SonarCloud'
+            JDKVersion: '1.11'
+            Category: '-Dgroups=SonarCloud'
           Dogfood:
             SQ_VERSION: 'DOGFOOD'
             JDKVersion: '1.11'


### PR DESCRIPTION
This reverts commit 9b4ba6900c4118b570ab734fdf510cc93abf4115.
