### PR TITLE
Update orchestrator dependency

### DIFF
--- a/its/tests/pom.xml
+++ b/its/tests/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.sonarsource.orchestrator</groupId>
       <artifactId>sonar-orchestrator</artifactId>
-      <version>3.40.0.183</version>
+      <version>3.40.0.280</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
In this version HTTP/2 has been deactivated with the hope to stabilize ITs