### PR TITLE
Add method to get HotspotStatus value from its title

### DIFF
--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/hotspot/HotspotStatus.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/hotspot/HotspotStatus.java
@@ -20,6 +20,7 @@
 package org.sonarsource.sonarlint.core.clientapi.backend.hotspot;
 
 import java.util.Arrays;
+import org.sonarsource.sonarlint.core.commons.HotspotReviewStatus;
 
 public enum HotspotStatus {
   // order is important here, it will be applied in the UI
@@ -48,4 +49,9 @@ public enum HotspotStatus {
     return Arrays.stream(HotspotStatus.values()).filter(hotspotStatus -> hotspotStatus.getTitle().equals(title)).findFirst()
       .orElseThrow(() -> new IllegalArgumentException("There is no such title of the hotspot status: " + title));
   }
+
+  public static HotspotStatus valueOfHotspotReviewStatus(HotspotReviewStatus reviewStatus) {
+    return HotspotStatus.valueOf(reviewStatus.name());
+  }
+
 }

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/hotspot/HotspotStatus.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/hotspot/HotspotStatus.java
@@ -19,6 +19,8 @@
  */
 package org.sonarsource.sonarlint.core.clientapi.backend.hotspot;
 
+import java.util.Arrays;
+
 public enum HotspotStatus {
   // order is important here, it will be applied in the UI
   TO_REVIEW("To Review", "This Security Hotspot needs to be reviewed to assess whether the code poses a risk."),
@@ -40,5 +42,10 @@ public enum HotspotStatus {
 
   public String getDescription() {
     return description;
+  }
+
+  public static HotspotStatus valueOfTitle(String title) {
+    return Arrays.stream(HotspotStatus.values()).filter(hotspotStatus -> hotspotStatus.getTitle().equals(title)).findFirst()
+      .orElseThrow(() -> new IllegalArgumentException("There is no such title of the hotspot status: " + title));
   }
 }

--- a/core/src/test/java/mediumtest/hotspots/HotspotStatusTests.java
+++ b/core/src/test/java/mediumtest/hotspots/HotspotStatusTests.java
@@ -21,6 +21,7 @@ package mediumtest.hotspots;
 
 import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.HotspotStatus;
+import org.sonarsource.sonarlint.core.commons.HotspotReviewStatus;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,4 +37,12 @@ class HotspotStatusTests {
     var thrown = assertThrows(IllegalArgumentException.class, ()-> HotspotStatus.valueOfTitle("Unknown"));
     assertThat(thrown).hasMessage("There is no such title of the hotspot status: Unknown");
   }
+
+  @Test
+  void valueOfHotspotReviewStatusTest() {
+    for (HotspotReviewStatus value : HotspotReviewStatus.values()) {
+      assertThat(HotspotStatus.valueOfHotspotReviewStatus(value)).isEqualTo(HotspotStatus.valueOf(value.name()));
+    }
+  }
+
 }

--- a/core/src/test/java/mediumtest/hotspots/HotspotStatusTests.java
+++ b/core/src/test/java/mediumtest/hotspots/HotspotStatusTests.java
@@ -1,0 +1,39 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package mediumtest.hotspots;
+
+import org.junit.jupiter.api.Test;
+import org.sonarsource.sonarlint.core.clientapi.backend.hotspot.HotspotStatus;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class HotspotStatusTests {
+
+  @Test
+  void valueOfTitleTest() {
+    assertThat(HotspotStatus.valueOfTitle("To Review")).isEqualTo(HotspotStatus.TO_REVIEW);
+    assertThat(HotspotStatus.valueOfTitle("Safe")).isEqualTo(HotspotStatus.SAFE);
+    assertThat(HotspotStatus.valueOfTitle("Fixed")).isEqualTo(HotspotStatus.FIXED);
+    assertThat(HotspotStatus.valueOfTitle("Acknowledged")).isEqualTo(HotspotStatus.ACKNOWLEDGED);
+    var thrown = assertThrows(IllegalArgumentException.class, ()-> HotspotStatus.valueOfTitle("Unknown"));
+    assertThat(thrown).hasMessage("There is no such title of the hotspot status: Unknown");
+  }
+}


### PR DESCRIPTION
Since we pass only titles to the frontend we need a way to map them back to enum values.