### PR TITLE
Remove workaround for SonarTS

### DIFF
--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfiguration.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfiguration.java
@@ -20,17 +20,12 @@
 package org.sonarsource.sonarlint.core.analysis.api;
 
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
-import org.sonarsource.sonarlint.core.commons.Language;
 
 @Immutable
 public class AnalysisEngineConfiguration {
@@ -38,7 +33,6 @@ public class AnalysisEngineConfiguration {
   private static final String NODE_EXECUTABLE_PROPERTY = "sonar.nodejs.executable";
 
   private final Path workDir;
-  private final EnumSet<Language> enabledLanguages;
   private final Map<String, String> extraProperties;
   private final Path nodeJsPath;
   private final long clientPid;
@@ -46,7 +40,6 @@ public class AnalysisEngineConfiguration {
 
   private AnalysisEngineConfiguration(Builder builder) {
     this.workDir = builder.workDir;
-    this.enabledLanguages = builder.enabledLanguages;
     this.extraProperties = new LinkedHashMap<>(builder.extraProperties);
     this.nodeJsPath = builder.nodeJsPath;
     this.clientPid = builder.clientPid;
@@ -59,10 +52,6 @@ public class AnalysisEngineConfiguration {
 
   public Path getWorkDir() {
     return workDir;
-  }
-
-  public Set<Language> getEnabledLanguages() {
-    return enabledLanguages;
   }
 
   public long getClientPid() {
@@ -83,7 +72,6 @@ public class AnalysisEngineConfiguration {
 
   public static final class Builder {
     private Path workDir;
-    private final EnumSet<Language> enabledLanguages = EnumSet.noneOf(Language.class);
     private Map<String, String> extraProperties = Collections.emptyMap();
     private Path nodeJsPath;
     private long clientPid;
@@ -106,30 +94,6 @@ public class AnalysisEngineConfiguration {
      */
     public Builder setExtraProperties(Map<String, String> extraProperties) {
       this.extraProperties = extraProperties;
-      return this;
-    }
-
-    /**
-     * Explicitly enable a {@link Language}
-     */
-    public Builder addEnabledLanguage(Language language) {
-      enabledLanguages.add(language);
-      return this;
-    }
-
-    /**
-     * Explicitly enable several {@link Language}s
-     */
-    public Builder addEnabledLanguages(Language... languages) {
-      enabledLanguages.addAll(Arrays.asList(languages));
-      return this;
-    }
-
-    /**
-     * Explicitly enable several {@link Language}s
-     */
-    public Builder addEnabledLanguages(Collection<Language> languages) {
-      enabledLanguages.addAll(languages);
       return this;
     }
 

--- a/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/AnalysisExtensionInstaller.java
+++ b/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/AnalysisExtensionInstaller.java
@@ -19,15 +19,12 @@
  */
 package org.sonarsource.sonarlint.core.analysis.container.global;
 
-import java.util.Set;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.config.Configuration;
 import org.sonar.api.utils.AnnotationUtils;
 import org.sonarsource.api.sonarlint.SonarLintSide;
-import org.sonarsource.sonarlint.core.analysis.api.AnalysisEngineConfiguration;
 import org.sonarsource.sonarlint.core.analysis.container.ContainerLifespan;
 import org.sonarsource.sonarlint.core.commons.Language;
-import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.plugin.commons.ExtensionInstaller;
 import org.sonarsource.sonarlint.core.plugin.commons.ExtensionUtils;
 import org.sonarsource.sonarlint.core.plugin.commons.LoadedPlugins;
@@ -36,17 +33,11 @@ import org.sonarsource.sonarlint.plugin.api.SonarLintRuntime;
 
 public class AnalysisExtensionInstaller extends ExtensionInstaller {
 
-  private static final SonarLintLogger LOG = SonarLintLogger.get();
-
-  private final Set<Language> enabledLanguages;
-
   private final LoadedPlugins loadedPlugins;
 
-  public AnalysisExtensionInstaller(SonarLintRuntime sonarRuntime, LoadedPlugins loadedPlugins, Configuration bootConfiguration,
-                                    AnalysisEngineConfiguration analysisEngineConfig) {
+  public AnalysisExtensionInstaller(SonarLintRuntime sonarRuntime, LoadedPlugins loadedPlugins, Configuration bootConfiguration) {
     super(sonarRuntime, bootConfiguration);
     this.loadedPlugins = loadedPlugins;
-    enabledLanguages = analysisEngineConfig.getEnabledLanguages();
   }
 
   public AnalysisExtensionInstaller install(ExtensionContainer container, ContainerLifespan lifespan) {
@@ -72,21 +63,12 @@ public class AnalysisExtensionInstaller extends ExtensionInstaller {
     return null;
   }
 
-  private boolean onlySonarSourceSensor(String pluginKey, Object extension) {
-    // SLCORE-259
-    if (!enabledLanguages.contains(Language.TS) && className(extension).contains("TypeScriptSensor")) {
-      LOG.debug("TypeScript sensor excluded");
-      return false;
-    }
+  private static boolean onlySonarSourceSensor(String pluginKey, Object extension) {
     return Language.containsPlugin(pluginKey) || isNotSensor(extension);
   }
 
   private static boolean isNotSensor(Object extension) {
     return !ExtensionUtils.isType(extension, Sensor.class);
-  }
-
-  private static String className(Object extension) {
-    return extension instanceof Class ? ((Class) extension).getName() : extension.getClass().getName();
   }
 
 }

--- a/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfigurationTests.java
+++ b/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfigurationTests.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.sonarsource.sonarlint.core.commons.Language;
 
 import static java.nio.file.Files.createDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,7 +38,6 @@ class AnalysisEngineConfigurationTests {
       .build();
     assertThat(config.getWorkDir()).isNull();
     assertThat(config.getEffectiveSettings()).isEmpty();
-    assertThat(config.getEnabledLanguages()).isEmpty();
     assertThat(config.getClientPid()).isZero();
   }
 
@@ -71,15 +69,6 @@ class AnalysisEngineConfigurationTests {
       .setWorkDir(work)
       .build();
     assertThat(config.getWorkDir()).isEqualTo(work);
-  }
-
-  @Test
-  void configureLanguages() {
-    var config = AnalysisEngineConfiguration.builder()
-      .addEnabledLanguage(Language.JAVA)
-      .addEnabledLanguages(Language.JS, Language.TS)
-      .build();
-    assertThat(config.getEnabledLanguages()).containsExactly(Language.JAVA, Language.JS, Language.TS);
   }
 
   @Test

--- a/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/mediumtests/AnalysisEngineMediumTests.java
+++ b/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/mediumtests/AnalysisEngineMediumTests.java
@@ -73,7 +73,6 @@ class AnalysisEngineMediumTests {
   void prepare(@TempDir Path workDir) throws IOException {
     var enabledLanguages = Set.of(Language.PYTHON);
     var analysisGlobalConfig = AnalysisEngineConfiguration.builder()
-      .addEnabledLanguages(enabledLanguages)
       .setClientPid(1234L)
       .setWorkDir(workDir)
       .build();

--- a/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
@@ -120,7 +120,6 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
     var allRulesDefinitionsByKey = loadPluginMetadata(loadingResult.getLoadedPlugins(), globalConfig.getEnabledLanguages(), true, globalConfig.isHotspotsEnabled());
 
     var analysisGlobalConfig = AnalysisEngineConfiguration.builder()
-      .addEnabledLanguages(globalConfig.getEnabledLanguages())
       .setClientPid(globalConfig.getClientPid())
       .setExtraProperties(globalConfig.extraProperties())
       .setNodeJs(globalConfig.getNodeJsPath())

--- a/core/src/main/java/org/sonarsource/sonarlint/core/StandaloneSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/StandaloneSonarLintEngineImpl.java
@@ -70,7 +70,6 @@ public final class StandaloneSonarLintEngineImpl extends AbstractSonarLintEngine
     allRulesDefinitionsByKey = loadPluginMetadata(loadingResult.getLoadedPlugins(), globalConfig.getEnabledLanguages(), false, false);
 
     var analysisGlobalConfig = AnalysisEngineConfiguration.builder()
-      .addEnabledLanguages(globalConfig.getEnabledLanguages())
       .setClientPid(globalConfig.getClientPid())
       .setExtraProperties(globalConfig.extraProperties())
       .setNodeJs(globalConfig.getNodeJsPath())


### PR DESCRIPTION
The TS sensor was manually excluded to handle the case where TS language was disabled but JS was enabled. This is not the case anymore as both are usually enabled at the same time, and the workaround does not work anymore since last SonarJS as both sensors have been merged.