### PR TITLE
Bumped sslcontext kickstart and switched to TrustManagerParameters for predicate

### DIFF
--- a/core/src/main/java/org/sonarsource/sonarlint/core/http/AskClientCertificatePredicate.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/http/AskClientCertificatePredicate.java
@@ -19,17 +19,17 @@
  */
 package org.sonarsource.sonarlint.core.http;
 
-import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
-import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import nl.altindag.ssl.model.TrustManagerParameters;
 import nl.altindag.ssl.util.CertificateUtils;
 import org.sonarsource.sonarlint.core.clientapi.SonarLintClient;
 import org.sonarsource.sonarlint.core.clientapi.client.http.CheckServerTrustedParams;
 import org.sonarsource.sonarlint.core.clientapi.client.http.X509CertificateDto;
 
-public class AskClientCertificatePredicate implements BiPredicate<X509Certificate[], String> {
+public class AskClientCertificatePredicate implements Predicate<TrustManagerParameters> {
 
   private final SonarLintClient client;
 
@@ -38,13 +38,13 @@ public class AskClientCertificatePredicate implements BiPredicate<X509Certificat
   }
 
   @Override
-  public boolean test(X509Certificate[] chain, String authType) {
+  public boolean test(TrustManagerParameters trustManagerParameters) {
     try {
       return client
         .checkServerTrusted(new CheckServerTrustedParams(
-          Arrays.stream(chain)
+          Arrays.stream(trustManagerParameters.getChain())
             .map(c -> new X509CertificateDto(CertificateUtils.convertToPem(c))).collect(Collectors.toList()),
-          authType))
+          trustManagerParameters.getAuthType()))
         .get()
         .isTrusted();
     } catch (InterruptedException ex) {

--- a/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpClientProvider.java
+++ b/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpClientProvider.java
@@ -22,10 +22,10 @@ package org.sonarsource.sonarlint.core.http;
 import java.net.ProxySelector;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.cert.X509Certificate;
-import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import nl.altindag.ssl.SSLFactory;
+import nl.altindag.ssl.model.TrustManagerParameters;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.config.TlsConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -52,13 +52,13 @@ public class HttpClientProvider {
   }
 
   public HttpClientProvider(String userAgent, @Nullable Path sonarlintUserHome,
-    @Nullable BiPredicate<X509Certificate[], String> certificateAndAuthTypeTrustPredicate, ProxySelector proxySelector, CredentialsProvider proxyCredentialsProvider) {
+    @Nullable Predicate<TrustManagerParameters> trustManagerParametersPredicate, ProxySelector proxySelector, CredentialsProvider proxyCredentialsProvider) {
     var sslFactoryBuilder = SSLFactory.builder()
       .withDefaultTrustMaterial()
       .withSystemTrustMaterial();
-    if (certificateAndAuthTypeTrustPredicate != null) {
+    if (trustManagerParametersPredicate != null) {
       var truststorePath = System.getProperty("sonarlint.ssl.trustStorePath", requireNonNull(sonarlintUserHome).resolve("ssl/truststore.p12").toString());
-      sslFactoryBuilder.withInflatableTrustMaterial(Paths.get(truststorePath), TRUSTSTORE_PWD, "PKCS12", certificateAndAuthTypeTrustPredicate);
+      sslFactoryBuilder.withInflatableTrustMaterial(Paths.get(truststorePath), TRUSTSTORE_PWD, "PKCS12", trustManagerParametersPredicate);
     }
     var asyncConnectionManager = PoolingAsyncClientConnectionManagerBuilder.create()
       .setTlsStrategy(new DefaultClientTlsStrategy(sslFactoryBuilder.build().getSslContext()))

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
       <dependency>
         <groupId>io.github.hakky54</groupId>
         <artifactId>sslcontext-kickstart</artifactId>
-        <version>8.1.1</version>
+        <version>8.1.2</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The withInflatableTrustMaterial has a better/alternative parameter now. Before it was needed to pass the chain and auth type, however this is marked now as deprecated and will be removed in the future.

The [TrustManagerParameters](https://github.com/Hakky54/sslcontext-kickstart/blob/master/sslcontext-kickstart/src/main/java/nl/altindag/ssl/model/TrustManagerParameters.java) contains for now the chain, authtype, socket and sslengine and additional validations can be done with those variables if reeded. The TrustManagerParameters can also grow over time and have more variable in the future. With the existing setup it was not possible to add these options.