### PR TITLE
QA should not wait for unit tests to start

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -149,7 +149,6 @@ qa_task:
   # Run ITs
   depends_on:
     - build
-    - test_windows
   <<: *ONLY_IF_EXCEPT_NIGHTLY
   eks_container:
     <<: *CONTAINER_DEFINITION


### PR DESCRIPTION
The QA should not wait for other test jobs to complete.