### PR TITLE
Update Guava to 32.1.1

### DIFF
--- a/its/tests/pom.xml
+++ b/its/tests/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.1-jre</version>
+      <version>32.1.1-jre</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>31.1-jre</version>
+        <version>32.1.1-jre</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>


### PR DESCRIPTION
I've read the release notes for [32.0.0](https://github.com/google/guava/releases/tag/v32.0.0), [32.0.1](https://github.com/google/guava/releases/tag/v32.0.1), [32.1.0](https://github.com/google/guava/releases/tag/v32.1.0), [32.1.1](https://github.com/google/guava/releases/tag/v32.1.1) and there seem to be no groundbreaking changes affecting us. As a disclaimer: My knowledge of the use of Guava in SLCORE is very limited, therefore this is only my humble opinion.

Some releases introduced issues fixed in later releases, therefore the jump to 32.1.1.