### PR TITLE
Shared ancestor for RuleDefinitionDto and EffectiveRuleDetailsDto

### DIFF
--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/rules/AbstractRuleDto.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/rules/AbstractRuleDto.java
@@ -1,0 +1,81 @@
+/*
+ * SonarLint Core - Client API
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.clientapi.backend.rules;
+
+import org.sonarsource.sonarlint.core.commons.IssueSeverity;
+import org.sonarsource.sonarlint.core.commons.RuleType;
+import org.sonarsource.sonarlint.core.commons.CleanCodeAttribute;
+import org.sonarsource.sonarlint.core.commons.SoftwareQuality;
+import org.sonarsource.sonarlint.core.commons.ImpactSeverity;
+import org.sonarsource.sonarlint.core.commons.Language;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Optional;
+
+public abstract class AbstractRuleDto {
+  private final String key;
+  private final String name;
+  private final IssueSeverity severity;
+  private final RuleType type;
+  private final CleanCodeAttribute cleanCodeAttribute;
+  private final Map<SoftwareQuality, ImpactSeverity> defaultImpacts;
+  private final Language language;
+
+  AbstractRuleDto(String key, String name, IssueSeverity severity, RuleType type,
+    @Nullable CleanCodeAttribute cleanCodeAttribute, Map<SoftwareQuality, ImpactSeverity> defaultImpacts,
+    Language language) {
+    this.key = key;
+    this.name = name;
+    this.severity = severity;
+    this.type = type;
+    this.cleanCodeAttribute = cleanCodeAttribute;
+    this.defaultImpacts = defaultImpacts;
+    this.language = language;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public IssueSeverity getSeverity() {
+    return severity;
+  }
+
+  public RuleType getType() {
+    return type;
+  }
+
+  public Optional<CleanCodeAttribute> getCleanCodeAttribute() {
+    return Optional.ofNullable(cleanCodeAttribute);
+  }
+
+  public Map<SoftwareQuality, ImpactSeverity> getDefaultImpacts() {
+    return defaultImpacts;
+  }
+
+  public Language getLanguage() {
+    return language;
+  }
+}

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/rules/EffectiveRuleDetailsDto.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/rules/EffectiveRuleDetailsDto.java
@@ -21,7 +21,6 @@ package org.sonarsource.sonarlint.core.clientapi.backend.rules;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.sonarsource.sonarlint.core.commons.CleanCodeAttribute;
@@ -31,53 +30,17 @@ import org.sonarsource.sonarlint.core.commons.Language;
 import org.sonarsource.sonarlint.core.commons.RuleType;
 import org.sonarsource.sonarlint.core.commons.SoftwareQuality;
 
-public class EffectiveRuleDetailsDto {
-  private final String key;
-  private final String name;
-  private final IssueSeverity severity;
-  private final RuleType type;
-  private final CleanCodeAttribute cleanCodeAttribute;
-  private final Map<SoftwareQuality, ImpactSeverity> defaultImpacts;
+public class EffectiveRuleDetailsDto extends AbstractRuleDto {
   private final Either<RuleMonolithicDescriptionDto, RuleSplitDescriptionDto> description;
   private final Collection<EffectiveRuleParamDto> params;
-  private final Language language;
 
-  public EffectiveRuleDetailsDto(String key, String name, IssueSeverity severity, RuleType type, @Nullable CleanCodeAttribute cleanCodeAttribute,
-    Map<SoftwareQuality, ImpactSeverity> defaultImpacts, Either<RuleMonolithicDescriptionDto, RuleSplitDescriptionDto> description, Collection<EffectiveRuleParamDto> params,
+  public EffectiveRuleDetailsDto(String key, String name, IssueSeverity severity, RuleType type,
+    @Nullable CleanCodeAttribute cleanCodeAttribute, Map<SoftwareQuality, ImpactSeverity> defaultImpacts,
+    Either<RuleMonolithicDescriptionDto, RuleSplitDescriptionDto> description, Collection<EffectiveRuleParamDto> params,
     Language language) {
-    this.key = key;
-    this.name = name;
-    this.severity = severity;
-    this.type = type;
-    this.cleanCodeAttribute = cleanCodeAttribute;
-    this.defaultImpacts = defaultImpacts;
+    super(key, name, severity, type, cleanCodeAttribute, defaultImpacts, language);
     this.description = description;
     this.params = params;
-    this.language = language;
-  }
-
-  public String getKey() {
-    return key;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public IssueSeverity getSeverity() {
-    return severity;
-  }
-
-  public RuleType getType() {
-    return type;
-  }
-
-  public Optional<CleanCodeAttribute> getCleanCodeAttribute() {
-    return Optional.ofNullable(cleanCodeAttribute);
-  }
-
-  public Map<SoftwareQuality, ImpactSeverity> getDefaultImpacts() {
-    return defaultImpacts;
   }
 
   public Either<RuleMonolithicDescriptionDto, RuleSplitDescriptionDto> getDescription() {
@@ -87,9 +50,4 @@ public class EffectiveRuleDetailsDto {
   public Collection<EffectiveRuleParamDto> getParams() {
     return params;
   }
-
-  public Language getLanguage() {
-    return language;
-  }
-
 }

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/rules/RuleDefinitionDto.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/rules/RuleDefinitionDto.java
@@ -20,7 +20,6 @@
 package org.sonarsource.sonarlint.core.clientapi.backend.rules;
 
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.commons.CleanCodeAttribute;
 import org.sonarsource.sonarlint.core.commons.ImpactSeverity;
@@ -29,52 +28,16 @@ import org.sonarsource.sonarlint.core.commons.Language;
 import org.sonarsource.sonarlint.core.commons.RuleType;
 import org.sonarsource.sonarlint.core.commons.SoftwareQuality;
 
-public class RuleDefinitionDto {
-  private final String key;
-  private final String name;
-  private final IssueSeverity defaultSeverity;
-  private final RuleType type;
-  private final CleanCodeAttribute cleanCodeAttribute;
-  private final Map<SoftwareQuality, ImpactSeverity> defaultImpacts;
+public class RuleDefinitionDto extends AbstractRuleDto {
   private final Map<String, RuleParamDefinitionDto> paramsByKey;
   private final boolean isActiveByDefault;
-  private final Language language;
 
-  public RuleDefinitionDto(String key, String name, IssueSeverity defaultSeverity, RuleType type, @Nullable CleanCodeAttribute cleanCodeAttribute,
-    Map<SoftwareQuality, ImpactSeverity> defaultImpacts, Map<String, RuleParamDefinitionDto> paramsByKey, boolean isActiveByDefault, Language language) {
-    this.key = key;
-    this.name = name;
-    this.defaultSeverity = defaultSeverity;
-    this.type = type;
-    this.cleanCodeAttribute = cleanCodeAttribute;
-    this.defaultImpacts = defaultImpacts;
+  public RuleDefinitionDto(String key, String name, IssueSeverity defaultSeverity, RuleType type,
+    @Nullable CleanCodeAttribute cleanCodeAttribute, Map<SoftwareQuality, ImpactSeverity> defaultImpacts,
+    Map<String, RuleParamDefinitionDto> paramsByKey, boolean isActiveByDefault, Language language) {
+    super(key, name, defaultSeverity, type, cleanCodeAttribute, defaultImpacts, language);
     this.paramsByKey = paramsByKey;
     this.isActiveByDefault = isActiveByDefault;
-    this.language = language;
-  }
-
-  public String getKey() {
-    return key;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public IssueSeverity getDefaultSeverity() {
-    return defaultSeverity;
-  }
-
-  public RuleType getType() {
-    return type;
-  }
-
-  public Optional<CleanCodeAttribute> getCleanCodeAttribute() {
-    return Optional.ofNullable(cleanCodeAttribute);
-  }
-
-  public Map<SoftwareQuality, ImpactSeverity> getDefaultImpacts() {
-    return defaultImpacts;
   }
 
   public Map<String, RuleParamDefinitionDto> getParamsByKey() {
@@ -83,9 +46,5 @@ public class RuleDefinitionDto {
 
   public boolean isActiveByDefault() {
     return isActiveByDefault;
-  }
-
-  public Language getLanguage() {
-    return language;
   }
 }

--- a/core/src/test/java/mediumtest/StandaloneRulesMediumTests.java
+++ b/core/src/test/java/mediumtest/StandaloneRulesMediumTests.java
@@ -90,7 +90,7 @@ class StandaloneRulesMediumTests {
     assertThat(ruleDetails.getRuleDefinition().getCleanCodeAttribute()).hasValue(CleanCodeAttribute.defaultCleanCodeAttribute());
     assertThat(ruleDetails.getRuleDefinition().getDefaultImpacts()).isEmpty();
     assertThat(ruleDetails.getRuleDefinition().getName()).isEqualTo("Public types, methods and fields (API) should be documented with Javadoc");
-    assertThat(ruleDetails.getRuleDefinition().getDefaultSeverity()).isEqualTo(IssueSeverity.MAJOR);
+    assertThat(ruleDetails.getRuleDefinition().getSeverity()).isEqualTo(IssueSeverity.MAJOR);
     assertThat(ruleDetails.getRuleDefinition().getType()).isEqualTo(RuleType.CODE_SMELL);
     assertThat(ruleDetails.getDescription().isLeft()).isTrue();
     assertThat(ruleDetails.getDescription().getLeft().getHtmlContent()).startsWith("<p>Try to imagine using the standard Java API (Collections, JDBC, IO, …\u200B) without Javadoc.");


### PR DESCRIPTION
This will simplify working with the rule information on the *SonarLint for Eclipse* side and maybe on the other IDEs as well.