### PR TITLE
SLCORE-550: Update sslcontext-kickstart

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
       <dependency>
         <groupId>io.github.hakky54</groupId>
         <artifactId>sslcontext-kickstart</artifactId>
-        <version>8.1.5</version>
+        <version>8.1.6</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Updating the library with the [fixes](https://github.com/Hakky54/sslcontext-kickstart/pull/370) regarding the [macOS issues](https://github.com/Hakky54/sslcontext-kickstart/issues/369).