### PR TITLE
SLE-741: Server info about anticipated transitions

### DIFF
--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/CheckAnticipatedStatusChangeSupportedParams.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/CheckAnticipatedStatusChangeSupportedParams.java
@@ -1,0 +1,32 @@
+/*
+ * SonarLint Core - Client API
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.clientapi.backend.issue;
+
+public class CheckAnticipatedStatusChangeSupportedParams {
+  private final String connectionId;
+
+  public CheckAnticipatedStatusChangeSupportedParams(String connectionId) {
+    this.connectionId = connectionId;
+  }
+
+  public String getConnectionId() {
+    return connectionId;
+  }
+}

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/CheckAnticipatedStatusChangeSupportedParams.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/CheckAnticipatedStatusChangeSupportedParams.java
@@ -20,13 +20,13 @@
 package org.sonarsource.sonarlint.core.clientapi.backend.issue;
 
 public class CheckAnticipatedStatusChangeSupportedParams {
-  private final String connectionId;
+  private final String configScopeId;
 
-  public CheckAnticipatedStatusChangeSupportedParams(String connectionId) {
-    this.connectionId = connectionId;
+  public CheckAnticipatedStatusChangeSupportedParams(String configScopeId) {
+    this.configScopeId = configScopeId;
   }
 
-  public String getConnectionId() {
-    return connectionId;
+  public String getConfigScopeId() {
+    return configScopeId;
   }
 }

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/CheckAnticipatedStatusChangeSupportedResponse.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/CheckAnticipatedStatusChangeSupportedResponse.java
@@ -1,0 +1,32 @@
+/*
+ * SonarLint Core - Client API
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.clientapi.backend.issue;
+
+public class CheckAnticipatedStatusChangeSupportedResponse {
+  private final boolean supported;
+
+  public CheckAnticipatedStatusChangeSupportedResponse(boolean supported) {
+    this.supported = supported;
+  }
+
+  public boolean isSupported() {
+    return supported;
+  }
+}

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/IssueService.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/IssueService.java
@@ -71,6 +71,22 @@ public interface IssueService {
   CompletableFuture<Void> addComment(AddIssueCommentParams params);
 
   /**
+   * Checks if the anticipated transitions are supported
+   * <ul>
+   *   <li>The provided connection should link to a SonarQube 10.2+ instance</li>
+   * <p>
+   * This method will fail if:
+   * <ul>
+   *   <li>the connectionId provided as a parameter is unknown</li>
+   *   <li>there is a communication problem with the server: network outage, server is down, unauthorized</li>
+   * </ul>
+   * In those cases, a failed future will be returned.
+   * </p>
+   */
+  @JsonRequest
+  CompletableFuture<CheckAnticipatedStatusChangeSupportedResponse> checkAnticipatedStatusChangeSupported(CheckAnticipatedStatusChangeSupportedParams params);
+
+  /**
    * Checks if the user can change the issue status. They are allowed in two cases:
    * <ul>
    *   <li>If it is a server-matched issue, users need the 'Administer Issues' permission</li>

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/IssueService.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/IssueService.java
@@ -71,13 +71,14 @@ public interface IssueService {
   CompletableFuture<Void> addComment(AddIssueCommentParams params);
 
   /**
-   * Checks if the anticipated transitions are supported
+   * Checks if the anticipated transitions are supported. They are allowed in one case:
    * <ul>
-   *   <li>The provided connection should link to a SonarQube 10.2+ instance</li>
+   *   <li>If the configScopeId is bound, its connection should link to a SonarQube 10.2+ instance</li>
    * <p>
    * This method will fail if:
    * <ul>
-   *   <li>the connectionId provided as a parameter is unknown</li>
+   *   <li>the configScopeId provided as a parameter has no binding</li>
+   *   <li>the configScopeId provided loses its binding in the middle of the function call</li>
    *   <li>there is a communication problem with the server: network outage, server is down, unauthorized</li>
    * </ul>
    * In those cases, a failed future will be returned.

--- a/core/src/main/java/org/sonarsource/sonarlint/core/issue/IssueServiceImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/issue/IssueServiceImpl.java
@@ -34,6 +34,8 @@ import javax.inject.Singleton;
 import org.sonarsource.sonarlint.core.ServerApiProvider;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.AddIssueCommentParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.ChangeIssueStatusParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckAnticipatedStatusChangeSupportedParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckAnticipatedStatusChangeSupportedResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.CheckStatusChangePermittedResponse;
 import org.sonarsource.sonarlint.core.clientapi.backend.issue.IssueService;
@@ -132,6 +134,30 @@ public class IssueServiceImpl implements IssueService {
       .collect(Collectors.toList());
   }
 
+  /**
+   *  Check if the anticipated transitions are supported on the server side (requires SonarQube 10.2+)
+   *
+   *  @param api used for checking if server is a SonarQube instance
+   *  @param connectionId required to get the version information from the server
+   *  @return whether server is SonarQube instance and matches version requirement
+   */
+  private boolean checkAnticipatedStatusChangeSupported(ServerApi api, String connectionId) {
+    return !api.isSonarCloud() && storageService.connection(connectionId).serverInfo().read()
+            .map(version -> version.getVersion().satisfiesMinRequirement(SQ_ANTICIPATED_TRANSITIONS_MIN_VERSION))
+            .orElse(false);
+  }
+
+  @Override
+  public CompletableFuture<CheckAnticipatedStatusChangeSupportedResponse> checkAnticipatedStatusChangeSupported(CheckAnticipatedStatusChangeSupportedParams params) {
+    var connectionId = params.getConnectionId();
+    var serverApiOpt = serverApiProvider.getServerApi(connectionId);
+    if (serverApiOpt.isEmpty()) {
+      return CompletableFuture.failedFuture(new IllegalArgumentException("Connection with ID '" + connectionId + "' does not exist"));
+    }
+    var serverApi = serverApiOpt.get();
+    return CompletableFuture.completedFuture(new CheckAnticipatedStatusChangeSupportedResponse(checkAnticipatedStatusChangeSupported(serverApi, connectionId)));
+  }
+
   @Override
   public CompletableFuture<CheckStatusChangePermittedResponse> checkStatusChangePermitted(CheckStatusChangePermittedParams params) {
     var connectionId = params.getConnectionId();
@@ -144,8 +170,7 @@ public class IssueServiceImpl implements IssueService {
     return asUUID(issueKey)
       .flatMap(localOnlyIssueRepository::findByKey)
       .map(r -> {
-        var anticipateTransitionsSupported = !serverApi.isSonarCloud() && storageService.connection(connectionId).serverInfo().read()
-          .map(version -> version.getVersion().satisfiesMinRequirement(SQ_ANTICIPATED_TRANSITIONS_MIN_VERSION)).orElse(false);
+        var anticipateTransitionsSupported = checkAnticipatedStatusChangeSupported(serverApi, connectionId);
         // no way to easily check if 'Administer Issue' permission is granted, might fail later
         return CompletableFuture.completedFuture(toResponse(anticipateTransitionsSupported, UNSUPPORTED_SQ_VERSION_REASON));
       })

--- a/core/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
+++ b/core/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
@@ -1,0 +1,117 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package mediumtest.issues;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonarsource.sonarlint.core.SonarLintBackendImpl;
+import org.sonarsource.sonarlint.core.clientapi.backend.issue.*;
+import testutils.MockWebServerExtensionWithProtobuf;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CheckAnticipatedStatusChangeSupportedMediumTests {
+  private SonarLintBackendImpl backend;
+  @RegisterExtension
+  public final MockWebServerExtensionWithProtobuf mockWebServerExtension = new MockWebServerExtensionWithProtobuf();
+  private String oldSonarCloudUrl;
+
+  @BeforeEach
+  void prepare() {
+    oldSonarCloudUrl = System.getProperty("sonarlint.internal.sonarcloud.url");
+  }
+
+  @AfterEach
+  void tearDown() throws ExecutionException, InterruptedException {
+    backend.shutdown().get();
+    mockWebServerExtension.shutdown();
+
+    if (oldSonarCloudUrl == null) {
+      System.clearProperty("sonarlint.internal.sonarcloud.url");
+    } else {
+      System.setProperty("sonarlint.internal.sonarcloud.url", oldSonarCloudUrl);
+    }
+  }
+
+  @Test
+  void it_should_fail_when_the_connection_is_unknown() {
+    backend = newBackend().build();
+
+    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+      .failsWithin(Duration.ofSeconds(2))
+      .withThrowableOfType(ExecutionException.class)
+      .havingCause()
+      .isInstanceOf(IllegalArgumentException.class)
+      .withMessage("Connection with ID 'connectionId' does not exist");
+  }
+
+  @Test
+  void it_should_not_be_available_for_sonarcloud() {
+    backend = newBackend()
+      .withSonarCloudConnection("connectionId", "orgKey")
+      .withActiveBranch("configScopeId", "branch")
+      .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
+      .build();
+
+    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+      .succeedsWithin(Duration.ofSeconds(2))
+      .extracting(CheckAnticipatedStatusChangeSupportedResponse::isSupported)
+      .isEqualTo(false);
+  }
+
+  @Test
+  void it_should_not_be_available_for_sonarqube_prior_to_10_2() {
+    backend = newBackend()
+      .withSonarQubeConnection("connectionId", storage -> storage.withServerVersion("10.1"))
+      .withActiveBranch("configScopeId", "branch")
+      .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
+      .build();
+
+    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+      .succeedsWithin(Duration.ofSeconds(2))
+      .extracting(CheckAnticipatedStatusChangeSupportedResponse::isSupported)
+      .isEqualTo(false);
+  }
+
+  @Test
+  void it_should_be_available_for_sonarqube_10_2_plus() {
+    backend = newBackend()
+      .withSonarQubeConnection("connectionId", storage -> storage.withServerVersion("10.2"))
+      .withActiveBranch("configScopeId", "branch")
+      .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
+      .build();
+
+    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+      .succeedsWithin(Duration.ofSeconds(2))
+      .extracting(CheckAnticipatedStatusChangeSupportedResponse::isSupported)
+      .isEqualTo(true);
+  }
+
+  private CompletableFuture<CheckAnticipatedStatusChangeSupportedResponse> checkAnticipatedStatusChangeSupported(String connectionId) {
+    return backend.getIssueService().checkAnticipatedStatusChangeSupported(new CheckAnticipatedStatusChangeSupportedParams(connectionId));
+  }
+}

--- a/core/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
+++ b/core/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
@@ -61,12 +61,12 @@ class CheckAnticipatedStatusChangeSupportedMediumTests {
   void it_should_fail_when_the_connection_is_unknown() {
     backend = newBackend().build();
 
-    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+    assertThat(checkAnticipatedStatusChangeSupported("configScopeId"))
       .failsWithin(Duration.ofSeconds(2))
       .withThrowableOfType(ExecutionException.class)
       .havingCause()
       .isInstanceOf(IllegalArgumentException.class)
-      .withMessage("Connection with ID 'connectionId' does not exist");
+      .withMessage("Binding for configuration scope ID 'configScopeId' does not exist");
   }
 
   @Test
@@ -77,7 +77,7 @@ class CheckAnticipatedStatusChangeSupportedMediumTests {
       .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
       .build();
 
-    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+    assertThat(checkAnticipatedStatusChangeSupported("configScopeId"))
       .succeedsWithin(Duration.ofSeconds(2))
       .extracting(CheckAnticipatedStatusChangeSupportedResponse::isSupported)
       .isEqualTo(false);
@@ -91,7 +91,7 @@ class CheckAnticipatedStatusChangeSupportedMediumTests {
       .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
       .build();
 
-    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+    assertThat(checkAnticipatedStatusChangeSupported("configScopeId"))
       .succeedsWithin(Duration.ofSeconds(2))
       .extracting(CheckAnticipatedStatusChangeSupportedResponse::isSupported)
       .isEqualTo(false);
@@ -105,13 +105,13 @@ class CheckAnticipatedStatusChangeSupportedMediumTests {
       .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
       .build();
 
-    assertThat(checkAnticipatedStatusChangeSupported("connectionId"))
+    assertThat(checkAnticipatedStatusChangeSupported("configScopeId"))
       .succeedsWithin(Duration.ofSeconds(2))
       .extracting(CheckAnticipatedStatusChangeSupportedResponse::isSupported)
       .isEqualTo(true);
   }
 
-  private CompletableFuture<CheckAnticipatedStatusChangeSupportedResponse> checkAnticipatedStatusChangeSupported(String connectionId) {
-    return backend.getIssueService().checkAnticipatedStatusChangeSupported(new CheckAnticipatedStatusChangeSupportedParams(connectionId));
+  private CompletableFuture<CheckAnticipatedStatusChangeSupportedResponse> checkAnticipatedStatusChangeSupported(String configScopeId) {
+    return backend.getIssueService().checkAnticipatedStatusChangeSupported(new CheckAnticipatedStatusChangeSupportedParams(configScopeId));
   }
 }


### PR DESCRIPTION
## Summary

In order to be used on _SonarLint for Eclipse_, general information about a connection supporting the anticipated transitions should be available. Rather than on an issue level, this information is gathered to configure markers at once and not per marker, saving computing time.

## Testing

Medium tests are added in order to check every possible scenario the new interface method might face.