### PR TITLE
SLCORE-589: Make resolved Taint Issues available

### DIFF
--- a/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/ConnectedSonarLintEngineImpl.java
@@ -407,8 +407,8 @@ public final class ConnectedSonarLintEngineImpl extends AbstractSonarLintEngine 
   }
 
   @Override
-  public List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String ideFilePath) {
-    return serverConnection.getServerTaintIssues(projectBinding, branchName, ideFilePath);
+  public List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String ideFilePath, boolean includeResolved) {
+    return serverConnection.getServerTaintIssues(projectBinding, branchName, ideFilePath, includeResolved);
   }
 
   @Override

--- a/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/client/api/connected/ConnectedSonarLintEngine.java
@@ -79,12 +79,13 @@ public interface ConnectedSonarLintEngine extends SonarLintEngine {
   /**
    * Gets locally stored server taint issues for a given file.
    *
-   * @param projectBinding information about the project (must have been previously updated with {@link #updateProject(EndpointParams, HttpClient, String, ClientProgressMonitor)})
-   * @param branchName     branch name
-   * @param filePath       relative to the project.
+   * @param projectBinding  information about the project (must have been previously updated with {@link #updateProject(EndpointParams, HttpClient, String, ClientProgressMonitor)})
+   * @param branchName      branch name
+   * @param filePath        relative to the project.
+   * @param includeResolved whether the resolved Taint Vulnerabilities should be included or not
    * @return All server taint issues in the local storage for the given file. If file has no issues, an empty list is returned.
    */
-  List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String filePath);
+  List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String filePath, boolean includeResolved);
 
   /**
    * Gets locally stored server taint issues.

--- a/its/tests/src/test/java/its/SonarCloudTests.java
+++ b/its/tests/src/test/java/its/SonarCloudTests.java
@@ -553,7 +553,7 @@ class SonarCloudTests extends AbstractConnectedTests {
         MAIN_BRANCH_NAME,
         null);
 
-      var sinkIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java");
+      var sinkIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java", false);
 
       assertThat(sinkIssues).hasSize(1);
 

--- a/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
+++ b/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
@@ -881,7 +881,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
       engine.downloadAllServerTaintIssuesForFile(endpointParams(ORCHESTRATOR), backend.getHttpClient(CONNECTION_ID), projectBinding, "src/main/java/foo/DbHelper.java",
         MAIN_BRANCH_NAME, null);
 
-      var sinkIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java");
+      var sinkIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java", false);
 
       assertThat(sinkIssues).hasSize(1);
 
@@ -923,7 +923,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
       Deque<ServerEvent> events = new ConcurrentLinkedDeque<>();
       engine.subscribeForEvents(endpointParams(ORCHESTRATOR), backend.getHttpClient(CONNECTION_ID), Set.of(PROJECT_KEY_JAVA_TAINT), events::add, null);
       var projectBinding = new ProjectBinding(PROJECT_KEY_JAVA_TAINT, "", "");
-      assertThat(engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java")).isEmpty();
+      assertThat(engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java", false)).isEmpty();
 
       // check TaintVulnerabilityRaised is received
       analyzeMavenProject("sample-java-taint", PROJECT_KEY_JAVA_TAINT);
@@ -941,7 +941,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
       assertThat(issues).isNotEmpty();
       var issueKey = issues.get(0);
 
-      var taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java");
+      var taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java", false);
       assertThat(taintIssues)
         .extracting("key", "resolved", "ruleKey", "message", "filePath", "severity", "type")
         .containsOnly(
@@ -977,7 +977,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
           });
       });
 
-      taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java");
+      taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java", false);
       assertThat(taintIssues).isEmpty();
 
       // check IssueChangedEvent is received
@@ -991,7 +991,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
             assertThat(e.getProjectKey()).isEqualTo(PROJECT_KEY_JAVA_TAINT);
           });
       });
-      taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java");
+      taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java", false);
       assertThat(taintIssues).isNotEmpty();
 
       // analyze another project under the same project key to close the taint issue
@@ -1006,7 +1006,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
             assertThat(e.getProjectKey()).isEqualTo(PROJECT_KEY_JAVA_TAINT);
           });
       });
-      taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java");
+      taintIssues = engine.getServerTaintIssues(projectBinding, MAIN_BRANCH_NAME, "src/main/java/foo/DbHelper.java", false);
       assertThat(taintIssues).isEmpty();
     }
   }

--- a/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueStoreReader.java
+++ b/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueStoreReader.java
@@ -47,13 +47,17 @@ public class IssueStoreReader {
     return loadedIssues;
   }
 
-  public List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String ideFilePath) {
+  public List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String ideFilePath, boolean includeResolved) {
     var sqPath = IssueStorePaths.idePathToServerPath(projectBinding, ideFilePath);
     if (sqPath == null) {
       return Collections.emptyList();
     }
     var loadedIssues = storage.project(projectBinding.projectKey()).findings().loadTaint(branchName, sqPath);
-    loadedIssues = filterOutResolvedIssues(loadedIssues);
+
+    if (!includeResolved) {
+      loadedIssues = filterOutResolvedIssues(loadedIssues);
+    }
+
     loadedIssues.forEach(issue -> issue.setFilePath(ideFilePath));
     return loadedIssues;
   }

--- a/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerConnection.java
+++ b/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerConnection.java
@@ -116,8 +116,8 @@ public class ServerConnection {
     return issueStoreReader.getServerIssues(projectBinding, branchName, ideFilePath);
   }
 
-  public List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String ideFilePath) {
-    return enhanceWithNewCodeInformation(projectBinding.projectKey(), issueStoreReader.getServerTaintIssues(projectBinding, branchName, ideFilePath));
+  public List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName, String ideFilePath, boolean includeResolved) {
+    return enhanceWithNewCodeInformation(projectBinding.projectKey(), issueStoreReader.getServerTaintIssues(projectBinding, branchName, ideFilePath, includeResolved));
   }
 
   public List<ServerTaintIssue> getServerTaintIssues(ProjectBinding projectBinding, String branchName) {


### PR DESCRIPTION
To be able to re-open Taint Vulnerabilities from within the IDE we require the option to display the resolved issue again.