### PR TITLE
SLCORE-603 Fix interrupted exception when reconnecting after close

### DIFF
--- a/core/src/main/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocket.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocket.java
@@ -145,7 +145,6 @@ public class SonarCloudWebSocket {
     if (!MoreExecutors.shutdownAndAwaitTermination(sonarCloudWebSocketScheduler, 1, TimeUnit.SECONDS)) {
       SonarLintLogger.get().warn("Unable to stop SonarCloud WebSocket job scheduler in a timely manner");
     }
-    client.close();
   }
 
   public boolean isOpen() {

--- a/http/src/main/java/org/sonarsource/sonarlint/core/http/WebSocketClient.java
+++ b/http/src/main/java/org/sonarsource/sonarlint/core/http/WebSocketClient.java
@@ -87,13 +87,7 @@ public class WebSocketClient {
     @Override
     public void onError(WebSocket webSocket, Throwable error) {
       LOG.error("Error occurred on the WebSocket", error);
-      try {
-        onClosedRunnable.run();
-      } finally {
-        if (!MoreExecutors.shutdownAndAwaitTermination(executor, 1, TimeUnit.SECONDS)) {
-          LOG.warn("Unable to stop web socket executor service in a timely manner");
-        }
-      }
+      finalizeWebSocket();
     }
 
     @Override
@@ -109,6 +103,12 @@ public class WebSocketClient {
       } catch (ExecutionException e) {
         LOG.debug("Cannot ack WebSocket close");
       }
+      finalizeWebSocket();
+      // uncompleted future means the closing has been handled already (default is null)
+      return new CompletableFuture<>();
+    }
+
+    private void finalizeWebSocket() {
       try {
         onClosedRunnable.run();
       } finally {
@@ -116,8 +116,6 @@ public class WebSocketClient {
           LOG.warn("Unable to stop web socket executor service in a timely manner");
         }
       }
-      // uncompleted future means the closing has been handled already (default is null)
-      return new CompletableFuture<>();
     }
   }
 

--- a/http/src/main/java/org/sonarsource/sonarlint/core/http/WebSocketClient.java
+++ b/http/src/main/java/org/sonarsource/sonarlint/core/http/WebSocketClient.java
@@ -36,7 +36,7 @@ import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 
 import static org.sonarsource.sonarlint.core.commons.concurrent.ThreadFactories.threadWithNamePrefix;
 
-public class WebSocketClient implements Closeable {
+public class WebSocketClient {
 
   private static final SonarLintLogger LOG = SonarLintLogger.get();
 
@@ -64,14 +64,7 @@ public class WebSocketClient implements Closeable {
       .join();
   }
 
-  @Override
-  public void close() {
-    if (!MoreExecutors.shutdownAndAwaitTermination(executor, 1, TimeUnit.SECONDS)) {
-      LOG.warn("Unable to stop web socket executor service in a timely manner");
-    }
-  }
-
-  private static class MessageConsummerWrapper implements WebSocket.Listener {
+  private class MessageConsummerWrapper implements WebSocket.Listener {
     private final Consumer<String> messageConsumer;
     private final Runnable onClosedRunnable;
 
@@ -112,7 +105,13 @@ public class WebSocketClient implements Closeable {
       } catch (ExecutionException e) {
         LOG.debug("Cannot ack WebSocket close");
       }
-      onClosedRunnable.run();
+      try {
+        onClosedRunnable.run();
+      } finally {
+        if (!MoreExecutors.shutdownAndAwaitTermination(executor, 1, TimeUnit.SECONDS)) {
+          LOG.warn("Unable to stop web socket executor service in a timely manner");
+        }
+      }
       // uncompleted future means the closing has been handled already (default is null)
       return new CompletableFuture<>();
     }

--- a/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
@@ -40,6 +40,7 @@ import java.util.function.Consumer;
 import javax.annotation.CheckForNull;
 import mediumtest.fixtures.storage.ConfigurationScopeStorageFixture;
 import mediumtest.fixtures.storage.StorageFixture;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.Nullable;
 import org.sonarsource.sonarlint.core.SonarLintBackendImpl;
@@ -569,9 +570,9 @@ public class SonarLintBackendFixture {
       return synchronizedConfigScopeIds;
     }
 
+    @Override
     public CompletableFuture<GetCredentialsResponse> getCredentials(GetCredentialsParams params) {
-      var response = new GetCredentialsResponse(credentialsByConnectionId.get(params.getConnectionId()));
-      return CompletableFuture.completedFuture(response);
+      return CompletableFutures.computeAsync(cancelChecker -> new GetCredentialsResponse(credentialsByConnectionId.get(params.getConnectionId())));
     }
 
     public void setToken(String connectionId, String secondToken) {


### PR DESCRIPTION
Closing the executor service too early leads to interrupting the thread that is doing the reconnect. We should close the executor only after the reconnect handler has been executed.
