### PR TITLE
Fix Overlapping exception in TelemetryMediumTest

### DIFF
--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -94,9 +94,6 @@ class TelemetryMediumTests {
       .build();
 
     assertThat(backend.getTelemetryService().getStatus().get().isEnabled()).isTrue();
-
-    // Trigger any telemetry event to initialize the file
-    this.backend.getHotspotService().openHotspotInBrowser(new OpenHotspotInBrowserParams("scopeId", "master", "ab12ef45"));
     assertThat(backend.telemetryFilePath()).isNotEmptyFile();
 
     // Emulate another process has disabled telemetry


### PR DESCRIPTION
Since the notification processing is asynchronous, we have a risk of race condition. In fact, calling the event is not needed anymore, as the backend initialization will create the telemetry file (probably for the new code period).
