### PR TITLE
SLCORE-647: "Won't fix" becomes "Accept"

### DIFF
--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/ResolutionStatus.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/issue/ResolutionStatus.java
@@ -20,7 +20,7 @@
 package org.sonarsource.sonarlint.core.clientapi.backend.issue;
 
 public enum ResolutionStatus {
-  // order is important here, it will be applied in the UI
+  ACCEPT("Accept", "The issue is valid but will not be fixed now. It represents accepted technical debt."),
   WONT_FIX("Won't Fix", "The issue is valid but does not need fixing. It represents accepted technical debt."),
   FALSE_POSITIVE("False Positive", "The issue is raised unexpectedly on code that should not trigger an issue.");
 

--- a/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IssueStatus.java
+++ b/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IssueStatus.java
@@ -20,5 +20,5 @@
 package org.sonarsource.sonarlint.core.commons;
 
 public enum IssueStatus {
-  WONT_FIX, FALSE_POSITIVE
+  ACCEPT, WONT_FIX, FALSE_POSITIVE
 }

--- a/commons/src/main/java/org/sonarsource/sonarlint/core/commons/Transition.java
+++ b/commons/src/main/java/org/sonarsource/sonarlint/core/commons/Transition.java
@@ -21,6 +21,7 @@ package org.sonarsource.sonarlint.core.commons;
 
 public enum Transition {
 
+  ACCEPT("accept"),
   WONT_FIX("wontfix"),
   FALSE_POSITIVE("falsepositive"),
   REOPEN("reopen");

--- a/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApi.java
+++ b/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApi.java
@@ -60,6 +60,7 @@ public class IssueApi {
   public static final Version MIN_SQ_VERSION_SUPPORTING_PULL = Version.create("9.6");
 
   private static final Map<IssueStatus, Transition> transitionByStatus = Map.of(
+    IssueStatus.ACCEPT, Transition.ACCEPT,
     IssueStatus.WONT_FIX, Transition.WONT_FIX,
     IssueStatus.FALSE_POSITIVE, Transition.FALSE_POSITIVE
   );


### PR DESCRIPTION
With SonarQube 10.4 and coming SonarCloud the transitions for resolving issues will be changed from **Won't fix** to **Accept**.