### PR TITLE
Run SC its with java 17

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -158,7 +158,7 @@ qa_task:
   matrix:
       -  env:
           SQ_VERSION: "SonarCloud"
-          JDK_VERSION: "11"
+          JDK_VERSION: "17"
           CATEGORY: "-Dgroups=SonarCloud"
           SONARCLOUD_IT_PASSWORD: VAULT[development/team/sonarlint/kv/data/sonarcloud-it data.password]
           QA_CATEGORY: SonarCloud


### PR DESCRIPTION
Run SC its with java 17 due to "The version of Java (11.0.21) used to run this analysis is deprecated, and SonarCloud no longer supports it. Please upgrade to Java 17 or later."
