### PR TITLE
SLCORE-665: Automatic connected mode setup

### DIFF
--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/SonarLintBackend.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/SonarLintBackend.java
@@ -35,6 +35,7 @@ import org.sonarsource.sonarlint.core.clientapi.backend.rules.RulesService;
 import org.sonarsource.sonarlint.core.clientapi.backend.telemetry.TelemetryService;
 import org.sonarsource.sonarlint.core.clientapi.backend.tracking.IssueTrackingService;
 import org.sonarsource.sonarlint.core.clientapi.backend.tracking.SecurityHotspotMatchingService;
+import org.sonarsource.sonarlint.core.clientapi.backend.usertoken.UserTokenService;
 import org.sonarsource.sonarlint.core.http.HttpClient;
 
 public interface SonarLintBackend {
@@ -80,6 +81,9 @@ public interface SonarLintBackend {
 
   @JsonDelegate
   NewCodeService getNewCodeService();
+
+  @JsonDelegate
+  UserTokenService getUserTokenService();
 
   @JsonRequest
   CompletableFuture<Void> shutdown();

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/usertoken/RevokeTokenParams.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/usertoken/RevokeTokenParams.java
@@ -1,0 +1,44 @@
+/*
+ * SonarLint Core - Client API
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.clientapi.backend.usertoken;
+
+public class RevokeTokenParams {
+  private final String baseUrl;
+  private final String tokenName;
+  private final String tokenValue;
+
+  public RevokeTokenParams(String baseUrl, String tokenName, String tokenValue) {
+    this.baseUrl = baseUrl;
+    this.tokenName = tokenName;
+    this.tokenValue = tokenValue;
+  }
+
+  public String getBaseUrl() {
+    return baseUrl;
+  }
+
+  public String getTokenName() {
+    return tokenName;
+  }
+
+  public String getTokenValue() {
+    return tokenValue;
+  }
+}

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/usertoken/UserTokenService.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/backend/usertoken/UserTokenService.java
@@ -1,0 +1,43 @@
+/*
+ * SonarLint Core - Client API
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.clientapi.backend.usertoken;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+public interface UserTokenService {
+  /**
+   *  <p> It revokes a user token that is existing on the server and was handed over to the client.
+   *  It silently deals with the following conditions:
+   *  <ul>
+   *    <li>the token provided by name (identified by {@link RevokeTokenParams#getTokenName()} exists</li>
+   *  </ul>
+   *  In those cases a completed future will be returned.
+   *  </p>
+   *  <p>
+   *  It returns a failed future if:
+   *  <ul>
+   *    <li>there is a communication problem with the server: network outage, server is down, unauthorized</li>
+   *  </ul>
+   *  </p>
+   */
+  @JsonRequest
+  CompletableFuture<Void> revokeToken(RevokeTokenParams params);
+}

--- a/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/client/connection/AssistCreatingConnectionParams.java
+++ b/client-api/src/main/java/org/sonarsource/sonarlint/core/clientapi/client/connection/AssistCreatingConnectionParams.java
@@ -19,15 +19,32 @@
  */
 package org.sonarsource.sonarlint.core.clientapi.client.connection;
 
+import javax.annotation.Nullable;
+
 public class AssistCreatingConnectionParams {
   private final String serverUrl;
+  @Nullable
+  private final String tokenName;
+  @Nullable
+  private final String tokenValue;
 
-  public AssistCreatingConnectionParams(String serverUrl) {
+  public AssistCreatingConnectionParams(String serverUrl, @Nullable String tokenName, @Nullable String tokenValue) {
     this.serverUrl = serverUrl;
+    this.tokenName = tokenName;
+    this.tokenValue = tokenValue;
   }
 
   public String getServerUrl() {
     return serverUrl;
   }
 
+  @Nullable
+  public String getTokenName() {
+    return tokenName;
+  }
+
+  @Nullable
+  public String getTokenValue() {
+    return tokenValue;
+  }
 }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/SonarLintBackendImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/SonarLintBackendImpl.java
@@ -36,6 +36,7 @@ import org.sonarsource.sonarlint.core.clientapi.backend.rules.RulesService;
 import org.sonarsource.sonarlint.core.clientapi.backend.telemetry.TelemetryService;
 import org.sonarsource.sonarlint.core.clientapi.backend.tracking.IssueTrackingService;
 import org.sonarsource.sonarlint.core.clientapi.backend.tracking.SecurityHotspotMatchingService;
+import org.sonarsource.sonarlint.core.clientapi.backend.usertoken.UserTokenService;
 import org.sonarsource.sonarlint.core.embedded.server.EmbeddedServer;
 import org.sonarsource.sonarlint.core.http.ConnectionAwareHttpClientProvider;
 import org.sonarsource.sonarlint.core.http.HttpClient;
@@ -132,6 +133,11 @@ public class SonarLintBackendImpl implements SonarLintBackend {
   @Override
   public NewCodeService getNewCodeService() {
     return getInitializedApplicationContext().getBean(NewCodeService.class);
+  }
+
+  @Override
+  public UserTokenService getUserTokenService() {
+    return getInitializedApplicationContext().getBean(UserTokenService.class);
   }
 
   @Override

--- a/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowHotspotOrIssueRequestHandler.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowHotspotOrIssueRequestHandler.java
@@ -26,6 +26,8 @@ import org.sonarsource.sonarlint.core.clientapi.client.binding.AssistBindingPara
 import org.sonarsource.sonarlint.core.clientapi.client.connection.AssistCreatingConnectionParams;
 import org.sonarsource.sonarlint.core.clientapi.client.connection.AssistCreatingConnectionResponse;
 
+import javax.annotation.Nullable;
+
 public class ShowHotspotOrIssueRequestHandler {
   private final BindingSuggestionProviderImpl bindingSuggestionProvider;
   private final SonarLintClient client;
@@ -47,7 +49,12 @@ public class ShowHotspotOrIssueRequestHandler {
   }
 
   CompletableFuture<AssistCreatingConnectionResponse> assistCreatingConnection(String serverUrl) {
-    return client.assistCreatingConnection(new AssistCreatingConnectionParams(serverUrl));
+    return assistCreatingConnection(serverUrl, null, null);
+  }
+
+  CompletableFuture<AssistCreatingConnectionResponse> assistCreatingConnection(String serverUrl,
+    @Nullable String tokenName, @Nullable String tokenValue) {
+    return client.assistCreatingConnection(new AssistCreatingConnectionParams(serverUrl, tokenName, tokenValue));
   }
 
   CompletableFuture<NewBinding> assistBinding(String connectionId, String projectKey) {

--- a/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/StatusRequestHandler.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/StatusRequestHandler.java
@@ -67,8 +67,12 @@ public class StatusRequestHandler implements HttpRequestHandler {
       .map(Header::getValue)
       .map(this::isTrustedServer)
       .orElse(false);
+
+    // We need a token when the requesting server is not a trusted one (in order to automatically create a connection).
     getDescription(trustedServer)
-      .thenAccept(description -> response.setEntity(new StringEntity(new Gson().toJson(new StatusResponse(clientInfo.getName(), description)), ContentType.APPLICATION_JSON)));
+      .thenAccept(description -> response.setEntity(
+        new StringEntity(new Gson().toJson(new StatusResponse(clientInfo.getName(), description, !trustedServer)),
+        ContentType.APPLICATION_JSON)));
 
   }
 
@@ -88,10 +92,13 @@ public class StatusRequestHandler implements HttpRequestHandler {
     private final String ideName;
     @Expose
     private final String description;
+    @Expose
+    private final boolean needsToken;
 
-    public StatusResponse(String ideName, String description) {
+    public StatusResponse(String ideName, String description, boolean needsToken) {
       this.ideName = ideName;
       this.description = description;
+      this.needsToken = needsToken;
     }
   }
 }

--- a/core/src/main/java/org/sonarsource/sonarlint/core/http/ConnectionUnawareHttpClientProvider.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/http/ConnectionUnawareHttpClientProvider.java
@@ -1,0 +1,37 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.http;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+@Named
+@Singleton
+public class ConnectionUnawareHttpClientProvider {
+  private final HttpClientProvider httpClientProvider;
+
+  public ConnectionUnawareHttpClientProvider(HttpClientProvider httpClientProvider) {
+    this.httpClientProvider = httpClientProvider;
+  }
+
+  public HttpClient getHttpClient(String token) {
+    return httpClientProvider.getHttpClientWithPreemptiveAuth(token, null);
+  }
+}

--- a/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
@@ -57,6 +57,7 @@ import org.sonarsource.sonarlint.core.http.AskClientCertificatePredicate;
 import org.sonarsource.sonarlint.core.http.ClientProxyCredentialsProvider;
 import org.sonarsource.sonarlint.core.http.ClientProxySelector;
 import org.sonarsource.sonarlint.core.http.ConnectionAwareHttpClientProvider;
+import org.sonarsource.sonarlint.core.http.ConnectionUnawareHttpClientProvider;
 import org.sonarsource.sonarlint.core.http.HttpClientProvider;
 import org.sonarsource.sonarlint.core.issue.IssueServiceImpl;
 import org.sonarsource.sonarlint.core.languages.LanguageSupportRepository;
@@ -78,6 +79,7 @@ import org.sonarsource.sonarlint.core.telemetry.TelemetryServiceImpl;
 import org.sonarsource.sonarlint.core.tracking.IssueTrackingServiceImpl;
 import org.sonarsource.sonarlint.core.tracking.LocalOnlyIssueRepository;
 import org.sonarsource.sonarlint.core.tracking.SecurityHotspotMatchingServiceImpl;
+import org.sonarsource.sonarlint.core.usertoken.UserTokenServiceImpl;
 import org.sonarsource.sonarlint.core.websocket.WebSocketService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -92,6 +94,7 @@ import org.springframework.context.annotation.Import;
   ClientProxySelector.class,
   ClientProxyCredentialsProvider.class,
   ConnectionAwareHttpClientProvider.class,
+  ConnectionUnawareHttpClientProvider.class,
   ConfigurationServiceImpl.class,
   ConfigurationRepository.class,
   RulesServiceImpl.class,
@@ -128,7 +131,8 @@ import org.springframework.context.annotation.Import;
   LocalOnlyIssueStorageService.class,
   StorageService.class,
   NewCodeServiceImpl.class,
-  SecurityHotspotMatchingServiceImpl.class
+  SecurityHotspotMatchingServiceImpl.class,
+  UserTokenServiceImpl.class
 })
 public class SonarLintSpringAppConfig {
 

--- a/core/src/main/java/org/sonarsource/sonarlint/core/usertoken/UserTokenServiceImpl.java
+++ b/core/src/main/java/org/sonarsource/sonarlint/core/usertoken/UserTokenServiceImpl.java
@@ -1,0 +1,40 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.usertoken;
+
+import java.util.concurrent.CompletableFuture;
+import org.sonarsource.sonarlint.core.ServerApiProvider;
+import org.sonarsource.sonarlint.core.clientapi.backend.usertoken.RevokeTokenParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.usertoken.UserTokenService;
+
+public class UserTokenServiceImpl implements UserTokenService {
+  private final ServerApiProvider serverApiProvider;
+
+  public UserTokenServiceImpl(ServerApiProvider serverApiProvider) {
+    this.serverApiProvider = serverApiProvider;
+  }
+
+  @Override
+  public CompletableFuture<Void> revokeToken(RevokeTokenParams params) {
+    return serverApiProvider.getServerApi(params.getBaseUrl(), null, params.getTokenValue())
+      .userTokens()
+      .revoke(params.getTokenName());
+  }
+}

--- a/core/src/test/java/org/sonarsource/sonarlint/core/embedded/server/ShowIssueRequestHandlerTest.java
+++ b/core/src/test/java/org/sonarsource/sonarlint/core/embedded/server/ShowIssueRequestHandlerTest.java
@@ -129,24 +129,44 @@ class ShowIssueRequestHandlerTest {
   }
 
   @Test
-  void should_extract_query_from_request() {
+  void should_extract_query_from_request_without_token() {
     var issueQuery = ShowIssueRequestHandler.extractQuery(new BasicClassicHttpRequest("GET", "/sonarlint/api/issues/show?server=" +
       "https%3A%2F%2Fnext.sonarqube.com%2Fsonarqube&project=org.sonarsource.sonarlint" +
       ".core%3Asonarlint-core-parent&issue=AX2VL6pgAvx3iwyNtLyr"));
     assertThat(issueQuery.getServerUrl()).isEqualTo("https://next.sonarqube.com/sonarqube");
     assertThat(issueQuery.getProjectKey()).isEqualTo("org.sonarsource.sonarlint.core:sonarlint-core-parent");
     assertThat(issueQuery.getIssueKey()).isEqualTo("AX2VL6pgAvx3iwyNtLyr");
+    assertThat(issueQuery.getTokenName()).isNull();
+    assertThat(issueQuery.getTokenValue()).isNull();
+  }
+
+  @Test
+  void should_extract_query_from_request_with_token() {
+    var issueQuery = ShowIssueRequestHandler.extractQuery(new BasicClassicHttpRequest("GET", "/sonarlint/api/issues/show?server=" +
+      "https%3A%2F%2Fnext.sonarqube.com%2Fsonarqube&project=org.sonarsource.sonarlint" +
+      ".core%3Asonarlint-core-parent&issue=AX2VL6pgAvx3iwyNtLyr&tokenName=abc&tokenValue=123"));
+    assertThat(issueQuery.getServerUrl()).isEqualTo("https://next.sonarqube.com/sonarqube");
+    assertThat(issueQuery.getProjectKey()).isEqualTo("org.sonarsource.sonarlint.core:sonarlint-core-parent");
+    assertThat(issueQuery.getIssueKey()).isEqualTo("AX2VL6pgAvx3iwyNtLyr");
+    assertThat(issueQuery.getTokenName()).isEqualTo("abc");
+    assertThat(issueQuery.getTokenValue()).isEqualTo("123");
   }
 
   @Test
   void should_validate_issue_query() {
-    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", "pullRequest").isValid()).isTrue();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", "pullRequest", null, null).isValid()).isTrue();
 
-    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("", "project", "issue", "branch", "pullRequest").isValid()).isFalse();
-    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "", "issue", "branch", "pullRequest").isValid()).isFalse();
-    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "", "branch", "pullRequest").isValid()).isFalse();
-    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "", "").isValid()).isFalse();
-    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", null).isValid()).isTrue();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("", "project", "issue", "branch", "pullRequest", null, null).isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "", "issue", "branch", "pullRequest", null, null).isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "", "branch", "pullRequest", null, null).isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "", "", null, null).isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", null, null, null).isValid()).isTrue();
+
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", "pullRequest", "name", null).isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", "pullRequest", null, "value").isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", "pullRequest", "name", "").isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", "pullRequest", "", "value").isValid()).isFalse();
+    assertThat(new ShowIssueRequestHandler.ShowIssueQuery("serverUrl", "project", "issue", "branch", "pullRequest", "name", "value").isValid()).isTrue();
   }
 
   @Test

--- a/its/tests/src/test/java/its/SonarCloudTests.java
+++ b/its/tests/src/test/java/its/SonarCloudTests.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -33,9 +34,11 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
+import org.apache.commons.lang.RandomStringUtils;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -71,6 +74,7 @@ import org.sonarsource.sonarlint.core.clientapi.backend.connection.org.ListUserO
 import org.sonarsource.sonarlint.core.clientapi.backend.connection.validate.ValidateConnectionParams;
 import org.sonarsource.sonarlint.core.clientapi.backend.initialize.FeatureFlagsDto;
 import org.sonarsource.sonarlint.core.clientapi.backend.initialize.InitializeParams;
+import org.sonarsource.sonarlint.core.clientapi.backend.usertoken.RevokeTokenParams;
 import org.sonarsource.sonarlint.core.clientapi.client.OpenUrlInBrowserParams;
 import org.sonarsource.sonarlint.core.clientapi.client.binding.AssistBindingParams;
 import org.sonarsource.sonarlint.core.clientapi.client.binding.AssistBindingResponse;
@@ -464,6 +468,34 @@ class SonarCloudTests extends AbstractConnectedTests {
       .validateConnection(new ValidateConnectionParams(new TransientSonarCloudConnectionDto(SONARCLOUD_ORGANIZATION, Either.forLeft(new TokenDto("foo"))))).get();
     assertThat(failIfWrongCredentials.isSuccess()).isFalse();
     assertThat(failIfWrongCredentials.getMessage()).isEqualTo("Authentication failed");
+  }
+
+  @Test
+  void test_revoke_token() {
+    var tokenName = RandomStringUtils.randomAlphabetic(32);
+
+    // If a prior IT is failing, remove the token (which can fail)
+    // -> SonarCloud staging does not reset like the orchestrator instances do!
+    try {
+      adminWsClient.userTokens().revoke(new RevokeRequest().setName(tokenName).setLogin(SONARCLOUD_USER));
+    } catch (Exception ignored) { }
+
+    var testToken = adminWsClient.userTokens()
+      .generate(new GenerateRequest().setName(tokenName));
+    assertThat(testToken.getName()).isEqualTo(tokenName);
+
+    // Using the credentials we used throughout the test, we want to remove the additional token!
+    assertThat(backend
+      .getUserTokenService()
+      .revokeToken(new RevokeTokenParams(SONARCLOUD_STAGING_URL, tokenName, testToken.getToken())))
+      .succeedsWithin(Duration.ofSeconds(10));
+
+    // SonarCloud staging gets accessed by everything, this way we can filter out OUR token (from THIS very build).
+    var searchResult = adminWsClient.userTokens().search(new org.sonarqube.ws.client.usertokens.SearchRequest().setLogin(testToken.getLogin()));
+    var tokensNamedTestTokenForRevoking = searchResult.getUserTokensList().stream()
+      .filter(token -> token.getName().equals(tokenName))
+      .collect(Collectors.toList());
+    assertThat(tokensNamedTestTokenForRevoking).isEmpty();
   }
 
   @Nested

--- a/medium-tests/src/test/java/mediumtest/EmbeddedServerMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/EmbeddedServerMediumTests.java
@@ -53,7 +53,7 @@ class EmbeddedServerMediumTests {
 
     assertThat(response)
       .extracting(HttpResponse::statusCode, HttpResponse::body)
-      .containsExactly(HttpStatus.OK_200, "{\"ideName\":\"ClientName\",\"description\":\"\"}");
+      .containsExactly(HttpStatus.OK_200, "{\"ideName\":\"ClientName\",\"description\":\"\",\"needsToken\":true}");
   }
 
   @Test
@@ -69,7 +69,7 @@ class EmbeddedServerMediumTests {
 
     assertThat(response)
       .extracting(HttpResponse::statusCode, HttpResponse::body)
-      .containsExactly(HttpStatus.OK_200, "{\"ideName\":\"ClientName\",\"description\":\"\"}");
+      .containsExactly(HttpStatus.OK_200, "{\"ideName\":\"ClientName\",\"description\":\"\",\"needsToken\":true}");
   }
 
   @Test
@@ -85,7 +85,7 @@ class EmbeddedServerMediumTests {
 
     assertThat(response)
       .extracting(HttpResponse::statusCode, HttpResponse::body)
-      .containsExactly(HttpStatus.OK_200, "{\"ideName\":\"ClientName\",\"description\":\"WorkspaceTitle\"}");
+      .containsExactly(HttpStatus.OK_200, "{\"ideName\":\"ClientName\",\"description\":\"WorkspaceTitle\",\"needsToken\":false}");
   }
 
   @Test

--- a/medium-tests/src/test/java/mediumtest/UserTokenMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/UserTokenMediumTests.java
@@ -1,0 +1,65 @@
+/*
+ * SonarLint Core - Medium Tests
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package mediumtest;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
+
+import mockwebserver3.MockResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonarsource.sonarlint.core.SonarLintBackendImpl;
+import org.sonarsource.sonarlint.core.clientapi.backend.usertoken.RevokeTokenParams;
+import org.sonarsource.sonarlint.core.commons.testutils.MockWebServerExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
+import static mediumtest.fixtures.SonarLintBackendFixture.newFakeClient;
+
+class UserTokenMediumTests {
+  @RegisterExtension
+  private final MockWebServerExtension mockWebServerExtension = new MockWebServerExtension();
+  
+  private SonarLintBackendImpl backend;
+
+  @AfterEach
+  void tearDown() throws ExecutionException, InterruptedException {
+    backend.shutdown().get();
+  }
+
+  /**
+   *  INFO: Check {@link its.SonarCloudTests#test_revoke_token()} and
+   *        {@link its.SonarQubeCommunityEditionTests#test_revoke_token()} for actual (non-mocked) tests against SQ/SC.
+   */
+  @Test
+  void test_revoke_user_token() {
+    var fakeClient = newFakeClient().build();
+    backend = newBackend().build(fakeClient);
+
+    mockWebServerExtension.addResponse("/api/user_tokens/revoke",
+      new MockResponse().setResponseCode(200));
+
+    assertThat(backend
+      .getUserTokenService()
+      .revokeToken(new RevokeTokenParams(mockWebServerExtension.url("/"), "tokenNameTest", "tokenValueTest")))
+      .succeedsWithin(Duration.ofSeconds(5));
+  }
+}

--- a/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApi.java
+++ b/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApi.java
@@ -34,6 +34,7 @@ import org.sonarsource.sonarlint.core.serverapi.rules.RulesApi;
 import org.sonarsource.sonarlint.core.serverapi.settings.SettingsApi;
 import org.sonarsource.sonarlint.core.serverapi.source.SourceApi;
 import org.sonarsource.sonarlint.core.serverapi.system.SystemApi;
+import org.sonarsource.sonarlint.core.serverapi.usertokens.UserTokensApi;
 
 public class ServerApi {
   private final ServerApiHelper helper;
@@ -88,6 +89,10 @@ public class ServerApi {
 
   public SystemApi system() {
     return new SystemApi(helper);
+  }
+
+  public UserTokensApi userTokens() {
+    return new UserTokensApi(helper);
   }
 
   public ProjectBranchesApi branches() {

--- a/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/usertokens/UserTokensApi.java
+++ b/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/usertokens/UserTokensApi.java
@@ -1,0 +1,46 @@
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.serverapi.usertokens;
+
+import java.util.concurrent.CompletableFuture;
+import org.sonarsource.sonarlint.core.serverapi.ServerApiHelper;
+
+import static org.sonarsource.sonarlint.core.http.HttpClient.FORM_URL_ENCODED_CONTENT_TYPE;
+import static org.sonarsource.sonarlint.core.serverapi.UrlUtils.urlEncode;
+
+/**
+ *  For the /api/user_tokens endpoint of SonarQube / SonarCloud. When adding more methods, please ensure the protobuf
+ *  files for "ws-user_tokens.proto" are present and configured correctly regarding the "java_package" preference!
+ */
+public class UserTokensApi {
+  private final ServerApiHelper helper;
+
+  public UserTokensApi(ServerApiHelper helper) {
+    this.helper = helper;
+  }
+
+  public CompletableFuture<Void> revoke(String tokenName) {
+    var body = "name=" + urlEncode(tokenName);
+    return helper.postAsync("/api/user_tokens/revoke", FORM_URL_ENCODED_CONTENT_TYPE, body)
+      .thenAccept(response -> {
+        // no data, return void
+      });
+  }
+}


### PR DESCRIPTION
When using the "Open in IDE" feature on SonarQube, we want to get a token (if possible) for an automated connected mode setup. It should still work with older SonarQube servers not able to generate a token as well as opening Security Hotspots in the IDE - this feature won't provide a token.
The changes on the SonarQube side were already done (**old SonarLint - new SonarQube** and **new SonarLint - old SonarQube** will work).

Follow-up ticket: [SLCORE-666 Make token revocation transparent for the client](https://sonarsource.atlassian.net/browse/SLCORE-666)