### PR TITLE
SLCORE-668: Fix download of sonar-text

### DIFF
--- a/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerConnection.java
+++ b/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerConnection.java
@@ -51,7 +51,7 @@ import org.sonarsource.sonarlint.core.serverconnection.prefix.FileTreeMatcher;
 public class ServerConnection {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
   private static final Version SECRET_ANALYSIS_MIN_SQ_VERSION = Version.create("9.9");
-  private static final Version CUSTOM_SECRETS_MIN_SQ_VERSION = Version.create("10.4");
+  public static final Version CUSTOM_SECRETS_MIN_SQ_VERSION = Version.create("10.4");
 
   private static final Version CLEAN_CODE_TAXONOMY_MIN_SQ_VERSION = Version.create("10.2");
 

--- a/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/PluginsSynchronizerTests.java
+++ b/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/PluginsSynchronizerTests.java
@@ -55,7 +55,7 @@ class PluginsSynchronizerTests {
     mockServer.addStringResponse("/api/plugins/download?plugin=javascript", "content-js");
 
     underTest = new PluginsSynchronizer(Set.of(Language.JAVA, Language.JS), new ConnectionStorage(dest, tmp, "connectionId"), emptySet());
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     var references = ProtobufFileUtil.readFile(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb"), PluginReferences.parser());
     assertThat(references.getPluginsByKeyMap().values()).extracting("key", "hash", "filename")
@@ -76,10 +76,10 @@ class PluginsSynchronizerTests {
       "]}");
     mockServer.addStringResponse("/api/plugins/download?plugin=java", "content-java");
     underTest = new PluginsSynchronizer(Set.of(Language.JAVA), new ConnectionStorage(dest, tmp, "connectionId"), emptySet());
-    underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
     mockServer.removeResponse("/api/plugins/download?plugin=java");
 
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     assertThat(anyPluginUpdated).isFalse();
   }
@@ -93,13 +93,13 @@ class PluginsSynchronizerTests {
       "]}");
     mockServer.addStringResponse("/api/plugins/download?plugin=java", "content-java");
     underTest = new PluginsSynchronizer(Set.of(Language.JAVA), new ConnectionStorage(dest, tmp, "connectionId"), emptySet());
-    underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
     mockServer.addStringResponse("/api/plugins/installed", "{\"plugins\": [" +
       "{\"key\": \"java\", \"hash\": \"79dba9cab72d8d31767f47c03d169598\", \"filename\": \"sonar-java-plugin-5.14.0.18485.jar\", \"sonarLintSupported\": true}" +
       "]}");
     mockServer.addStringResponse("/api/plugins/download?plugin=java", "content-java2");
 
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     var references = ProtobufFileUtil.readFile(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb"), PluginReferences.parser());
     assertThat(references.getPluginsByKeyMap().values()).extracting("key", "hash", "filename")
@@ -116,7 +116,7 @@ class PluginsSynchronizerTests {
       "]}");
 
     underTest = new PluginsSynchronizer(Set.of(Language.JAVA), new ConnectionStorage(dest, dest, "connectionId"), Set.of());
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb")).doesNotExist();
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-java-plugin-5.13.1.18282.jar")).doesNotExist();
@@ -130,7 +130,7 @@ class PluginsSynchronizerTests {
       "]}");
 
     underTest = new PluginsSynchronizer(Set.of(Language.JAVA), new ConnectionStorage(dest, dest, "connectionId"), Set.of());
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb")).doesNotExist();
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-java-plugin-5.12.0.jar")).doesNotExist();
@@ -144,7 +144,7 @@ class PluginsSynchronizerTests {
       "]}");
 
     underTest = new PluginsSynchronizer(Set.of(Language.JAVA), new ConnectionStorage(dest, dest, "connectionId"), Set.of("java"));
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb")).doesNotExist();
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-java-plugin-5.13.1.18282.jar")).doesNotExist();
@@ -159,7 +159,7 @@ class PluginsSynchronizerTests {
       "]}");
 
     underTest = new PluginsSynchronizer(Set.of(Language.JS), new ConnectionStorage(dest, tmp, "connectionId"), emptySet());
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb")).doesNotExist();
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-java-plugin-5.13.1.18282.jar")).doesNotExist();
@@ -175,7 +175,7 @@ class PluginsSynchronizerTests {
     mockServer.addStringResponse("/api/plugins/download?plugin=java-custom", "content-java-custom");
 
     underTest = new PluginsSynchronizer(Set.of(Language.JS), new ConnectionStorage(dest, tmp, "connectionId"), emptySet());
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     var references = ProtobufFileUtil.readFile(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb"), PluginReferences.parser());
     assertThat(references.getPluginsByKeyMap().values()).extracting("key", "hash", "filename")
@@ -195,7 +195,7 @@ class PluginsSynchronizerTests {
     mockServer.addStringResponse("/api/plugins/download?plugin=typescript", "content-ts");
 
     underTest = new PluginsSynchronizer(Set.of(Language.TS), new ConnectionStorage(dest, tmp, "connectionId"), emptySet());
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     var references = ProtobufFileUtil.readFile(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb"), PluginReferences.parser());
     assertThat(references.getPluginsByKeyMap().values()).extracting("key", "hash", "filename")
@@ -214,10 +214,51 @@ class PluginsSynchronizerTests {
       "]}");
 
     underTest = new PluginsSynchronizer(Set.of(Language.JAVA), new ConnectionStorage(dest, tmp, "connectionId"), emptySet());
-    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
 
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/636f6e6e656374696f6e4964/plugin_references.pb")).doesNotExist();
     assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-typescript-plugin-1.9.0.3766.jar")).doesNotExist();
     assertThat(anyPluginUpdated).isFalse();
+  }
+
+  /**
+   *  Emulating SonarQube 10.3 where custom secrets are not enabled and `sonar-text` is embedded and
+   *  `sonar-text-enterprise` not downloaded because it is not supporting SonarLint yet!
+   */
+  @Test
+  void should_not_synchronize_sonar_text_pre_104(@TempDir Path dest) {
+    mockServer.addStringResponse("/api/plugins/installed", "{\"plugins\": [" +
+      "{\"key\": \"text\", \"hash\": \"de5308f43260d357acc97712ce4c5475\", \"filename\": \"sonar-text-plugin-1.2.3.4.jar\", \"sonarLintSupported\": true}," +
+      "{\"key\": \"textenterprise\", \"hash\": \"de5308f43260d357acc97712ce4c5475\", \"filename\": \"sonar-text-enterprise-plugin-5.6.7.8.jar\", \"sonarLintSupported\": false}" +
+      "]}");
+
+    underTest = new PluginsSynchronizer(Set.of(Language.SECRETS), new ConnectionStorage(dest, dest, "connectionId"), Set.of("text"));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), false);
+
+    assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb")).doesNotExist();
+    assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-text-plugin-1.2.3.4.jar")).doesNotExist();
+    assertThat(anyPluginUpdated).isFalse();
+  }
+
+  /**
+   *  Emulating SonarQube 10.4 where custom secrets are enabled and `sonar-text` is embedded but will be downloaded
+   *  alongside `sonar-text-enterprise` because it is now supporting SonarLint!
+   */
+  @Test
+  void should_not_synchronize_sonar_text_post_103(@TempDir Path dest) {
+    mockServer.addStringResponse("/api/plugins/installed", "{\"plugins\": [" +
+      "{\"key\": \"text\", \"hash\": \"de5308f43260d357acc97712ce4c5475\", \"filename\": \"sonar-text-plugin-1.2.3.4.jar\", \"sonarLintSupported\": true}," +
+      "{\"key\": \"textenterprise\", \"hash\": \"de5308f43260d357acc97712ce4c5475\", \"filename\": \"sonar-text-enterprise-plugin-5.6.7.8.jar\", \"sonarLintSupported\": true}" +
+      "]}");
+    mockServer.addStringResponse("/api/plugins/download?plugin=text", "content-text");
+    mockServer.addStringResponse("/api/plugins/download?plugin=textenterprise", "content-textenterprise");
+
+    underTest = new PluginsSynchronizer(Set.of(Language.SECRETS), new ConnectionStorage(dest, dest, "connectionId"), Set.of("text"));
+    var anyPluginUpdated = underTest.synchronize(new ServerApi(mockServer.serverApiHelper()), new ProgressMonitor(null), true);
+
+    assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/plugin_references.pb")).exists();
+    assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-text-plugin-1.2.3.4.jar")).exists();
+    assertThat(dest.resolve("636f6e6e656374696f6e4964/plugins/sonar-text-enterprise-plugin-5.6.7.8.jar")).exists();
+    assertThat(anyPluginUpdated).isTrue();
   }
 }


### PR DESCRIPTION
## Summary

There was an issue that connecting SonarLint to SQ 10.3 and earlier worked the same as before. However, with 10.4, the `sonar-text` analyzer wasn't downloaded anymore because it was still seen as embedded while the `PluginsSynchonizer` was synchronizing the plug-ins for the connection.

The [first approach](https://github.com/SonarSource/sonarlint-core/commit/6aeaf961919d1eb5cd880b50c9da41168d119e1d) to mitigate this issue only worked when the connection was established; the IDE was closed and then opened again for the synchronization to start again. This was due to the check to remove the embedded instance of `sonar-text` not being able to access the server information yet to check the SQ version.
The synchronization of the SQ server information was not finished the first time, but when the IDE was restarted, the information was already present.

With this PR, the changes are now finally in place to wait for the server information to be synchronized before making the check on SQ 10.4+ (when we don't use the embedded `sonar-text` but rather fetch the one from the server alongside `sonar-text-enterprise`) and before handing everything over to the `PluginsSynchonizer` to synchronize the plug-ins to be downloaded.

## Testing

Due to SQ 10.4 DEV currently not yet including the new `sonar-text` and `sonar-text-enterprise` versions, which support SonarLint via the manifest attributes, there are unit as well as medium tests in place to emulate the behavior of having SQ 10.4 and SQ 10.3!
Additionally, manual tests were done with the new `sonar-text` and `sonar-text-enterprise` versions and SQ 10.4 DEV locally, where the plug-ins were exchanged alongside manual testing against SQ 10.3 and SQ 10.2 where `sonar-text` was not to be downloaded but where the embedded one should be used.