### PR TITLE
Update parent pom and license headers

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 SonarLint Core
-Copyright (C) 2016-2023 SonarSource SA
+Copyright (C) 2016-2024 SonarSource SA
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Have a look at the documentation [here](spec/README.adoc).
 License
 -------
 
-Copyright 2016-2023 SonarSource.
+Copyright 2016-2024 SonarSource.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisEngine.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisEngine.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ActiveRule.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ActiveRule.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisConfiguration.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfiguration.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisResults.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisResults.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFile.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFileEdit.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFileEdit.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModuleFileEvent.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModuleFileEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModuleFileSystem.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModuleFileSystem.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModuleInfo.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModuleInfo.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModulesProvider.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/ClientModulesProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/DefaultLocation.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/DefaultLocation.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/Flow.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/Flow.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/Issue.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/Issue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/IssueLocation.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/IssueLocation.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/QuickFix.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/QuickFix.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/TextEdit.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/TextEdit.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/WithTextRange.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/WithTextRange.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/AnalyzeCommand.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/AnalyzeCommand.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/Command.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/Command.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/NotifyModuleEventCommand.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/NotifyModuleEventCommand.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/RegisterModuleCommand.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/RegisterModuleCommand.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/UnregisterModuleCommand.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/UnregisterModuleCommand.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/command/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/ContainerLifespan.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/ContainerLifespan.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisConfigurationProvider.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisConfigurationProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisContainer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisSettings.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisSettings.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisTempFolderProvider.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisTempFolderProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/IssueListenerHolder.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/IssueListenerHolder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/SonarLintPathPattern.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/SonarLintPathPattern.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/AbstractFilePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/AbstractFilePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/AndPredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/AndPredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultFilePredicates.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultFilePredicates.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultTextPointer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultTextPointer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultTextRange.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultTextRange.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FalsePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FalsePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileExtensionPredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileExtensionPredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileIndexer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileIndexer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileMetadata.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileMetadata.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FilenamePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FilenamePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileIndex.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileIndex.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/Language.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/Language.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/LanguageDetection.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/LanguageDetection.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/LanguagePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/LanguagePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/NotPredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/NotPredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/OptimizedFilePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/OptimizedFilePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/OptimizedFilePredicateAdapter.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/OptimizedFilePredicateAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/OrPredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/OrPredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/PathPatternPredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/PathPatternPredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/ProgressReport.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/ProgressReport.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintFileSystem.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintFileSystem.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputDir.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputDir.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFile.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputProject.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputProject.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/StatusPredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/StatusPredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/TruePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/TruePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/TypePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/TypePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/URIPredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/URIPredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/DefaultIssueFilterChain.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/DefaultIssueFilterChain.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/IssueFilters.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/IssueFilters.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/SensorInputFileEdit.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/SensorInputFileEdit.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/SensorQuickFix.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/SensorQuickFix.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/SensorTextEdit.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/SensorTextEdit.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/TextRangeUtils.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/TextRangeUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/EnforceIssuesFilter.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/EnforceIssuesFilter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/IgnoreIssuesFilter.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/IgnoreIssuesFilter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/SonarLintNoSonarFilter.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/SonarLintNoSonarFilter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/AbstractPatternInitializer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/AbstractPatternInitializer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/BlockIssuePattern.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/BlockIssuePattern.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueExclusionPatternInitializer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueExclusionPatternInitializer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueInclusionPatternInitializer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueInclusionPatternInitializer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssuePattern.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssuePattern.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsLoader.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsLoader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsRegexpScanner.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsRegexpScanner.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/LineRange.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/LineRange.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorOptimizer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorOptimizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorsExecutor.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorsExecutor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SonarLintSensorStorage.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SonarLintSensorStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/AnalysisExtensionInstaller.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/AnalysisExtensionInstaller.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalAnalysisContainer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalAnalysisContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalConfigurationProvider.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalConfigurationProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalExtensionContainer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalExtensionContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalSettings.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalSettings.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolder.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolderProvider.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolderProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/ModuleRegistry.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/ModuleRegistry.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/TransientModuleFileSystem.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/TransientModuleFileSystem.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/DefaultModuleFileEvent.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/DefaultModuleFileEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleContainer.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleFileEventNotifier.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleFileEventNotifier.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/module/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/ActiveRuleAdapter.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/ActiveRuleAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/ActiveRulesAdapter.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/ActiveRulesAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/ConfigurationBridge.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/ConfigurationBridge.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultAnalysisError.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultAnalysisError.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultFilterableIssue.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultFilterableIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultFlow.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultFlow.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorContext.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorContext.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorDescriptor.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorDescriptor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSonarLintIssue.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSonarLintIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSonarLintIssueLocation.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSonarLintIssueLocation.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultStorable.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultStorable.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultTempFolder.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultTempFolder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MapSettings.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MapSettings.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MultivalueProperty.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MultivalueProperty.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/SonarLintModuleFileSystem.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/SonarLintModuleFileSystem.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpFileLinesContext.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpFileLinesContext.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpFileLinesContextFactory.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpFileLinesContextFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCoverage.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCoverage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCpdTokens.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCpdTokens.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewHighlighting.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewHighlighting.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMeasure.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMeasure.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMessageFormatting.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMessageFormatting.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSignificantCode.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSignificantCode.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSymbolTable.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSymbolTable.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/package-info.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/sonarapi/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisConfigurationTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisConfigurationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfigurationTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/AnalysisEngineConfigurationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFileTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/ClientInputFileTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/DefaultLocationTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/DefaultLocationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/IssueLocationTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/api/IssueLocationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisTempFolderProviderTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/AnalysisTempFolderProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultFilePredicatesTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/DefaultFilePredicatesTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileMetadataTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/FileMetadataTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilderTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileBuilderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileCacheTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/InputFileCacheTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/LanguageDetectionTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/LanguageDetectionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/ProgressReportTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/ProgressReportTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintFileSystemTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintFileSystemTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputDirTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputDirTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFileTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/SonarLintInputFileTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/EnforceIssuesFilterTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/EnforceIssuesFilterTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/IgnoreIssuesFilterTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/IgnoreIssuesFilterTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueExclusionPatternInitializerTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueExclusionPatternInitializerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueInclusionPatternInitializerTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssueInclusionPatternInitializerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssuePatternTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/pattern/IssuePatternTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsLoaderTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsLoaderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsRegexpScannerTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/IssueExclusionsRegexpScannerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/LineRangeTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/issue/ignore/scanner/LineRangeTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorOptimizerTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorOptimizerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorsExecutorTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SensorsExecutorTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SonarLintSensorStorageTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/analysis/sensor/SonarLintSensorStorageTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/global/AnalysisExtensionInstallerTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/global/AnalysisExtensionInstallerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalSettingsTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalSettingsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolderProviderTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolderProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilderTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/container/module/ModuleInputFileBuilderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/mediumtests/AnalysisEngineMediumTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/mediumtests/AnalysisEngineMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultAnalysisErrorTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultAnalysisErrorTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultFilterableIssueTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultFilterableIssueTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorContextTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorContextTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorDescriptorTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSensorDescriptorTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSonarLintIssueTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultSonarLintIssueTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultTempFolderTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/DefaultTempFolderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MapSettingsTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MapSettingsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MultivaluePropertyTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/MultivaluePropertyTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCoverageTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCoverageTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCpdTokensTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewCpdTokensTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewHighlightingTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewHighlightingTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMeasureTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMeasureTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMessageFormattingTest.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewMessageFormattingTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSignificantCodeTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSignificantCodeTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSymbolTableTests.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/sonarapi/noop/NoOpNewSymbolTableTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/testutils/FileUtils.java
+++ b/backend/analysis-engine/src/test/java/testutils/FileUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/testutils/InMemoryTestClientInputFile.java
+++ b/backend/analysis-engine/src/test/java/testutils/InMemoryTestClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/testutils/OnDiskTestClientInputFile.java
+++ b/backend/analysis-engine/src/test/java/testutils/OnDiskTestClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/testutils/TestClientInputFile.java
+++ b/backend/analysis-engine/src/test/java/testutils/TestClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/analysis-engine/src/test/java/testutils/TestInputFileBuilder.java
+++ b/backend/analysis-engine/src/test/java/testutils/TestInputFileBuilder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Analysis Engine
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/cli/src/main/java/org/sonarsource/sonarlint/core/backend/cli/SonarLintServerCli.java
+++ b/backend/cli/src/main/java/org/sonarsource/sonarlint/core/backend/cli/SonarLintServerCli.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Backend CLI
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/cli/src/main/java/org/sonarsource/sonarlint/core/backend/cli/package-info.java
+++ b/backend/cli/src/main/java/org/sonarsource/sonarlint/core/backend/cli/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Backend CLI
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/CleanCodeAttribute.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/CleanCodeAttribute.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/CleanCodeAttributeCategory.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/CleanCodeAttributeCategory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/ConnectionKind.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/ConnectionKind.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/HotspotReviewStatus.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/HotspotReviewStatus.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IOExceptionUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IOExceptionUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/ImpactSeverity.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/ImpactSeverity.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IssueSeverity.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IssueSeverity.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IssueStatus.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/IssueStatus.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/LineWithHash.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/LineWithHash.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/LocalOnlyIssue.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/LocalOnlyIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/LocalOnlyIssueResolution.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/LocalOnlyIssueResolution.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/NewCodeDefinition.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/NewCodeDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/NewCodeMode.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/NewCodeMode.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/PluginsMinVersions.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/PluginsMinVersions.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/RuleKey.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/RuleKey.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/RuleType.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/RuleType.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SoftwareQuality.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SoftwareQuality.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintCoreVersion.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintCoreVersion.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintException.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintUserHome.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintUserHome.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/Transition.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/Transition.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/Version.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/Version.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/VulnerabilityProbability.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/VulnerabilityProbability.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/SonarLanguage.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/SonarLanguage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/TextRange.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/TextRange.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/TextRangeWithHash.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/TextRangeWithHash.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/package-info.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/progress/CanceledException.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/progress/CanceledException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/progress/ClientProgressMonitor.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/progress/ClientProgressMonitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/FormattingTuple.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/FormattingTuple.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/LogOutput.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/LogOutput.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/LogOutputDelegator.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/LogOutputDelegator.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/MessageFormatter.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/MessageFormatter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/NormalizedParameters.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/NormalizedParameters.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/SonarLintLogger.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/SonarLintLogger.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/package-info.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/log/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/package-info.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/ExecutorServiceShutdownWatchable.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/ExecutorServiceShutdownWatchable.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/ProgressMonitor.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/ProgressMonitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/SonarLintCancelMonitor.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/SonarLintCancelMonitor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/package-info.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/progress/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/HotspotReviewStatusTest.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/HotspotReviewStatusTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/IOExceptionUtilsTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/IOExceptionUtilsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/NewCodeDefinitionTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/NewCodeDefinitionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/PluginsMinVersionsTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/PluginsMinVersionsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/RuleKeyTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/RuleKeyTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/SonarLintCoreVersionTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/SonarLintCoreVersionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/SonarLintUserHomeTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/SonarLintUserHomeTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/TextRangeTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/TextRangeTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/TextRangeWithHashTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/TextRangeWithHashTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/VersionTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/VersionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/ConcurrentListAppender.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/ConcurrentListAppender.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/LogOutputDelegatorTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/LogOutputDelegatorTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/MessageFormatterTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/MessageFormatterTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/SonarLintLogTester.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/SonarLintLogTester.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/SonarLintLoggerTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/log/SonarLintLoggerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/progress/ExecutorServiceShutdownWatchableTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/progress/ExecutorServiceShutdownWatchableTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/progress/ProgressMonitorTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/progress/ProgressMonitorTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/MockWebServerExtension.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/MockWebServerExtension.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingCandidatesFinder.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingCandidatesFinder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingSuggestionProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingSuggestionProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConnectionService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConnectionService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/NodeJsHelper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/NodeJsHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/OrganizationsCache.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/OrganizationsCache.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ServerApiProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ServerApiProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ServerFileExclusions.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ServerFileExclusions.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarLintMDC.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarLintMDC.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarProjectsCache.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarProjectsCache.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/TextSearchIndex.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/TextSearchIndex.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/TokenGeneratorHelper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/TokenGeneratorHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/NodeJsService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/NodeJsService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/MatchedSonarProjectBranchChangedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/MatchedSonarProjectBranchChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/SonarProjectBranchMatchingEndedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/SonarProjectBranchMatchingEndedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/SonarProjectBranchTrackingService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/SonarProjectBranchTrackingService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/branch/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/Binding.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/Binding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/BoundScope.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/BoundScope.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/DebounceComputer.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/DebounceComputer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/SmartCancelableLoadingCache.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/SmartCancelableLoadingCache.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/ThreadFactories.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/ThreadFactories.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/commons/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/AwaitingUserTokenFutureRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/AwaitingUserTokenFutureRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/CorsFilter.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/CorsFilter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/EmbeddedServer.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/EmbeddedServer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/GeneratedUserTokenHandler.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/GeneratedUserTokenHandler.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/RequestHandlerBindingAssistant.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/RequestHandlerBindingAssistant.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowHotspotRequestHandler.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowHotspotRequestHandler.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowIssueRequestHandler.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowIssueRequestHandler.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/StatusRequestHandler.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/StatusRequestHandler.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/BindingConfigChangedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/BindingConfigChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConfigurationScopeRemovedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConfigurationScopeRemovedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConfigurationScopesAddedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConfigurationScopesAddedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionConfigurationAddedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionConfigurationAddedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionConfigurationRemovedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionConfigurationRemovedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionConfigurationUpdatedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionConfigurationUpdatedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionCredentialsChangedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ConnectionCredentialsChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/LocalOnlyIssueStatusChangedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/LocalOnlyIssueStatusChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ServerIssueStatusChangedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/ServerIssueStatusChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/SonarServerEventReceivedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/SonarServerEventReceivedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/TaintVulnerabilitiesSynchronizedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/TaintVulnerabilitiesSynchronizedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/event/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/FilePathTranslation.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/FilePathTranslation.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/PathTranslationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/PathTranslationService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ClientFile.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ClientFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ClientFileSystemService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ClientFileSystemService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/FileExclusionService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/FileExclusionService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/FileSystemUpdatedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/FileSystemUpdatedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/hotspot/HotspotService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/hotspot/HotspotService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/hotspot/HotspotStatusChangeException.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/hotspot/HotspotStatusChangeException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/hotspot/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/hotspot/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/AskClientCertificatePredicate.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/AskClientCertificatePredicate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/ClientProxyCredentialsProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/ClientProxyCredentialsProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/ClientProxySelector.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/ClientProxySelector.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/ConnectionAwareHttpClientProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/ConnectionAwareHttpClientProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/http/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/IssueService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/IssueService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/matching/IssueMatcher.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/matching/IssueMatcher.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/matching/MatchingAttributesMapper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/matching/MatchingAttributesMapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/matching/MatchingResult.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/matching/MatchingResult.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/languages/LanguageSupportRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/languages/LanguageSupportRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/languages/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/languages/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/IssueStatusBinding.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/IssueStatusBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/LocalOnlyIssueStorageService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/LocalOnlyIssueStorageService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/XodusLocalOnlyIssueStore.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/XodusLocalOnlyIssueStore.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/local/only/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/newcode/NewCodeService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/newcode/NewCodeService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/newcode/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/newcode/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginsRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginsRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginsService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/PluginsService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/ClientProgressNotifier.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/ClientProgressNotifier.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/NoOpProgressNotifier.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/NoOpProgressNotifier.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/ProgressNotifier.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/ProgressNotifier.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/TaskManager.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/TaskManager.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/progress/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/BindingConfiguration.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/BindingConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationScope.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationScope.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationScopeWithBinding.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationScopeWithBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/config/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/AbstractConnectionConfiguration.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/AbstractConnectionConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/ConnectionConfigurationRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/ConnectionConfigurationRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/SonarCloudConnectionConfiguration.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/SonarCloudConnectionConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/SonarQubeConnectionConfiguration.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/SonarQubeConnectionConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/rules/RulesRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/rules/RulesRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/rules/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/rules/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/CleanCodePrinciples.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/CleanCodePrinciples.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/OthersSectionHtmlContent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/OthersSectionHtmlContent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RuleDetails.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RuleDetails.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RuleDetailsAdapter.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RuleDetailsAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RuleNotFoundException.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RuleNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RulesExtractionHelper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RulesExtractionHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RulesService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/RulesService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/rules/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/server/event/ServerEventsService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/server/event/ServerEventsService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/server/event/SonarQubeEventStream.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/server/event/SonarQubeEventStream.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/server/event/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/server/event/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/LastEventPolling.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/LastEventPolling.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/ServerNotification.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/ServerNotification.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/SmartNotifications.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/SmartNotifications.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SpringApplicationContextInitializer.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SpringApplicationContextInitializer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/storage/StorageService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/storage/StorageService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/storage/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/storage/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/HotspotSynchronizationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/HotspotSynchronizationService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/IssueSynchronizationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/IssueSynchronizationService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SonarProjectBranchesChangedEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SonarProjectBranchesChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SonarProjectBranchesSynchronizationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SonarProjectBranchesSynchronizationService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SynchronizationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SynchronizationService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SynchronizationTimestampRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/SynchronizationTimestampRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/TaintSynchronizationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/TaintSynchronizationService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryServerAttributesProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryServerAttributesProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/ClientTrackedFindingMatchingAttributeMapper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/ClientTrackedFindingMatchingAttributeMapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/DigestUtils.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/DigestUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/IssueMatchingService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/IssueMatchingService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/LocalOnlyIssueMatchingAttributesMapper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/LocalOnlyIssueMatchingAttributesMapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/LocalOnlyIssueRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/LocalOnlyIssueRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/LocalOnlySecurityHotspot.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/LocalOnlySecurityHotspot.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/SecurityHotspotMatchingService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/SecurityHotspotMatchingService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/ServerHotspotMatchingAttributesMapper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/ServerHotspotMatchingAttributesMapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/ServerIssueMatchingAttributesMapper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/ServerIssueMatchingAttributesMapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TaintVulnerabilityTrackingService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TaintVulnerabilityTrackingService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/usertoken/UserTokenService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/usertoken/UserTokenService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/History.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/History.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocket.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocket.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketEventSubscribePayload.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketEventSubscribePayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/events/SmartNotificationEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/events/SmartNotificationEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/events/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/events/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/parsing/SmartNotificationEventParser.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/parsing/SmartNotificationEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/parsing/package-info.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/parsing/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/BindingClueProviderTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/BindingClueProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/BindingSuggestionProviderTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/BindingSuggestionProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConnectionServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConnectionServiceTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/NodeJsHelperTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/NodeJsHelperTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/ServerApiProviderTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/ServerApiProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarProjectsCacheTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarProjectsCacheTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/TelemetryServerAttributesProviderTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/TelemetryServerAttributesProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelperTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelperTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/branch/SonarProjectBranchTrackingServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/branch/SonarProjectBranchTrackingServiceTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/commons/SmartCancelableLoadingCacheTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/commons/SmartCancelableLoadingCacheTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/embedded/server/ShowIssueRequestHandlerTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/embedded/server/ShowIssueRequestHandlerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/file/FilePathTranslationTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/file/FilePathTranslationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/file/PathTranslationServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/file/PathTranslationServiceTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/hotspot/HotspotServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/hotspot/HotspotServiceTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/issue/matching/IssueMatcherTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/issue/matching/IssueMatcherTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/local/only/XodusLocalOnlyIssueStoreTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/local/only/XodusLocalOnlyIssueStoreTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/newcode/NewCodeServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/newcode/NewCodeServiceTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/config/BindingConfigurationTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/config/BindingConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationRepositoryTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/config/ConfigurationRepositoryTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/connection/SonarCloudConnectionConfigurationTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/connection/SonarCloudConnectionConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/connection/SonarQubeConnectionConfigurationTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/repository/connection/SonarQubeConnectionConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/rules/RuleDetailsAdapterTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/rules/RuleDetailsAdapterTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/rules/RulesFixtures.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/rules/RulesFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/rules/RulesServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/rules/RulesServiceTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/tracking/LocalOnlyIssueMatchingAttributesMapperTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/tracking/LocalOnlyIssueMatchingAttributesMapperTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/tracking/ServerHotspotMatchingAttributesMapperTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/tracking/ServerHotspotMatchingAttributesMapperTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/tracking/ServerIssueMatchingAttributesMapperTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/tracking/ServerIssueMatchingAttributesMapperTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/parsing/SmartNotificationEventParserTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/parsing/SmartNotificationEventParserTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/testutils/ClientFileSystemFixtures.java
+++ b/backend/core/src/test/java/testutils/ClientFileSystemFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/testutils/LocalOnlyIssueFixtures.java
+++ b/backend/core/src/test/java/testutils/LocalOnlyIssueFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
+++ b/backend/core/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/testutils/TakeThreadDumpAfter.java
+++ b/backend/core/src/test/java/testutils/TakeThreadDumpAfter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/testutils/TestClientInputFile.java
+++ b/backend/core/src/test/java/testutils/TestClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/testutils/TestUtils.java
+++ b/backend/core/src/test/java/testutils/TestUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/core/src/test/java/testutils/ThreadDumpExtension.java
+++ b/backend/core/src/test/java/testutils/ThreadDumpExtension.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/ApacheHttpClientAdapter.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/ApacheHttpClientAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/ApacheHttpResponse.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/ApacheHttpResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpClient.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpClient.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpClientProvider.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpClientProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpConnectionListener.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/HttpConnectionListener.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/RedirectInterceptor.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/RedirectInterceptor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/WebSocketClient.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/WebSocketClient.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/package-info.java
+++ b/backend/http/src/main/java/org/sonarsource/sonarlint/core/http/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/http/src/test/java/org/sonarsource/sonarlint/core/http/HttpClientProviderTests.java
+++ b/backend/http/src/test/java/org/sonarsource/sonarlint/core/http/HttpClientProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - HTTP
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/SonarLintRuntime.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/SonarLintRuntime.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewInputFileEdit.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewInputFileEdit.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewQuickFix.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewQuickFix.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewSonarLintIssue.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewSonarLintIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewTextEdit.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/NewTextEdit.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/package-info.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/ModuleFileEvent.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/ModuleFileEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/ModuleFileListener.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/ModuleFileListener.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/ModuleFileSystem.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/ModuleFileSystem.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/package-info.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/module/file/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/package-info.java
+++ b/backend/plugin-api/src/main/java/org/sonarsource/sonarlint/plugin/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Plugin API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/com/sonarsource/plugins/license/api/LicensedPluginRegistration.java
+++ b/backend/plugin-commons/src/main/java/com/sonarsource/plugins/license/api/LicensedPluginRegistration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/com/sonarsource/plugins/license/api/package-info.java
+++ b/backend/plugin-commons/src/main/java/com/sonarsource/plugins/license/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonar/api/SonarQubeVersion.java
+++ b/backend/plugin-commons/src/main/java/org/sonar/api/SonarQubeVersion.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonar/api/profiles/ProfileDefinition.java
+++ b/backend/plugin-commons/src/main/java/org/sonar/api/profiles/ProfileDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonar/api/profiles/package-info.java
+++ b/backend/plugin-commons/src/main/java/org/sonar/api/profiles/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonar/api/utils/log/Loggers.java
+++ b/backend/plugin-commons/src/main/java/org/sonar/api/utils/log/Loggers.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonar/api/utils/log/package-info.java
+++ b/backend/plugin-commons/src/main/java/org/sonar/api/utils/log/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/ApiVersions.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/ApiVersions.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/DataflowBugDetection.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/DataflowBugDetection.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/ExtensionInstaller.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/ExtensionInstaller.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/ExtensionUtils.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/ExtensionUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/LoadedPlugins.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/LoadedPlugins.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/PluginsLoadResult.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/PluginsLoadResult.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/PluginsLoader.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/PluginsLoader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/api/SkipReason.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/api/SkipReason.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/api/package-info.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/api/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/ClassDerivedBeanDefinition.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/ClassDerivedBeanDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/ComponentKeys.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/ComponentKeys.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/Container.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/Container.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/ExtensionContainer.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/ExtensionContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/LazyUnlessStartableStrategy.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/LazyUnlessStartableStrategy.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/PriorityBeanFactory.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/PriorityBeanFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/SpringComponentContainer.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/SpringComponentContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/SpringInitStrategy.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/SpringInitStrategy.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/StartableBeanPostProcessor.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/StartableBeanPostProcessor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/StartableContainer.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/StartableContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/package-info.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/container/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginClassLoaderDef.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginClassLoaderDef.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginClassloaderFactory.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginClassloaderFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInfo.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInfo.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInstancesLoader.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInstancesLoader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginRequirementsCheckResult.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginRequirementsCheckResult.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/Slf4jBridgeClassLoader.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/Slf4jBridgeClassLoader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginManifest.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginManifest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsChecker.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsChecker.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/package-info.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/package-info.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/PluginContextImpl.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/PluginContextImpl.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/SonarApiLoggerAdapter.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/SonarApiLoggerAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/SonarLintRuntimeImpl.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/SonarLintRuntimeImpl.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/package-info.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/com/sonarsource/plugins/license/api/LicensedPluginRegistrationTests.java
+++ b/backend/plugin-commons/src/test/java/com/sonarsource/plugins/license/api/LicensedPluginRegistrationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/ApiVersionsTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/ApiVersionsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/ExtensionUtilsTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/ExtensionUtilsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/SkipReasonTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/SkipReasonTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/ComponentKeysTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/ComponentKeysTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/LazyUnlessStartableStrategyTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/LazyUnlessStartableStrategyTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/PriorityBeanFactoryTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/PriorityBeanFactoryTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/SpringComponentContainerTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/SpringComponentContainerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/StartableBeanPostProcessorTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/container/StartableBeanPostProcessorTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginClassloaderFactoryTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginClassloaderFactoryTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInfoTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInfoTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInstancesLoaderTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/PluginInstancesLoaderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginManifestTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginManifestTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsCheckerTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsCheckerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/SonarApiLoggerAdapterTest.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/sonarapi/SonarApiLoggerAdapterTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Plugin Commons
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/AbstractRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/AbstractRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/AnalysisRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/AnalysisRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/BackendJsonRpcLauncher.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/BackendJsonRpcLauncher.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/BindingRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/BindingRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/ConfigurationRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/ConfigurationRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/ConnectionRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/ConnectionRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/FileRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/FileRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/HotspotRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/HotspotRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/IssueRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/IssueRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/IssueTrackingRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/IssueTrackingRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/NewCodeRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/NewCodeRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/RpcClientLogOutput.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/RpcClientLogOutput.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/RulesRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/RulesRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SecurityHotspotMatchingRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SecurityHotspotMatchingRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SonarLintRpcClientLogbackAppender.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SonarLintRpcClientLogbackAppender.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SonarLintRpcServerImpl.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SonarLintRpcServerImpl.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SonarProjectBranchRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/SonarProjectBranchRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TaintVulnerabilityTrackingRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TaintVulnerabilityTrackingRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TelemetryRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TelemetryRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/UserTokenRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/UserTokenRpcServiceDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/package-info.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rpc-impl/src/test/java/org/sonarsource/sonarlint/core/rpc/impl/SonarLintRpcServerImplTests.java
+++ b/backend/rpc-impl/src/test/java/org/sonarsource/sonarlint/core/rpc/impl/SonarLintRpcServerImplTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Implementation
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonar/channel/ChannelDispatcher.java
+++ b/backend/rule-extractor/src/main/java/org/sonar/channel/ChannelDispatcher.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/EmptyConfiguration.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/EmptyConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/EmptySettings.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/EmptySettings.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/LegacyHotspotRuleDescriptionSectionsGenerator.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/LegacyHotspotRuleDescriptionSectionsGenerator.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/NoopTempFolder.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/NoopTempFolder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/RuleDefinitionsLoader.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/RuleDefinitionsLoader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/RulesDefinitionExtractor.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/RulesDefinitionExtractor.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/RulesDefinitionExtractorContainer.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/RulesDefinitionExtractorContainer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SecurityStandards.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SecurityStandards.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleDefinition.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleDescriptionSection.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleDescriptionSection.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleParamDefinition.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleParamDefinition.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleParamType.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleParamType.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/package-info.java
+++ b/backend/rule-extractor/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/test/java/mediumtests/RuleExtractorMediumTests.java
+++ b/backend/rule-extractor/src/test/java/mediumtests/RuleExtractorMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/EmptyConfigurationTest.java
+++ b/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/EmptyConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/EmptySettingsTest.java
+++ b/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/EmptySettingsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/LegacyHotspotRuleDescriptionSectionsGeneratorTest.java
+++ b/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/LegacyHotspotRuleDescriptionSectionsGeneratorTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/NoopTempFolderTest.java
+++ b/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/NoopTempFolderTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/SecurityStandardsTest.java
+++ b/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/SecurityStandardsTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleDefinitionTests.java
+++ b/backend/rule-extractor/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/SonarLintRuleDefinitionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/EndpointParams.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/EndpointParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApiHelper.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApiHelper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/UrlUtils.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/UrlUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/authentication/AuthenticationApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/authentication/AuthenticationApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/authentication/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/authentication/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/branches/ProjectBranchesApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/branches/ProjectBranchesApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/branches/ServerBranch.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/branches/ServerBranch.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/branches/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/branches/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/Component.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/Component.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/ComponentApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/ComponentApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/DefaultRemoteProject.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/DefaultRemoteProject.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/ServerProject.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/ServerProject.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/component/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/developers/DevelopersApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/developers/DevelopersApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/developers/Event.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/developers/Event.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/developers/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/developers/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/NotFoundException.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/NotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/ProjectNotFoundException.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/ProjectNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/ServerErrorException.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/ServerErrorException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/UnexpectedBodyException.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/UnexpectedBodyException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/UnsupportedServerException.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/UnsupportedServerException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/exception/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/HotspotApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/HotspotApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/ServerHotspot.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/ServerHotspot.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/ServerHotspotDetails.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/ServerHotspotDetails.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/hotspot/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/newcode/NewCodeApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/newcode/NewCodeApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/newcode/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/newcode/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/organization/OrganizationApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/organization/OrganizationApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/organization/ServerOrganization.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/organization/ServerOrganization.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/organization/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/organization/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/ServerPlugin.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/ServerPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/IssueChangedEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/IssueChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/PushApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/PushApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/RuleSetChangedEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/RuleSetChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SecurityHotspotChangedEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SecurityHotspotChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SecurityHotspotClosedEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SecurityHotspotClosedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SecurityHotspotRaisedEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SecurityHotspotRaisedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/ServerHotspotEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/ServerHotspotEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SonarProjectEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SonarProjectEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SonarServerEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/SonarServerEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/TaintVulnerabilityClosedEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/TaintVulnerabilityClosedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/TaintVulnerabilityRaisedEvent.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/TaintVulnerabilityRaisedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/EventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/EventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/IssueChangedEventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/IssueChangedEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/RuleSetChangedEventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/RuleSetChangedEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotChangedEventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotChangedEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotClosedEventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotClosedEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotRaisedEventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotRaisedEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/TaintVulnerabilityClosedEventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/TaintVulnerabilityClosedEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/TaintVulnerabilityRaisedEventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/TaintVulnerabilityRaisedEventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/common/ImpactPayload.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/common/ImpactPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/common/LocationPayload.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/common/LocationPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/common/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/common/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfile.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfileApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfileApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/ServerActiveRule.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/ServerActiveRule.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/ServerRule.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/ServerRule.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/settings/SettingsApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/settings/SettingsApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/settings/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/settings/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/source/SourceApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/source/SourceApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/source/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/source/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/Event.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/Event.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/EventBuffer.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/EventBuffer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/EventParser.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/EventParser.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/EventStream.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/EventStream.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/stream/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/ServerInfo.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/ServerInfo.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/SystemApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/SystemApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/ValidationResult.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/ValidationResult.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/system/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/usertokens/UserTokensApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/usertokens/UserTokensApi.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/util/ProtobufUtil.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/util/ProtobufUtil.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/util/ServerApiUtils.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/util/ServerApiUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/util/package-info.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/util/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/main/proto/sonarcloud/ws-organizations.proto
+++ b/backend/server-api/src/main/proto/sonarcloud/ws-organizations.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarcloud.ws.organizations;

--- a/backend/server-api/src/main/proto/sonarqube/ws-commons.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-commons.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.commons;

--- a/backend/server-api/src/main/proto/sonarqube/ws-components.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-components.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.component;

--- a/backend/server-api/src/main/proto/sonarqube/ws-hotspots.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-hotspots.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.hotspots;

--- a/backend/server-api/src/main/proto/sonarqube/ws-issues.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-issues.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.issues;

--- a/backend/server-api/src/main/proto/sonarqube/ws-measures.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-measures.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.measures;

--- a/backend/server-api/src/main/proto/sonarqube/ws-projectbranches.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-projectbranches.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.projectbranch;

--- a/backend/server-api/src/main/proto/sonarqube/ws-qualityprofiles.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-qualityprofiles.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.qualityprofiles;

--- a/backend/server-api/src/main/proto/sonarqube/ws-rules.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-rules.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto2";
 
 package sonarqube.ws.rules;

--- a/backend/server-api/src/main/proto/sonarqube/ws-settings.proto
+++ b/backend/server-api/src/main/proto/sonarqube/ws-settings.proto
@@ -1,21 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2023 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto3";
 
 package sonarqube.ws.settings;

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/MockWebServerExtensionWithProtobuf.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/MockWebServerExtensionWithProtobuf.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/authentication/AuthenticationApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/authentication/AuthenticationApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/branches/ProjectBranchesApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/branches/ProjectBranchesApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/branches/ServerBranchTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/branches/ServerBranchTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/component/ComponentApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/component/ComponentApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/component/DefaultRemoteProjectTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/component/DefaultRemoteProjectTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/developers/DevelopersApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/developers/DevelopersApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/exception/ProjectNotFoundExceptionTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/exception/ProjectNotFoundExceptionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/hotspot/HotspotApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/hotspot/HotspotApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/hotspot/ServerHotspotDetailsTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/hotspot/ServerHotspotDetailsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/newcode/NewCodeApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/newcode/NewCodeApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/organization/OrganizationApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/organization/OrganizationApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/organization/ServerOrganizationTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/organization/ServerOrganizationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/PushApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/PushApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotChangedEventParserTest.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotChangedEventParserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotClosedEventParserTest.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotClosedEventParserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotRaisedEventParserTest.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/parsing/SecurityHotspotRaisedEventParserTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfileApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfileApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/settings/SettingsApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/settings/SettingsApiTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/stream/EventStreamTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/stream/EventStreamTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/util/ProtobufUtilTest.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/util/ProtobufUtilTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server API
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfiguration.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerSettingsUpdateSummary.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerSettingsUpdateSummary.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ComponentsStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ComponentsStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ConnectionStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ConnectionStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/DownloadException.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/DownloadException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/FileUtils.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/FileUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/HotspotDownloader.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/HotspotDownloader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloader.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueStorePaths.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueStorePaths.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueStoreReader.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueStoreReader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/LocalStorageSynchronizer.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/LocalStorageSynchronizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/PluginsSynchronizer.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/PluginsSynchronizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBinding.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBranches.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBranches.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBranchesStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBranchesStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/RuleSet.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/RuleSet.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerConnection.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerConnection.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerHotspotUpdater.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerHotspotUpdater.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerInfoSynchronizer.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerInfoSynchronizer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerIssueUpdater.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerIssueUpdater.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerPathProvider.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerPathProvider.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerUpdaterUtils.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerUpdaterUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerVersionAndStatusChecker.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/ServerVersionAndStatusChecker.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/Settings.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/Settings.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/SonarProjectStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/SonarProjectStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/SonarServerSettingsChangedEvent.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/SonarServerSettingsChangedEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StorageFacade.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StorageFacade.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StorageFacadeCache.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StorageFacadeCache.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StoredPlugin.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StoredPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StoredServerInfo.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/StoredServerInfo.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/SynchronizationResult.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/SynchronizationResult.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloader.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtils.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/FileLevelServerIssue.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/FileLevelServerIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/LineLevelServerIssue.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/LineLevelServerIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/RangeLevelServerIssue.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/RangeLevelServerIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerFinding.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerFinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerIssue.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerTaintIssue.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerTaintIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/package-info.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/issues/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/package-info.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/prefix/FileTreeMatcher.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/prefix/FileTreeMatcher.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/prefix/ReversePathTree.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/prefix/ReversePathTree.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/prefix/package-info.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/prefix/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/HotspotReviewStatusBinding.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/HotspotReviewStatusBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/InstantBinding.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/InstantBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/IssueSeverityBinding.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/IssueSeverityBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/IssueTypeBinding.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/IssueTypeBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/NewCodeDefinitionStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/NewCodeDefinitionStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/PluginsStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/PluginsStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProjectServerIssueStore.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProjectServerIssueStore.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProjectStoragePaths.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProjectStoragePaths.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProtobufFileUtil.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProtobufFileUtil.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/RWLock.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/RWLock.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerInfoStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerInfoStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerIssueStoresManager.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerIssueStoresManager.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/SmartNotificationsStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/SmartNotificationsStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/StorageException.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/StorageException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/StorageUtils.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/StorageUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/TarGzUtils.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/TarGzUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/UpdateSummary.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/UpdateSummary.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/UuidBinding.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/UuidBinding.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/XodusServerIssueStore.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/XodusServerIssueStore.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/package-info.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/main/proto/sonarlint.proto
+++ b/backend/server-connection/src/main/proto/sonarlint.proto
@@ -1,22 +1,22 @@
-// SonarLint, open source software quality management tool.
-// Copyright (C) 2015-2017 SonarSource
-// mailto:contact AT sonarsource DOT com
-//
-// SonarLint is free software; you can redistribute it and/or
-// modify it under the terms of the GNU Lesser General Public
-// License as published by the Free Software Foundation; either
-// version 3 of the License, or (at your option) any later version.
-//
-// SonarLint is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with this program; if not, write to the Free Software Foundation,
-// Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
-
-
+/*
+ * SonarLint Core - Server Connection
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 syntax = "proto3";
 
 package sonarlint;

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/DownloadExceptionTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/DownloadExceptionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/FileUtilsTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/FileUtilsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/HotspotDownloaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/HotspotDownloaderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloaderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueStorePathsTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueStorePathsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueStoreReaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueStoreReaderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/PluginsSynchronizerTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/PluginsSynchronizerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBindingTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ProjectBindingTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ProjectStoragePathsTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ProjectStoragePathsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerHotspotUpdaterTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerHotspotUpdaterTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerInfoSynchronizerTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerInfoSynchronizerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerIssueUpdaterTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerIssueUpdaterTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerPathProviderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerPathProviderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerVersionAndStatusCheckerTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/ServerVersionAndStatusCheckerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/StorageExceptionTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/StorageExceptionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloaderTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtilsTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtilsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerIssueTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerIssueTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerTaintIssueTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/issues/ServerTaintIssueTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/prefix/FileTreeMatcherTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/prefix/FileTreeMatcherTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/prefix/ReversePathTreeTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/prefix/ReversePathTreeTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/NewCodeDefinitionStorageTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/NewCodeDefinitionStorageTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProtobufFileUtilTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProtobufFileUtilTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerHotspotFixtures.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerHotspotFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerIssueFixtures.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/ServerIssueFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/XodusServerIssueStoreMigrationTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/XodusServerIssueStoreMigrationTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/XodusServerIssueStoreTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/XodusServerIssueStoreTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/testutils/InMemoryIssueStore.java
+++ b/backend/server-connection/src/test/java/testutils/InMemoryIssueStore.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/server-connection/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
+++ b/backend/server-connection/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Server Connection
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/slf4j-sonar-log/src/main/java/org/slf4j/Logger.java
+++ b/backend/slf4j-sonar-log/src/main/java/org/slf4j/Logger.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - SLF4J log adaptor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/slf4j-sonar-log/src/main/java/org/slf4j/LoggerAdapter.java
+++ b/backend/slf4j-sonar-log/src/main/java/org/slf4j/LoggerAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - SLF4J log adaptor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/slf4j-sonar-log/src/main/java/org/slf4j/LoggerFactory.java
+++ b/backend/slf4j-sonar-log/src/main/java/org/slf4j/LoggerFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - SLF4J log adaptor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/slf4j-sonar-log/src/main/java/org/slf4j/MDC.java
+++ b/backend/slf4j-sonar-log/src/main/java/org/slf4j/MDC.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - SLF4J log adaptor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/slf4j-sonar-log/src/main/java/org/slf4j/Marker.java
+++ b/backend/slf4j-sonar-log/src/main/java/org/slf4j/Marker.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - SLF4J log adaptor
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/InternalDebug.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/InternalDebug.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/LocalDateAdapter.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/LocalDateAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/LocalDateTimeAdapter.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/LocalDateTimeAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/OffsetDateTimeAdapter.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/OffsetDateTimeAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryAnalyzerPerformance.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryAnalyzerPerformance.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHelpAndFeedbackCounter.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHelpAndFeedbackCounter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClient.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClient.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLiveAttributes.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLiveAttributes.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManager.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManager.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryNotificationsCounter.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryNotificationsCounter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryServerConstantAttributes.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryServerConstantAttributes.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryServerLiveAttributes.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryServerLiveAttributes.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtils.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/package-info.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/HotspotPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/HotspotPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/IssuePayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/IssuePayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/ShowHotspotPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/ShowHotspotPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/ShowIssuePayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/ShowIssuePayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TaintVulnerabilitiesPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TaintVulnerabilitiesPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryAnalyzerPerformancePayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryAnalyzerPerformancePayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryHelpAndFeedbackPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryHelpAndFeedbackPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryNotificationsCounterPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryNotificationsCounterPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryNotificationsPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryNotificationsPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryRulesPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryRulesPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/cayc/CleanAsYouCodePayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/cayc/CleanAsYouCodePayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/cayc/NewCodeFocusPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/cayc/NewCodeFocusPayload.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/cayc/package-info.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/cayc/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/package-info.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtilsTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtilsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayloadTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayloadTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Telemetry
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/AnalysisConfiguration.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/AnalysisConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/EngineConfiguration.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/EngineConfiguration.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/Issue.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/Issue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/MessageException.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/MessageException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/PluginDetails.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/PluginDetails.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/RawIssue.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/RawIssue.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/RawIssueListener.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/RawIssueListener.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/SonarLintAnalysisEngine.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/SonarLintAnalysisEngine.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/SonarLintWrappedException.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/SonarLintWrappedException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/package-info.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/analysis/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/HashingPathMapper.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/HashingPathMapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/ObjectStore.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/ObjectStore.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/PathMapper.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/PathMapper.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/Reader.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/Reader.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/SimpleObjectStore.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/SimpleObjectStore.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/Writer.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/Writer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/package-info.java
+++ b/client/java-client-legacy/src/main/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/AnalysisConfigurationTest.java
+++ b/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/AnalysisConfigurationTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/PluginDetailsTests.java
+++ b/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/PluginDetailsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/RawIssueTests.java
+++ b/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/RawIssueTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/SonarLintWrappedExceptionTests.java
+++ b/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/analysis/SonarLintWrappedExceptionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/HashingPathMapperTests.java
+++ b/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/objectstore/HashingPathMapperTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/testutils/OnDiskTestClientInputFile.java
+++ b/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/testutils/OnDiskTestClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/testutils/TestUtils.java
+++ b/client/java-client-legacy/src/test/java/org/sonarsource/sonarlint/core/client/legacy/testutils/TestUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Legacy
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttribute.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttribute.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttributeCategory.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttributeCategory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/ClientFileExclusions.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/ClientFileExclusions.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/ClientLogOutput.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/ClientLogOutput.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/GitUtils.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/GitUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/HotspotStatus.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/HotspotStatus.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/ImpactSeverity.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/ImpactSeverity.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/IssueResolutionStatus.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/IssueResolutionStatus.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/Language.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/Language.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/SoftwareQuality.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/SoftwareQuality.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/package-info.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttributeCategoryTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttributeCategoryTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttributeTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/CleanCodeAttributeTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/ClientFileExclusionsTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/ClientFileExclusionsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/DateUtilsTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/DateUtilsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/GitUtilsTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/GitUtilsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/HotspotStatusTest.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/HotspotStatusTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/ImpactSeverityTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/ImpactSeverityTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/IssueResolutionStatusTest.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/IssueResolutionStatusTest.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/LanguageTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/LanguageTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/SoftwareQualityTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/SoftwareQualityTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Java Client Utils
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/ClientJsonRpcLauncher.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/ClientJsonRpcLauncher.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Java Client
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/ConfigScopeNotFoundException.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/ConfigScopeNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Java Client
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/ConnectionNotFoundException.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/ConnectionNotFoundException.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Java Client
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SloopLauncher.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SloopLauncher.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Java Client
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Java Client
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Java Client
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/client/rpc-java-client/src/test/java/org/sonarsource/sonarlint/core/rpc/client/SloopLauncherTests.java
+++ b/client/rpc-java-client/src/test/java/org/sonarsource/sonarlint/core/rpc/client/SloopLauncherTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Java Client
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
+++ b/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/ExamplePlugin.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/FooLintRulesDefinition.java
+++ b/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/FooLintRulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/OneIssuePerLineSensor.java
+++ b/its/plugins/custom-sensor-plugin/src/main/java/org/sonarsource/plugins/example/OneIssuePerLineSensor.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin for SonarQube
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalExtension.java
+++ b/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalExtension.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin with global extension
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalExtensionPlugin.java
+++ b/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalExtensionPlugin.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin with global extension
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalLanguage.java
+++ b/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalLanguage.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin with global extension
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalRulesDefinition.java
+++ b/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalRulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin with global extension
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalSensor.java
+++ b/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalSensor.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin with global extension
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalSonarWayProfile.java
+++ b/its/plugins/global-extension-plugin/src/main/java/org/sonarsource/plugins/example/GlobalSonarWayProfile.java
@@ -1,6 +1,6 @@
 /*
  * Example Plugin with global extension
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaFileCheckRegistrar.java
+++ b/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaFileCheckRegistrar.java
@@ -1,6 +1,6 @@
 /*
  * Java Custom Rules Plugin
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaRulesDefinition.java
+++ b/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaRulesDefinition.java
@@ -1,6 +1,6 @@
 /*
  * Java Custom Rules Plugin
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaRulesPlugin.java
+++ b/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaRulesPlugin.java
@@ -1,6 +1,6 @@
 /*
  * Java Custom Rules Plugin
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/RulesList.java
+++ b/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/RulesList.java
@@ -1,6 +1,6 @@
 /*
  * Java Custom Rules Plugin
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/checks/AvoidAnnotationRule.java
+++ b/its/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/checks/AvoidAnnotationRule.java
@@ -1,6 +1,6 @@
 /*
  * Java Custom Rules Plugin
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/AbstractConnectedTests.java
+++ b/its/tests/src/test/java/its/AbstractConnectedTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/FileExclusionTests.java
+++ b/its/tests/src/test/java/its/FileExclusionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/MockSonarLintRpcClientDelegate.java
+++ b/its/tests/src/test/java/its/MockSonarLintRpcClientDelegate.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/SloopLauncherTests.java
+++ b/its/tests/src/test/java/its/SloopLauncherTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/SloopLauncherWithJreTests.java
+++ b/its/tests/src/test/java/its/SloopLauncherWithJreTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/SonarCloudTests.java
+++ b/its/tests/src/test/java/its/SonarCloudTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/SonarQubeCommunityEditionTests.java
+++ b/its/tests/src/test/java/its/SonarQubeCommunityEditionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
+++ b/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/SonarQubeEnterpriseEditionTests.java
+++ b/its/tests/src/test/java/its/SonarQubeEnterpriseEditionTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/StandaloneTests.java
+++ b/its/tests/src/test/java/its/StandaloneTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/ConsoleConsumer.java
+++ b/its/tests/src/test/java/its/utils/ConsoleConsumer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/ConsoleLogOutput.java
+++ b/its/tests/src/test/java/its/utils/ConsoleLogOutput.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/InputFileFinder.java
+++ b/its/tests/src/test/java/its/utils/InputFileFinder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/ItUtils.java
+++ b/its/tests/src/test/java/its/utils/ItUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/JreLocator.java
+++ b/its/tests/src/test/java/its/utils/JreLocator.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/LogOnTestFailure.java
+++ b/its/tests/src/test/java/its/utils/LogOnTestFailure.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/OrchestratorUtils.java
+++ b/its/tests/src/test/java/its/utils/OrchestratorUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/PluginLocator.java
+++ b/its/tests/src/test/java/its/utils/PluginLocator.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/SloopDistLocator.java
+++ b/its/tests/src/test/java/its/utils/SloopDistLocator.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/TestClientInputFile.java
+++ b/its/tests/src/test/java/its/utils/TestClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/its/tests/src/test/java/its/utils/UnArchiveUtils.java
+++ b/its/tests/src/test/java/its/utils/UnArchiveUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - ITs - Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/BindingSuggestionsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/BindingSuggestionsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/ConnectedFileExclusionsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectedFileExclusionsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/ConnectedHotspotMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectedHotspotMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/ConnectedIssueExclusionsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectedIssueExclusionsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/ConnectedIssueMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectedIssueMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/ConnectedStorageProblemsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectedStorageProblemsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/ConnectionSetupMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectionSetupMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/EffectiveRulesMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/EffectiveRulesMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/EmbeddedServerMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/EmbeddedServerMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/InitializationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/InitializationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/LogMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/LogMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/NotebookLanguageMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/NotebookLanguageMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/StandaloneIssueMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/StandaloneIssueMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/StandaloneNoPluginMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/StandaloneNoPluginMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/StandaloneRulesMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/StandaloneRulesMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/UserTokenMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/UserTokenMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/analysis/ConnectedCustomSecretsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/ConnectedCustomSecretsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/analysis/NodeJsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/NodeJsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/analysis/RulesInConnectedModeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/RulesInConnectedModeMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/analysis/SupportedFilePatternsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/SupportedFilePatternsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/branch/SonarProjectBranchMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/branch/SonarProjectBranchMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionGetAllProjectsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionGetAllProjectsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionValidatorMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionValidatorMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/connection/OrganizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/OrganizationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/ClientFileSystemFixtures.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/ClientFileSystemFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/LocalOnlyIssueFixtures.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/LocalOnlyIssueFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/ServerFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/ServerFixture.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/SonarLintTestRpcServer.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/SonarLintTestRpcServer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/TestPlugin.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/TestPlugin.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/storage/ConfigurationScopeStorageFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/storage/ConfigurationScopeStorageFixture.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/storage/ProjectStorageFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/storage/ProjectStorageFixture.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/storage/ServerIssueFixtures.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/storage/ServerIssueFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/storage/ServerSecurityHotspotFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/storage/ServerSecurityHotspotFixture.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/storage/ServerTaintIssueFixtures.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/storage/ServerTaintIssueFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/fixtures/storage/StorageFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/storage/StorageFixture.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotCheckStatusChangePermittedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotCheckStatusChangePermittedMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotEventsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotLocalDetectionSupportMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotLocalDetectionSupportMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotStatusChangeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotStatusChangeMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/hotspots/MatchWithServerHotspotsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/MatchWithServerHotspotsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/hotspots/OpenHotspotInBrowserMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/OpenHotspotInBrowserMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/hotspots/OpenHotspotInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/OpenHotspotInIdeMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/http/AuthenticationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/AuthenticationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/http/ProxyMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/ProxyMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/http/SslMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/SslMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/http/TimeoutMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/TimeoutMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/issues/IssueEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/IssueEventsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/issues/IssuesStatusChangeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/IssuesStatusChangeMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/issues/LocalOnlyResolvedIssuesStorageMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/LocalOnlyResolvedIssuesStorageMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/issues/TrackWithServerIssuesMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/TrackWithServerIssuesMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/newcode/NewCodeTelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/newcode/NewCodeTelemetryMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/rules/RuleEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/rules/RuleEventsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/smartnotifications/LastEventPollingTests.java
+++ b/medium-tests/src/test/java/mediumtest/smartnotifications/LastEventPollingTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/synchronization/BranchSpecificSynchronizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/BranchSpecificSynchronizationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/synchronization/ConnectionSyncMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/ConnectionSyncMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/synchronization/PluginSynchronizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/PluginSynchronizationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/synchronization/RuleSetSynchronizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/RuleSetSynchronizationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/synchronization/ServerInfoSynchronizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/ServerInfoSynchronizationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/synchronization/TaintVulnerabilitySynchronizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/TaintVulnerabilitySynchronizationMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilitiesMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilitiesMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilityEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilityEventsMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/ConsoleConsumer.java
+++ b/medium-tests/src/test/java/testutils/ConsoleConsumer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/JuliSLF4JDelegatingLog.java
+++ b/medium-tests/src/test/java/testutils/JuliSLF4JDelegatingLog.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/LocalOnlyIssueFixtures.java
+++ b/medium-tests/src/test/java/testutils/LocalOnlyIssueFixtures.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
+++ b/medium-tests/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/OnDiskTestClientInputFile.java
+++ b/medium-tests/src/test/java/testutils/OnDiskTestClientInputFile.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/PluginLocator.java
+++ b/medium-tests/src/test/java/testutils/PluginLocator.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/TestUtils.java
+++ b/medium-tests/src/test/java/testutils/TestUtils.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/ThreadLeakDetector.java
+++ b/medium-tests/src/test/java/testutils/ThreadLeakDetector.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/websockets/ContextListener.java
+++ b/medium-tests/src/test/java/testutils/websockets/ContextListener.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/websockets/RequestListener.java
+++ b/medium-tests/src/test/java/testutils/websockets/RequestListener.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/websockets/ServletAwareConfig.java
+++ b/medium-tests/src/test/java/testutils/websockets/ServletAwareConfig.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/websockets/WebSocketConnection.java
+++ b/medium-tests/src/test/java/testutils/websockets/WebSocketConnection.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/websockets/WebSocketConnectionRepository.java
+++ b/medium-tests/src/test/java/testutils/websockets/WebSocketConnectionRepository.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/websockets/WebSocketEndpoint.java
+++ b/medium-tests/src/test/java/testutils/websockets/WebSocketEndpoint.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/medium-tests/src/test/java/testutils/websockets/WebSocketServer.java
+++ b/medium-tests/src/test/java/testutils/websockets/WebSocketServer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Medium Tests
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.sonarsource.parent</groupId>
     <artifactId>parent</artifactId>
-    <version>70.0.0.270</version>
+    <version>71.0.0.1292</version>
     <relativePath/>
   </parent>
   <groupId>org.sonarsource.sonarlint.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,20 @@
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <includes combine.children="append">
+            <include>src/*/proto/**/*.proto</include>
+          </includes>
+          <mapping combine.children="append">
+            <proto>SLASHSTAR_STYLE</proto>
+          </mapping>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SingleThreadedMessageConsumer.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SingleThreadedMessageConsumer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintLauncherBuilder.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintLauncherBuilder.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcErrorCode.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcErrorCode.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcServer.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcServer.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/CustomEitherAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/CustomEitherAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherCredentialsAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherCredentialsAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherProgressNotificationAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherProgressNotificationAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherRuleDescriptionAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherRuleDescriptionAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherRuleDescriptionTabContentAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherRuleDescriptionTabContentAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherServerOrLocalHotspotAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherServerOrLocalHotspotAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherServerOrLocalIssueAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherServerOrLocalIssueAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherTransientConnectionAdapterFactory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/EitherTransientConnectionAdapterFactory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/InstantTypeAdapter.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/InstantTypeAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/PathTypeAdapter.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/PathTypeAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/UuidTypeAdapter.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/UuidTypeAdapter.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/adapter/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/ActiveRuleDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/ActiveRuleDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/AnalysisRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/AnalysisRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/DidChangeClientNodeJsPathParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/DidChangeClientNodeJsPathParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetAnalysisConfigParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetAnalysisConfigParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetAnalysisConfigResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetAnalysisConfigResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetGlobalConfigurationResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetGlobalConfigurationResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetGlobalConnectedConfigurationParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetGlobalConnectedConfigurationParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetRuleDetailsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetRuleDetailsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetRuleDetailsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetRuleDetailsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetSupportedFilePatternsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetSupportedFilePatternsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetSupportedFilePatternsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/GetSupportedFilePatternsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/analysis/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/binding/BindingRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/binding/BindingRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/binding/GetBindingSuggestionParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/binding/GetBindingSuggestionParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/binding/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/binding/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/DidChangeActiveSonarProjectBranchParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/DidChangeActiveSonarProjectBranchParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/DidVcsRepositoryChangeParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/DidVcsRepositoryChangeParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/GetMatchedSonarProjectBranchParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/GetMatchedSonarProjectBranchParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/GetMatchedSonarProjectBranchResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/GetMatchedSonarProjectBranchResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/SonarProjectBranchRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/SonarProjectBranchRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/branch/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/ConfigurationRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/ConfigurationRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/BindingConfigurationDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/BindingConfigurationDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/BindingSuggestionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/BindingSuggestionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/DidUpdateBindingParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/DidUpdateBindingParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/binding/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/ConfigurationScopeDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/ConfigurationScopeDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/DidAddConfigurationScopesParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/DidAddConfigurationScopesParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/DidRemoveConfigurationScopeParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/DidRemoveConfigurationScopeParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/config/scope/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/ConnectionRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/ConnectionRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/auth/HelpGenerateUserTokenParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/auth/HelpGenerateUserTokenParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/auth/HelpGenerateUserTokenResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/auth/HelpGenerateUserTokenResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/check/CheckSmartNotificationsSupportedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/check/CheckSmartNotificationsSupportedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/check/CheckSmartNotificationsSupportedResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/check/CheckSmartNotificationsSupportedResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/common/TransientSonarCloudConnectionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/common/TransientSonarCloudConnectionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/common/TransientSonarQubeConnectionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/common/TransientSonarQubeConnectionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/DidChangeCredentialsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/DidChangeCredentialsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/DidUpdateConnectionsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/DidUpdateConnectionsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/SonarCloudConnectionConfigurationDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/SonarCloudConnectionConfigurationDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/SonarQubeConnectionConfigurationDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/SonarQubeConnectionConfigurationDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/config/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/FuzzySearchUserOrganizationsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/FuzzySearchUserOrganizationsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/FuzzySearchUserOrganizationsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/FuzzySearchUserOrganizationsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/GetOrganizationParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/GetOrganizationParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/GetOrganizationResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/GetOrganizationResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/ListUserOrganizationsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/ListUserOrganizationsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/ListUserOrganizationsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/ListUserOrganizationsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/OrganizationDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/OrganizationDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/org/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/FuzzySearchProjectsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/FuzzySearchProjectsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/FuzzySearchProjectsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/FuzzySearchProjectsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/GetAllProjectsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/GetAllProjectsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/GetAllProjectsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/GetAllProjectsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/SonarProjectDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/SonarProjectDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/projects/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/validate/ValidateConnectionParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/validate/ValidateConnectionParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/validate/ValidateConnectionResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/connection/validate/ValidateConnectionResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/DidUpdateFileSystemParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/DidUpdateFileSystemParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/FileRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/FileRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/FileStatusDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/FileStatusDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/GetFilesStatusParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/GetFilesStatusParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/GetFilesStatusResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/GetFilesStatusResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/file/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/ChangeHotspotStatusParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/ChangeHotspotStatusParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckLocalDetectionSupportedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckLocalDetectionSupportedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckLocalDetectionSupportedResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckLocalDetectionSupportedResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckStatusChangePermittedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckStatusChangePermittedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckStatusChangePermittedResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/CheckStatusChangePermittedResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/HotspotRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/HotspotRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/HotspotStatus.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/HotspotStatus.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/OpenHotspotInBrowserParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/OpenHotspotInBrowserParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/hotspot/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/ClientConstantInfoDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/ClientConstantInfoDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/FeatureFlagsDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/FeatureFlagsDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/InitializeParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/InitializeParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/TelemetryClientConstantAttributesDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/TelemetryClientConstantAttributesDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/AddIssueCommentParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/AddIssueCommentParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ChangeIssueStatusParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ChangeIssueStatusParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckAnticipatedStatusChangeSupportedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckAnticipatedStatusChangeSupportedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckAnticipatedStatusChangeSupportedResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckAnticipatedStatusChangeSupportedResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckStatusChangePermittedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckStatusChangePermittedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckStatusChangePermittedResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/CheckStatusChangePermittedResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/IssueRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/IssueRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenAllIssuesForFileParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenAllIssuesForFileParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenAllIssuesForFileResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenAllIssuesForFileResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenIssueParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenIssueParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenIssueResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ReopenIssueResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ResolutionStatus.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/ResolutionStatus.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/GetNewCodeDefinitionParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/GetNewCodeDefinitionParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/GetNewCodeDefinitionResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/GetNewCodeDefinitionResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/NewCodeRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/NewCodeRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/newcode/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/AbstractRuleDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/AbstractRuleDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/EffectiveRuleDetailsDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/EffectiveRuleDetailsDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/EffectiveRuleParamDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/EffectiveRuleParamDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetEffectiveRuleDetailsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetEffectiveRuleDetailsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetEffectiveRuleDetailsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetEffectiveRuleDetailsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetStandaloneRuleDescriptionParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetStandaloneRuleDescriptionParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetStandaloneRuleDescriptionResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/GetStandaloneRuleDescriptionResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/ImpactDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/ImpactDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/ListAllStandaloneRulesDefinitionsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/ListAllStandaloneRulesDefinitionsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleContextualSectionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleContextualSectionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleContextualSectionWithDefaultContextKeyDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleContextualSectionWithDefaultContextKeyDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleDefinitionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleDefinitionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleDescriptionTabDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleDescriptionTabDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleMonolithicDescriptionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleMonolithicDescriptionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleNonContextualSectionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleNonContextualSectionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleParamDefinitionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleParamDefinitionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleParamType.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleParamType.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleSplitDescriptionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RuleSplitDescriptionDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RulesRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/RulesRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/StandaloneRuleConfigDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/StandaloneRuleConfigDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/UpdateStandaloneRulesConfigurationParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/UpdateStandaloneRulesConfigurationParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/VulnerabilityProbability.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/VulnerabilityProbability.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/rules/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/GetStatusResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/GetStatusResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/TelemetryRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/TelemetryRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ClientTrackedFindingDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ClientTrackedFindingDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/IssueTrackingRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/IssueTrackingRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/LineWithHashDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/LineWithHashDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ListAllParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ListAllParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ListAllResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ListAllResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/LocalOnlyIssueDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/LocalOnlyIssueDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/LocalOnlySecurityHotspotDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/LocalOnlySecurityHotspotDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/MatchWithServerSecurityHotspotsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/MatchWithServerSecurityHotspotsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/MatchWithServerSecurityHotspotsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/MatchWithServerSecurityHotspotsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/SecurityHotspotMatchingRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/SecurityHotspotMatchingRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ServerMatchedIssueDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ServerMatchedIssueDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ServerMatchedSecurityHotspotDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/ServerMatchedSecurityHotspotDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TaintVulnerabilityDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TaintVulnerabilityDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TaintVulnerabilityTrackingRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TaintVulnerabilityTrackingRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TextRangeWithHashDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TextRangeWithHashDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TrackWithServerIssuesParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TrackWithServerIssuesParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TrackWithServerIssuesResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/TrackWithServerIssuesResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/tracking/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/usertoken/RevokeTokenParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/usertoken/RevokeTokenParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/usertoken/UserTokenRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/usertoken/UserTokenRpcService.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/OpenUrlInBrowserParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/OpenUrlInBrowserParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/analysis/DidChangeNodeJsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/analysis/DidChangeNodeJsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/analysis/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/analysis/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/AssistBindingParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/AssistBindingParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/AssistBindingResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/AssistBindingResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/GetBindingSuggestionsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/GetBindingSuggestionsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/NoBindingSuggestionFoundParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/NoBindingSuggestionFoundParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/SuggestBindingParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/SuggestBindingParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/binding/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/DidChangeMatchedSonarProjectBranchParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/DidChangeMatchedSonarProjectBranchParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/MatchSonarProjectBranchParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/MatchSonarProjectBranchParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/MatchSonarProjectBranchResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/MatchSonarProjectBranchResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/branch/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/AssistCreatingConnectionParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/AssistCreatingConnectionParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/AssistCreatingConnectionResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/AssistCreatingConnectionResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/GetCredentialsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/GetCredentialsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/GetCredentialsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/GetCredentialsResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/connection/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/event/DidReceiveServerHotspotEvent.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/event/DidReceiveServerHotspotEvent.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/event/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/event/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/fs/ListFilesParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/fs/ListFilesParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/fs/ListFilesResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/fs/ListFilesResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/hotspot/HotspotDetailsDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/hotspot/HotspotDetailsDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/hotspot/ShowHotspotParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/hotspot/ShowHotspotParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/hotspot/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/hotspot/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/CheckServerTrustedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/CheckServerTrustedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/CheckServerTrustedResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/CheckServerTrustedResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/GetProxyPasswordAuthenticationParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/GetProxyPasswordAuthenticationParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/GetProxyPasswordAuthenticationResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/GetProxyPasswordAuthenticationResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/ProxyDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/ProxyDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/SelectProxiesParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/SelectProxiesParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/SelectProxiesResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/SelectProxiesResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/X509CertificateDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/X509CertificateDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/http/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/info/GetClientLiveInfoResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/info/GetClientLiveInfoResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/info/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/info/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/issue/IssueDetailsDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/issue/IssueDetailsDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/issue/ShowIssueParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/issue/ShowIssueParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/issue/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/issue/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/log/LogLevel.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/log/LogLevel.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/log/LogParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/log/LogParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/log/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/log/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/MessageType.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/MessageType.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/ShowMessageParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/ShowMessageParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/ShowSoonUnsupportedMessageParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/ShowSoonUnsupportedMessageParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/message/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/plugin/DidUpdatePluginsParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/plugin/DidUpdatePluginsParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/ProgressEndNotification.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/ProgressEndNotification.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/ProgressUpdateNotification.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/ProgressUpdateNotification.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/ReportProgressParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/ReportProgressParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/StartProgressParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/StartProgressParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/progress/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/smartnotification/ShowSmartNotificationParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/smartnotification/ShowSmartNotificationParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/sync/DidSynchronizeConfigurationScopeParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/sync/DidSynchronizeConfigurationScopeParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/sync/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/sync/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/taint/vulnerability/DidChangeTaintVulnerabilitiesParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/taint/vulnerability/DidChangeTaintVulnerabilitiesParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AddQuickFixAppliedForRuleParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AddQuickFixAppliedForRuleParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AddReportedRulesParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AddReportedRulesParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AnalysisDoneOnSingleLanguageParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AnalysisDoneOnSingleLanguageParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/DevNotificationsClickedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/DevNotificationsClickedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/HelpAndFeedbackClickedParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/HelpAndFeedbackClickedParams.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/TelemetryClientLiveAttributesResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/TelemetryClientLiveAttributesResponse.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/CleanCodeAttribute.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/CleanCodeAttribute.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/CleanCodeAttributeCategory.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/CleanCodeAttributeCategory.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/ClientFileDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/ClientFileDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/FlowDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/FlowDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/ImpactSeverity.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/ImpactSeverity.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/IssueSeverity.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/IssueSeverity.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/Language.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/Language.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/LocationDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/LocationDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/RuleType.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/RuleType.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/SoftwareQuality.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/SoftwareQuality.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/TextRangeDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/TextRangeDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/TokenDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/TokenDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/UsernamePasswordDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/UsernamePasswordDto.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/package-info.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/package-info.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/InitializeParamsTests.java
+++ b/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/InitializeParamsTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/TelemetryClientConstantAttributesDtoTests.java
+++ b/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/TelemetryClientConstantAttributesDtoTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/common/TokenDtoTests.java
+++ b/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/common/TokenDtoTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/common/UsernamePasswordDtoTests.java
+++ b/rpc-protocol/src/test/java/org/sonarsource/sonarlint/core/rpc/protocol/common/UsernamePasswordDtoTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - RPC Protocol
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rule-extractor-cli/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/cli/RuleExtractorCli.java
+++ b/rule-extractor-cli/src/main/java/org/sonarsource/sonarlint/core/rule/extractor/cli/RuleExtractorCli.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor - CLI
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rule-extractor-cli/src/test/java/mediumtests/RuleExtractorCliMediumTests.java
+++ b/rule-extractor-cli/src/test/java/mediumtests/RuleExtractorCliMediumTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor - CLI
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or

--- a/rule-extractor-cli/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/cli/RuleExtractorCliTests.java
+++ b/rule-extractor-cli/src/test/java/org/sonarsource/sonarlint/core/rule/extractor/cli/RuleExtractorCliTests.java
@@ -1,6 +1,6 @@
 /*
  * SonarLint Core - Rule Extractor - CLI
- * Copyright (C) 2016-2023 SonarSource SA
+ * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
  * This program is free software; you can redistribute it and/or


### PR DESCRIPTION
The update of license headers have been lost in one of the rebase of the sloop branch. I took the opportunity to fix some other headers.