### PR TITLE
Build with Java 17 (but keep targeting 11)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,7 +62,7 @@ build_task:
   # Build and Stage to repox
   <<: *ONLY_IF
   env:
-    JDK_VERSION: "11"
+    JDK_VERSION: "17"
     DEPLOY_PULL_REQUEST: "true"
     ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
     ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
   </modules>
 
   <properties>
+    <maven.compiler.release>11</maven.compiler.release>
     <sonar-plugin-api.version>10.1.0.809</sonar-plugin-api.version>
     <sonar-markdown.version>9.4.0.54424</sonar-markdown.version>
     <sonar-scanner-protocol.version>7.9</sonar-scanner-protocol.version>


### PR DESCRIPTION
This fixes a problem running the Sonar analysis that now requires Java 17