### PR TITLE
Avoid sending multiple binding suggestions

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingSuggestionProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingSuggestionProvider.java
@@ -94,12 +94,6 @@ public class BindingSuggestionProvider {
     }
   }
 
-  @EventListener
-  public void configurationScopesAdded(ConfigurationScopesAddedEvent event) {
-    var configScopeIds = event.getAddedConfigurationScopeIds();
-    suggestBindingForGivenScopesAndAllConnections(configScopeIds);
-  }
-
   public void suggestBindingForGivenScopesAndAllConnections(Set<String> configScopeIdsToSuggest) {
     if (!configScopeIdsToSuggest.isEmpty()) {
       var allConnectionIds = connectionRepository.getConnectionsById().keySet();
@@ -122,15 +116,6 @@ public class BindingSuggestionProvider {
       var candidateConnectionIds = Set.of(addedConnectionId);
       queueBindingSuggestionComputation(allConfigScopeIds, candidateConnectionIds);
     }
-  }
-
-  @EventListener
-  public void filesystemUpdated(FileSystemUpdatedEvent event) {
-    var configScopeWithAddedOrUpdatedBindingClue = event.getAddedOrUpdated().stream()
-      .filter(file -> BindingClueProvider.ALL_BINDING_CLUE_FILENAMES.contains(file.getFileName()))
-      .map(ClientFile::getConfigScopeId)
-      .collect(Collectors.toSet());
-    suggestBindingForGivenScopesAndAllConnections(configScopeWithAddedOrUpdatedBindingClue);
   }
 
   public Map<String, List<BindingSuggestionDto>> getBindingSuggestions(String configScopeId, String connectionId, SonarLintCancelMonitor cancelMonitor) {

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
@@ -63,7 +63,7 @@ public interface SonarLintRpcClientDelegate {
 
   void suggestBinding(Map<String, List<BindingSuggestionDto>> suggestionsByConfigScope);
 
-  void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope);
+  void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker);
 
   void openUrlInBrowser(URL url);
 

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
@@ -135,8 +135,8 @@ public class SonarLintRpcClientImpl implements SonarLintRpcClient {
   }
 
   @Override
-  public void suggestConnection(SuggestConnectionParams params) {
-    notify(() -> delegate.suggestConnection(params.getSuggestionsByConfigScopeId()));
+  public CompletableFuture<Void> suggestConnection(SuggestConnectionParams params) {
+    return runAsync(cancelChecker -> delegate.suggestConnection(params.getSuggestionsByConfigScopeId(), cancelChecker));
   }
 
   @Override

--- a/its/tests/src/test/java/its/MockSonarLintRpcClientDelegate.java
+++ b/its/tests/src/test/java/its/MockSonarLintRpcClientDelegate.java
@@ -63,7 +63,7 @@ public class MockSonarLintRpcClientDelegate implements SonarLintRpcClientDelegat
   }
 
   @Override
-  public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope) {
+  public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker) {
 
   }
 

--- a/medium-tests/src/test/java/mediumtest/ConnectionSuggestionMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectionSuggestionMediumTests.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -44,17 +43,20 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.Configur
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidAddConfigurationScopesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidUpdateFileSystemParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.ConnectionSuggestionDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.SonarCloudConnectionSuggestionDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.SonarQubeConnectionSuggestionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
+import org.sonarsource.sonarlint.core.serverapi.proto.sonarqube.ws.Components;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
 import static mediumtest.fixtures.SonarLintBackendFixture.newFakeClient;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static testutils.TestUtils.protobufBody;
 
 class ConnectionSuggestionMediumTests {
 
@@ -92,7 +94,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -120,7 +122,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -152,7 +154,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -178,7 +180,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -204,7 +206,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -236,7 +238,7 @@ class ConnectionSuggestionMediumTests {
             new BindingConfigurationDto(null, null, false)))));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -271,7 +273,7 @@ class ConnectionSuggestionMediumTests {
             new BindingConfigurationDto(null, null, false)))));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -312,7 +314,7 @@ class ConnectionSuggestionMediumTests {
             new BindingConfigurationDto(null, null, false)))));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -340,7 +342,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -368,7 +370,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);

--- a/medium-tests/src/test/java/mediumtest/ConnectionSuggestionMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectionSuggestionMediumTests.java
@@ -38,25 +38,19 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcServer;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.BindingConfigurationDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.BindingSuggestionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.ConfigurationScopeDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidAddConfigurationScopesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidUpdateFileSystemParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.ConnectionSuggestionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
-import org.sonarsource.sonarlint.core.serverapi.proto.sonarqube.ws.Components;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
 import static mediumtest.fixtures.SonarLintBackendFixture.newFakeClient;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static testutils.TestUtils.protobufBody;
 
 class ConnectionSuggestionMediumTests {
 

--- a/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
@@ -32,6 +32,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.binding.GetSharedConn
 import static mediumtest.fixtures.ServerFixture.newSonarCloudServer;
 import static mediumtest.fixtures.ServerFixture.newSonarQubeServer;
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
+import static org.apache.commons.lang.StringUtils.removeEnd;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
@@ -95,7 +96,7 @@ class SharedConnectedModeSettingsMediumTests {
     var expectedFileContent = String.format("{\n" +
       "    \"sonarQubeUri\": \"%s\",\n" +
       "    \"projectKey\": \"%s\"\n" +
-      "}", server.baseUrl(), projectKey);
+      "}", removeEnd(server.baseUrl(), "/"), projectKey);
 
     backend = newBackend()
       .withSonarQubeConnection(connectionId, server)

--- a/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
@@ -672,7 +672,7 @@ public class SonarLintBackendFixture {
     }
 
     @Override
-    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope) {
+    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker) {
 
     }
 

--- a/medium-tests/src/test/java/mediumtest/sloop/SloopLauncherTests.java
+++ b/medium-tests/src/test/java/mediumtest/sloop/SloopLauncherTests.java
@@ -171,7 +171,7 @@ class SloopLauncherTests {
     }
 
     @Override
-    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope) {
+    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker) {
 
     }
 

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
@@ -76,7 +76,7 @@ public interface SonarLintRpcClient {
    * Suggest to create a connection and a binding to the client
    */
   @JsonNotification
-  void suggestConnection(SuggestConnectionParams params);
+  CompletableFuture<Void> suggestConnection(SuggestConnectionParams params);
 
   @JsonNotification
   void openUrlInBrowser(OpenUrlInBrowserParams params);


### PR DESCRIPTION
- Since `ConnectionSuggestionProvider` was listening to the same events at the `BindingSuggestionProvider`, it is not useful to keep the listeners in `BindingSuggestionProvider` because anyway the connection provider will fallback to the binding provider if there is no connection to be suggested
- Avoid the `BindingSuggestionProvider` to propose a binding while the connection is being created on the client side
- Fix test error with trailing '/'