### PR TITLE
Remove useless usage of CompletableFuture for suggesting connection

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConnectionSuggestionProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConnectionSuggestionProvider.java
@@ -142,7 +142,7 @@ public class ConnectionSuggestionProvider {
       }
     }
 
-    suggestConnectionToClientIfAny(connectionSuggestionsByConfigScopeIds, cancelMonitor);
+    suggestConnectionToClientIfAny(connectionSuggestionsByConfigScopeIds);
     computeBindingSuggestionfAny(bindingSuggestionsForConfigScopeIds);
   }
 
@@ -167,18 +167,10 @@ public class ConnectionSuggestionProvider {
     return Optional.empty();
   }
 
-  private void suggestConnectionToClientIfAny(Map<String, List<ConnectionSuggestionDto>> connectionSuggestionsByConfigScopeIds,
-    SonarLintCancelMonitor cancelMonitor) {
+  private void suggestConnectionToClientIfAny(Map<String, List<ConnectionSuggestionDto>> connectionSuggestionsByConfigScopeIds) {
     if (!connectionSuggestionsByConfigScopeIds.isEmpty()) {
       LOG.debug("Found {} connection suggestion(s)", connectionSuggestionsByConfigScopeIds.size());
-      try {
-        bindingSuggestionProvider.disable();
-        var future = client.suggestConnection(new SuggestConnectionParams(connectionSuggestionsByConfigScopeIds));
-        cancelMonitor.onCancel(() -> future.cancel(true));
-        future.join();
-      } finally {
-        bindingSuggestionProvider.enable();
-      }
+      client.suggestConnection(new SuggestConnectionParams(connectionSuggestionsByConfigScopeIds));
     }
   }
 

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
@@ -63,7 +63,7 @@ public interface SonarLintRpcClientDelegate {
 
   void suggestBinding(Map<String, List<BindingSuggestionDto>> suggestionsByConfigScope);
 
-  void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker);
+  void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope);
 
   void openUrlInBrowser(URL url);
 

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
@@ -135,8 +135,8 @@ public class SonarLintRpcClientImpl implements SonarLintRpcClient {
   }
 
   @Override
-  public CompletableFuture<Void> suggestConnection(SuggestConnectionParams params) {
-    return runAsync(cancelChecker -> delegate.suggestConnection(params.getSuggestionsByConfigScopeId(), cancelChecker));
+  public void suggestConnection(SuggestConnectionParams params) {
+    notify(() -> delegate.suggestConnection(params.getSuggestionsByConfigScopeId()));
   }
 
   @Override

--- a/its/plugins/java-custom-rules/pom.xml
+++ b/its/plugins/java-custom-rules/pom.xml
@@ -55,16 +55,31 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>shade</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>
         <artifactId>sonar-packaging-maven-plugin</artifactId>
-        <version>1.20.0.405</version>
+        <version>1.23.0.740</version>
         <extensions>true</extensions>
         <configuration>
           <pluginClass>org.sonar.samples.java.MyJavaRulesPlugin</pluginClass>
           <pluginApiMinVersion>7.9</pluginApiMinVersion>
           <pluginKey>custom</pluginKey>
           <sonarLintSupported>true</sonarLintSupported>
+          <skipDependenciesPackaging>true</skipDependenciesPackaging>
           <requirePlugins>java:${sonarjava.version}</requirePlugins>
+          <requiredForLanguages>java</requiredForLanguages>
         </configuration>
       </plugin>
 

--- a/its/tests/src/test/java/its/MockSonarLintRpcClientDelegate.java
+++ b/its/tests/src/test/java/its/MockSonarLintRpcClientDelegate.java
@@ -63,7 +63,7 @@ public class MockSonarLintRpcClientDelegate implements SonarLintRpcClientDelegat
   }
 
   @Override
-  public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker) {
+  public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope) {
 
   }
 

--- a/medium-tests/src/test/java/mediumtest/ConnectionSuggestionMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectionSuggestionMediumTests.java
@@ -88,7 +88,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -117,7 +117,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -150,7 +150,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -177,7 +177,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -204,7 +204,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -237,7 +237,7 @@ class ConnectionSuggestionMediumTests {
             new BindingConfigurationDto(null, null, false)))));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -273,7 +273,7 @@ class ConnectionSuggestionMediumTests {
             new BindingConfigurationDto(null, null, false)))));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -315,7 +315,7 @@ class ConnectionSuggestionMediumTests {
             new BindingConfigurationDto(null, null, false)))));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -344,7 +344,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);
@@ -373,7 +373,7 @@ class ConnectionSuggestionMediumTests {
     backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(Collections.emptyList(), List.of(fileDto)));
 
     ArgumentCaptor<Map<String, List<ConnectionSuggestionDto>>> suggestionCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture(), any());
+    verify(fakeClient, timeout(5000)).suggestConnection(suggestionCaptor.capture());
 
     var connectionSuggestion = suggestionCaptor.getValue();
     assertThat(connectionSuggestion).containsOnlyKeys(CONFIG_SCOPE_ID);

--- a/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
@@ -672,7 +672,7 @@ public class SonarLintBackendFixture {
     }
 
     @Override
-    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker) {
+    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope) {
 
     }
 

--- a/medium-tests/src/test/java/mediumtest/sloop/SloopLauncherTests.java
+++ b/medium-tests/src/test/java/mediumtest/sloop/SloopLauncherTests.java
@@ -171,7 +171,7 @@ class SloopLauncherTests {
     }
 
     @Override
-    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope, CancelChecker cancelChecker) {
+    public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope) {
 
     }
 

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
@@ -76,7 +76,7 @@ public interface SonarLintRpcClient {
    * Suggest to create a connection and a binding to the client
    */
   @JsonNotification
-  CompletableFuture<Void> suggestConnection(SuggestConnectionParams params);
+  void suggestConnection(SuggestConnectionParams params);
 
   @JsonNotification
   void openUrlInBrowser(OpenUrlInBrowserParams params);


### PR DESCRIPTION
Since the `suggestConnection` only shows a notification, it's purely asynchronous and we cannot wait.

I'd suggest using `didUpdateBinding` and modifying the `bindingSuggestionDisabled` field on the client side before and after processing the binding.