### PR TITLE
SLCORE-733 Publish artifacts needed by clients to Maven Central

### DIFF
--- a/backend/embedded/javadoc/README.md
+++ b/backend/embedded/javadoc/README.md
@@ -1,0 +1,1 @@
+# Embedded backend modules

--- a/backend/embedded/pom.xml
+++ b/backend/embedded/pom.xml
@@ -130,6 +130,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>empty-javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${basedir}/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/client/embedded/javadoc/README.md
+++ b/client/embedded/javadoc/README.md
@@ -1,0 +1,1 @@
+# Embedded client modules

--- a/client/embedded/pom.xml
+++ b/client/embedded/pom.xml
@@ -101,6 +101,23 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>empty-javadoc-jar</id>
+            <phase>package</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <configuration>
+              <classifier>javadoc</classifier>
+              <classesDirectory>${basedir}/javadoc</classesDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,6 @@
     <module>backend/cli</module>
     <module>backend/commons</module>
     <module>backend/core</module>
-    <module>backend/embedded</module>
     <module>backend/http</module>
     <module>backend/plugin-api</module>
     <module>backend/plugin-commons</module>
@@ -38,7 +37,6 @@
     <module>backend/server-connection</module>
     <module>backend/slf4j-sonar-log</module>
     <module>backend/telemetry</module>
-    <module>client/embedded</module>
     <module>client/java-client-legacy</module>
     <module>client/java-client-utils</module>
     <module>client/rpc-java-client</module>


### PR DESCRIPTION
There are two commits:
1. Remove embedded modules from the parent pom because we don't use them currently. 
2. Create a dummy Javadoc jar for these modules to pass the deploy-check in case we decide to use them in the future
    - It doesn't generate Javadoc by default because these modules don't have any source files.