### PR TITLE
NO-JIRA: Fix pipeline running OOM

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -225,8 +225,8 @@ promote_task:
   <<: *ONLY_IF_EXCEPT_NIGHTLY
   eks_container:
     <<: *CONTAINER_DEFINITION
-    cpu: 1
-    memory: 1G
+    cpu: 2
+    memory: 4G
   env:
       JDK_VERSION: "11"
       ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]


### PR DESCRIPTION
This happens on the promotion due to the Maven Cache not having enough memory to load all the modules built (e.g., backend ones having a JRE are too big). [Here](https://cirrus-ci.com/task/4630130524422144) is a failing task.

I had the bottleneck on SLE also at some point, so I re-used [its](https://github.com/SonarSource/sonarlint-eclipse/blob/master/.cirrus.default.yml#L277-L299) configuration that was found together with RE.