### PR TITLE
SLCORE-774 Do not send empty string suggestions to the client

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
@@ -45,6 +45,7 @@ import org.sonarsource.sonarlint.core.repository.connection.SonarCloudConnection
 import org.sonarsource.sonarlint.core.repository.connection.SonarQubeConnectionConfiguration;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.removeEnd;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 import static org.sonarsource.sonarlint.core.commons.log.SonarLintLogger.singlePlural;
@@ -151,21 +152,22 @@ public class BindingClueProvider {
     var serverUrl = scannerProps.serverUrl;
     var projectKey = scannerProps.projectKey;
     var organization = scannerProps.organization;
-    if (StringUtils.isEmpty(projectKey) || projectKey.isBlank()) {
-      return true;
+    if (serverUrl == null) {
+      return isEmptyScConfig(projectKey, organization);
     }
-    if (sqConnectionConfiguredWithBlankValue(organization, serverUrl)) {
-      return true;
-    }
-    return scConnectionConfiguredWithBlankValue(serverUrl, organization);
+    return isEmptySqConfig(projectKey, serverUrl);
   }
 
-  private static boolean sqConnectionConfiguredWithBlankValue(@Nullable String organization, @Nullable String serverUrl) {
-    return organization == null && StringUtils.isBlank(serverUrl);
+  private static boolean isEmptySqConfig(@Nullable String projectKey, @Nullable String serverUrl) {
+    return isEmptyValue(projectKey) && isEmptyValue(serverUrl);
   }
 
-  private static boolean scConnectionConfiguredWithBlankValue(@Nullable String serverUrl, @Nullable String organization) {
-    return serverUrl == null && StringUtils.isBlank(organization);
+  private static boolean isEmptyScConfig(@Nullable String projectKey, @Nullable String organization) {
+    return isEmptyValue(projectKey) && isEmptyValue(organization);
+  }
+
+  private static boolean isEmptyValue(@Nullable String value) {
+    return StringUtils.isEmpty(value) || StringUtils.isBlank(value);
   }
 
   private Set<String> matchConnections(BindingClue bindingClue, Set<String> eligibleConnectionIds) {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
@@ -34,7 +34,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.apache.commons.lang.StringUtils;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
 import org.sonarsource.sonarlint.core.fs.ClientFile;
@@ -45,6 +44,7 @@ import org.sonarsource.sonarlint.core.repository.connection.SonarCloudConnection
 import org.sonarsource.sonarlint.core.repository.connection.SonarQubeConnectionConfiguration;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.removeEnd;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 import static org.sonarsource.sonarlint.core.commons.log.SonarLintLogger.singlePlural;
@@ -158,15 +158,11 @@ public class BindingClueProvider {
   }
 
   private static boolean isEmptySqConfig(@Nullable String projectKey, @Nullable String serverUrl) {
-    return isEmptyValue(projectKey) && isEmptyValue(serverUrl);
+    return isBlank(projectKey) && isBlank(serverUrl);
   }
 
   private static boolean isEmptyScConfig(@Nullable String projectKey, @Nullable String organization) {
-    return isEmptyValue(projectKey) && isEmptyValue(organization);
-  }
-
-  private static boolean isEmptyValue(@Nullable String value) {
-    return StringUtils.isEmpty(value) || StringUtils.isBlank(value);
+    return isBlank(projectKey) && isBlank(organization);
   }
 
   private Set<String> matchConnections(BindingClue bindingClue, Set<String> eligibleConnectionIds) {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
@@ -34,7 +34,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.StringUtils;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
 import org.sonarsource.sonarlint.core.fs.ClientFile;
@@ -45,7 +45,6 @@ import org.sonarsource.sonarlint.core.repository.connection.SonarCloudConnection
 import org.sonarsource.sonarlint.core.repository.connection.SonarQubeConnectionConfiguration;
 
 import static java.util.stream.Collectors.toSet;
-import static org.apache.commons.lang.StringUtils.isEmpty;
 import static org.apache.commons.lang.StringUtils.removeEnd;
 import static org.apache.commons.lang.StringUtils.trimToNull;
 import static org.sonarsource.sonarlint.core.commons.log.SonarLintLogger.singlePlural;

--- a/medium-tests/pom.xml
+++ b/medium-tests/pom.xml
@@ -87,6 +87,11 @@
       <version>4.8.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
+++ b/medium-tests/src/test/java/mediumtest/fixtures/SonarLintBackendFixture.java
@@ -552,6 +552,7 @@ public class SonarLintBackendFixture {
     private final Queue<ShowSmartNotificationParams> smartNotificationsToShow = new ConcurrentLinkedQueue<>();
     private final Map<String, ProgressReport> progressReportsByTaskId = new ConcurrentHashMap<>();
     private final Set<String> synchronizedConfigScopeIds = new HashSet<>();
+    private final Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope = new HashMap<>();
     private final Map<String, Either<TokenDto, UsernamePasswordDto>> credentialsByConnectionId;
     private final boolean printLogsToStdOut;
     private final Queue<LogParams> logs = new ConcurrentLinkedQueue<>();
@@ -635,6 +636,10 @@ public class SonarLintBackendFixture {
       return synchronizedConfigScopeIds;
     }
 
+    public Map<String, List<ConnectionSuggestionDto>> getSuggestionsByConfigScope() {
+      return suggestionsByConfigScope;
+    }
+
     @Override
     public Either<TokenDto, UsernamePasswordDto> getCredentials(String connectionId) {
       return credentialsByConnectionId.get(connectionId);
@@ -683,7 +688,7 @@ public class SonarLintBackendFixture {
 
     @Override
     public void suggestConnection(Map<String, List<ConnectionSuggestionDto>> suggestionsByConfigScope) {
-
+      this.suggestionsByConfigScope.putAll(suggestionsByConfigScope);
     }
 
     @Override


### PR DESCRIPTION
In the SonarLint configuration file, it's possible to have content with a "valid" connection config with empty values. Today, we report these empty lines as suggestions when we detect such config files. This fix ensures that we will only show useful suggestions for the user in this case.