### PR TITLE
Revert "SLCORE-672 remove explicit dependency check for DBD plugins"

### DIFF
--- a/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsChecker.java
+++ b/backend/plugin-commons/src/main/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsChecker.java
@@ -173,9 +173,17 @@ public class SonarPluginRequirementsChecker {
     if (basePluginKey != null && checkForPluginSkipped(currentResultsByKey.get(basePluginKey))) {
       return processUnsatisfiedDependency(currentResult.getPlugin(), basePluginKey);
     }
-    if (DataflowBugDetection.PLUGIN_ALLOW_LIST.contains(plugin.getKey()) && !enableDataflowBugDetection) {
+    if (DataflowBugDetection.PLUGIN_ALLOW_LIST.contains(plugin.getKey())) {
+      // Workaround for SLCORE-667
+      // dbd and dbdpythonfrontend require Python to be working
+      if (!enableDataflowBugDetection) {
         LOG.debug("DBD feature disabled. Skip loading plugin '{}'.", plugin.getName());
         return new PluginRequirementsCheckResult(plugin, SkipReason.UnsupportedFeature.INSTANCE);
+      }
+      var pythonPluginResult = currentResultsByKey.get(SonarLanguage.PYTHON.getPluginKey());
+      if (checkForPluginSkipped(pythonPluginResult)) {
+        return processUnsatisfiedDependency(currentResult.getPlugin(), SonarLanguage.PYTHON.getPluginKey());
+      }
     }
     return currentResult;
   }

--- a/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsCheckerTests.java
+++ b/backend/plugin-commons/src/test/java/org/sonarsource/sonarlint/core/plugin/commons/loading/SonarPluginRequirementsCheckerTests.java
@@ -390,11 +390,10 @@ class SonarPluginRequirementsCheckerTests {
     assertThat(logsWithoutStartStop()).contains("DBD feature disabled. Skip loading plugin 'dbdpythonfrontend'.");
   }
 
-
   @Test
   void load_plugin_skip_plugins_having_unsatisfied_python_dbd(@TempDir Path storage) throws IOException {
     var fakePlugin = fakePlugin(storage, "fake.jar",
-      path -> createPluginManifest(path, "dbd", V1_0, withRequiredPlugins("python:1.15")));
+      path -> createPluginManifest(path, "dbd", V1_0));
     Set<Path> jars = Set.of(fakePlugin);
 
     var loadedPlugins = underTest.checkRequirements(jars, NONE, null, Optional.empty(), true);
@@ -404,18 +403,6 @@ class SonarPluginRequirementsCheckerTests {
     assertThat(logsWithoutStartStop()).contains("Plugin 'dbd' dependency on 'python' is unsatisfied. Skip loading it.");
   }
 
-  @Test
-  void load_plugin_skip_plugins_having_unsatisfied_java_dbd(@TempDir Path storage) throws IOException {
-    var fakePlugin = fakePlugin(storage, "fake.jar",
-      path -> createPluginManifest(path, "dbd", V1_0, withRequiredPlugins("java:7.35")));
-    Set<Path> jars = Set.of(fakePlugin);
-
-    var loadedPlugins = underTest.checkRequirements(jars, NONE, null, Optional.empty(), true);
-
-    assertThat(loadedPlugins.values()).extracting(r -> r.getPlugin().getKey(), PluginRequirementsCheckResult::isSkipped, p -> p.getSkipReason().orElse(null))
-      .containsOnly(tuple("dbd", true, new SkipReason.UnsatisfiedDependency(SonarLanguage.JAVA.getPluginKey())));
-    assertThat(logsWithoutStartStop()).contains("Plugin 'dbd' dependency on 'java' is unsatisfied. Skip loading it.");
-  }
   @Test
   void load_plugin_having_satisfied_python_frontend_dbd(@TempDir Path storage) throws IOException {
     var fakePlugin = fakePlugin(storage, "fake.jar",


### PR DESCRIPTION
This reverts commit e2fa6ffdab029a38c26d30cd3fcaacdde843fb54 so that newer versions of SonarLint are compatible with older SonarQube servers (with older DBD versions).