### PR TITLE
SLCORE-861 Use unix separator when using `git-files-blame` or `jgit` libs

### DIFF
--- a/backend/commons/pom.xml
+++ b/backend/commons/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>org.eclipse.jgit</artifactId>
       <version>${jgit.version}</version>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
     <!-- unit tests -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintBlameResult.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarLintBlameResult.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.apache.commons.io.FilenameUtils;
 import org.sonar.scm.git.blame.BlameResult;
 
 import static java.util.Objects.isNull;
@@ -44,7 +45,7 @@ public class SonarLintBlameResult {
   public Optional<Date> getLatestChangeDateForLinesInFile(Path filePath, Collection<Integer> lineNumbers) {
     validateLineNumbersArgument(lineNumbers);
     var fileBlameByPath = blameResult.getFileBlameByPath();
-    var blameForFile = fileBlameByPath.get(filePath.toString());
+    var blameForFile = fileBlameByPath.get(FilenameUtils.separatorsToUnix(filePath.toString()));
     if (blameForFile == null) {
       return Optional.empty();
     }

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/GitUtils.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/GitUtils.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.util.Date;
+import org.apache.commons.io.FilenameUtils;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.PersonIdent;
@@ -47,7 +48,7 @@ public class GitUtils {
     if (paths.length > 0) {
       var add = git.add();
       for (String p : paths) {
-        add.addFilepattern(p);
+        add.addFilepattern(FilenameUtils.separatorsToUnix(p));
       }
       add.call();
     }


### PR DESCRIPTION
SLCORE-861 Use unix separator when using `git-files-blame` or `jgit` libs

# For SonarSourcers:

- [ ] Prefix the commit message with the ticket number, i.e. `SLCORE-XXXX` (or use `NO-JIRA` for a trivial change not tracked by a ticket)
- [ ] When changing an API:
    - [ ] Explain in the JavaDoc the purpose of the new API
    - [ ] Document the change in [API_CHANGES.md](https://github.com/SonarSource/sonarlint-core/blob/master/API_CHANGES.md)
    - [ ] If the change breaks the current API, explicitly communicate those to the impacted consumers prior to merging (eg. IDE squad)
- [ ] Make sure the tests adhere to the convention:
    - [ ] All test method names should use `snake_case`, for example: `test_validate_input`.
- [ ] Make sure checks are green: build passes, Quality Gate is green
