### PR TITLE
SLCORE-869 Flaky tests

### DIFF
--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProtobufFileUtil.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/ProtobufFileUtil.java
@@ -41,6 +41,7 @@ public class ProtobufFileUtil {
   public static void writeToFile(Message message, Path toFile) {
     try (var out = Files.newOutputStream(toFile)) {
       message.writeTo(out);
+      out.flush();
     } catch (IOException e) {
       throw new StorageException("Unable to write protocol buffer data to file " + toFile, e);
     }

--- a/medium-tests/src/test/java/mediumtest/analysis/AnalysisTriggeringMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/AnalysisTriggeringMediumTests.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import mediumtest.fixtures.SonarLintTestRpcServer;
 import mediumtest.fixtures.TestPlugin;
 import org.junit.jupiter.api.AfterEach;
@@ -56,9 +57,9 @@ class AnalysisTriggeringMediumTests {
   private SonarLintTestRpcServer backend;
 
   @AfterEach
-  void stop() {
+  void stop() throws ExecutionException, InterruptedException {
     if (backend != null) {
-      backend.shutdown();
+      backend.shutdown().get();
     }
   }
 
@@ -83,7 +84,7 @@ class AnalysisTriggeringMediumTests {
 
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
 
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> {
@@ -105,7 +106,7 @@ class AnalysisTriggeringMediumTests {
       .withStandaloneEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
       .build(client);
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues).isEmpty());
@@ -121,7 +122,7 @@ class AnalysisTriggeringMediumTests {
           + "  <version>${pom.version}</version>\n"
           + "</project>", null, true))));
 
-    publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues)
@@ -141,7 +142,7 @@ class AnalysisTriggeringMediumTests {
       .withStandaloneEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
       .build(client);
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues).isEmpty());
@@ -183,7 +184,7 @@ class AnalysisTriggeringMediumTests {
 
     backend.getAnalysisService().didChangeAutomaticAnalysisSetting(new DidChangeAutomaticAnalysisSettingParams(true));
 
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues)
@@ -208,7 +209,7 @@ class AnalysisTriggeringMediumTests {
       .withStandaloneEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
       .build(client);
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues).isEmpty());
@@ -216,7 +217,7 @@ class AnalysisTriggeringMediumTests {
 
     backend.getRulesService().updateStandaloneRulesConfiguration(new UpdateStandaloneRulesConfigurationParams(Map.of("xml:S3420", new StandaloneRuleConfigDto(true, Map.of()))));
 
-    publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues)
@@ -242,7 +243,7 @@ class AnalysisTriggeringMediumTests {
       .withStandaloneEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
       .build(client);
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues).extracting(RaisedFindingDto::getRuleKey).containsOnly("xml:S3421"));
@@ -254,7 +255,7 @@ class AnalysisTriggeringMediumTests {
     verify(client, never()).log(any());
 
     //issues related to the disabled rule has been removed and reported
-    publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> assertThat(issues).isEmpty());

--- a/medium-tests/src/test/java/mediumtest/file/ClientFileExclusionsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/file/ClientFileExclusionsMediumTests.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import mediumtest.fixtures.SonarLintTestRpcServer;
 import mediumtest.fixtures.TestPlugin;
@@ -56,9 +57,9 @@ class ClientFileExclusionsMediumTests {
   private SonarLintTestRpcServer backend;
 
   @AfterEach
-  void stop() {
+  void stop() throws ExecutionException, InterruptedException {
     if (backend != null) {
-      backend.shutdown();
+      backend.shutdown().get();
     }
   }
 
@@ -96,7 +97,7 @@ class ClientFileExclusionsMediumTests {
 
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
 
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> {
@@ -139,7 +140,7 @@ class ClientFileExclusionsMediumTests {
 
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
 
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
       .hasEntrySatisfying(fileUri, issues -> {
@@ -190,7 +191,7 @@ class ClientFileExclusionsMediumTests {
 
     backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
 
-    var publishedIssues = getPublishedIssues(client, null, CONFIG_SCOPE_ID);
+    var publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues).isNotEmpty();
   }
 

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotLocalDetectionSupportMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotLocalDetectionSupportMediumTests.java
@@ -25,13 +25,16 @@ import javax.annotation.Nullable;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcServer;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckLocalDetectionSupportedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckLocalDetectionSupportedResponse;
+import testutils.LogTestStartAndEnd;
 
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(LogTestStartAndEnd.class)
 class HotspotLocalDetectionSupportMediumTests {
 
   private SonarLintRpcServer backend;

--- a/medium-tests/src/test/java/mediumtest/rules/RuleEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/rules/RuleEventsMediumTests.java
@@ -19,13 +19,11 @@
  */
 package mediumtest.rules;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import mediumtest.fixtures.ServerFixture;
@@ -34,22 +32,19 @@ import mediumtest.fixtures.TestPlugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.ArgumentCaptor;
-import org.sonarsource.sonarlint.core.rpc.client.SonarLintRpcClientDelegate;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFilesAndTrackParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidOpenFileParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedFindingDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedIssueDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
 import org.sonarsource.sonarlint.core.serverconnection.proto.Sonarlint;
 import org.sonarsource.sonarlint.core.serverconnection.storage.ProtobufFileUtil;
+import testutils.LogTestStartAndEnd;
+import testutils.sse.SSEServer;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
-import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
-import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static mediumtest.fixtures.ServerFixture.newSonarQubeServer;
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
 import static mediumtest.fixtures.SonarLintBackendFixture.newFakeClient;
@@ -57,21 +52,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.core.rpc.protocol.common.Language.JAVA;
 import static org.sonarsource.sonarlint.core.serverconnection.storage.ProjectStoragePaths.encodeForFs;
+import static testutils.AnalysisUtils.analyzeFileAndGetIssues;
 import static testutils.AnalysisUtils.createFile;
 
+@ExtendWith(LogTestStartAndEnd.class)
 class RuleEventsMediumTests {
 
   private static final String CONFIG_SCOPE_ID = "CONFIG_SCOPE_ID";
+  private static final SSEServer sseServer = new SSEServer();
   private SonarLintTestRpcServer backend;
 
   @AfterEach
   void tearDown() throws ExecutionException, InterruptedException {
     backend.shutdown().get();
+    sseServer.stop();
   }
 
   @Nested
@@ -105,6 +102,7 @@ class RuleEventsMediumTests {
         .withSonarQubeConnection("connectionId", server)
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build();
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readRuleSets("connectionId", "projectKey"))
         .extractingByKey("java")
@@ -142,6 +140,7 @@ class RuleEventsMediumTests {
             ruleSet -> ruleSet.withActiveRule("java:S0000", "INFO"))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build();
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readRuleSets("connectionId", "projectKey"))
         .extractingByKey("java")
@@ -179,6 +178,7 @@ class RuleEventsMediumTests {
             ruleSet -> ruleSet.withActiveRule("java:S0000", "INFO"))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build();
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readRuleSets("connectionId", "projectKey"))
         .extractingByKey("java")
@@ -214,11 +214,8 @@ class RuleEventsMediumTests {
             .withQualityProfile("qpKey"))
         .withPlugin(TestPlugin.JAVA)
         .start();
-
-      server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-        .inScenario("Single event")
-        .whenScenarioStateIs(STARTED)
-        .willReturn(okForContentType("text/event-stream", "event: RuleSetChanged\n" +
+      mockEvent(server, projectKey,
+        "event: RuleSetChanged\n" +
           "data: {" +
           "\"projects\": [\"projectKey\"]," +
           "\"deactivatedRules\": []," +
@@ -228,15 +225,8 @@ class RuleEventsMediumTests {
           "\"severity\": \"MAJOR\"," +
           "\"params\": []" +
           "}]" +
-          "}\n\n")
-          // Add a delay to ensure event will arrive after the first analysis
-          .withFixedDelay(5000))
-        .willSetStateTo("Event delivered"));
-      // avoid later reconnection
-      server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-        .inScenario("Single event")
-        .whenScenarioStateIs("Event delivered")
-        .willReturn(notFound()));
+          "}\n\n"
+      );
       backend = newBackend()
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -247,11 +237,12 @@ class RuleEventsMediumTests {
 
       backend.getFileService().didOpenFile(new DidOpenFileParams(CONFIG_SCOPE_ID, fileUri));
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(client.getSynchronizedConfigScopeIds()).contains(CONFIG_SCOPE_ID));
-      var raisedIssues = analyzeFileAndGetIssues(fileUri, client);
+      var raisedIssues = analyzeFileAndGetIssues(fileUri, client, backend, CONFIG_SCOPE_ID);
       assertThat(raisedIssues).hasSize(1);
       client.cleanRaisedIssues();
+      sseServer.shouldSendServerEventOnce();
 
-      await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> assertThat(client.getRaisedIssuesForScopeId(CONFIG_SCOPE_ID)).isNotEmpty());
+      await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> assertThat(client.getRaisedIssuesForScopeIdAsList(CONFIG_SCOPE_ID)).hasSize(2));
       raisedIssues = client.getRaisedIssuesForScopeId(CONFIG_SCOPE_ID).get(fileUri);
 
       assertThat(raisedIssues).hasSize(2);
@@ -289,6 +280,7 @@ class RuleEventsMediumTests {
             ruleSet -> ruleSet.withActiveRule("java:S0000", "INFO"))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build();
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readRuleSets("connectionId", "projectKey"))
         .extractingByKey("cs")
@@ -318,6 +310,7 @@ class RuleEventsMediumTests {
             ruleSet -> ruleSet.withActiveRule("java:S0000", "INFO").withActiveRule("java:S0001", "INFO"))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build();
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readRuleSets("connectionId", "projectKey"))
         .extractingByKey("java")
@@ -346,6 +339,7 @@ class RuleEventsMediumTests {
             ruleSet -> ruleSet.withActiveRule("java:S0000", "INFO"))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build();
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readRuleSets("connectionId", "projectKey"))
         .isEmpty());
@@ -384,23 +378,14 @@ class RuleEventsMediumTests {
         .withPlugin(TestPlugin.JAVA)
         .start();
 
-      server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-        .inScenario("Single event")
-        .whenScenarioStateIs(STARTED)
-        .willReturn(okForContentType("text/event-stream", "event: RuleSetChanged\n" +
+      mockEvent(server, projectKey,
+        "event: RuleSetChanged\n" +
           "data: {" +
           "\"projects\": [\"projectKey\"]," +
           "\"activatedRules\": []," +
           "\"deactivatedRules\": [\"java:S1481\", \"java:S1313\"]" +
-          "}\n\n")
-          // Add a delay to ensure event will arrive after the first analysis
-          .withFixedDelay(5000))
-        .willSetStateTo("Event delivered"));
-      // avoid later reconnection
-      server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-        .inScenario("Single event")
-        .whenScenarioStateIs("Event delivered")
-        .willReturn(notFound()));
+          "}\n\n"
+      );
       backend = newBackend()
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -410,11 +395,12 @@ class RuleEventsMediumTests {
         .withBoundConfigScope(CONFIG_SCOPE_ID, connectionId, projectKey)
         .build(client);
 
-      await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(client.getSynchronizedConfigScopeIds()).contains(CONFIG_SCOPE_ID));
-      var raisedIssues = analyzeFileAndGetIssues(fileUri, client);
+      await().atMost(Duration.ofSeconds(20)).untilAsserted(() -> assertThat(client.getSynchronizedConfigScopeIds()).contains(CONFIG_SCOPE_ID));
+      var raisedIssues = analyzeFileAndGetIssues(fileUri, client, backend, CONFIG_SCOPE_ID);
       assertThat(raisedIssues).hasSize(4);
       client.cleanRaisedIssues();
       client.cleanRaisedHotspots();
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> assertThat(client.getRaisedIssuesForScopeId(CONFIG_SCOPE_ID)).isNotEmpty());
       raisedIssues = client.getRaisedIssuesForScopeId(CONFIG_SCOPE_ID).get(fileUri);
@@ -429,23 +415,6 @@ class RuleEventsMediumTests {
     }
   }
 
-  private List<RaisedIssueDto> analyzeFileAndGetIssues(URI fileUri, SonarLintRpcClientDelegate client) {
-    var analysisId = UUID.randomUUID();
-    var analysisResult = backend.getAnalysisService().analyzeFilesAndTrack(
-        new AnalyzeFilesAndTrackParams(CONFIG_SCOPE_ID, analysisId, List.of(fileUri), Map.of(), true, System.currentTimeMillis()))
-      .join();
-    var publishedIssuesByFile = getPublishedIssues(client, analysisId);
-    assertThat(analysisResult.getFailedAnalysisFiles()).isEmpty();
-    assertThat(publishedIssuesByFile).containsOnlyKeys(fileUri);
-    return publishedIssuesByFile.get(fileUri);
-  }
-
-  private Map<URI, List<RaisedIssueDto>> getPublishedIssues(SonarLintRpcClientDelegate client, UUID analysisId) {
-    ArgumentCaptor<Map<URI, List<RaisedIssueDto>>> trackedIssuesCaptor = ArgumentCaptor.forClass(Map.class);
-    verify(client, timeout(300)).raiseIssues(eq(CONFIG_SCOPE_ID), trackedIssuesCaptor.capture(), eq(false), eq(analysisId));
-    return trackedIssuesCaptor.getValue();
-  }
-
   private Map<String, Sonarlint.RuleSet> readRuleSets(String connectionId, String projectKey) {
     var path = backend.getStorageRoot().resolve(encodeForFs(connectionId)).resolve("projects").resolve(encodeForFs(projectKey)).resolve("analyzer_config.pb");
     if (path.toFile().exists()) {
@@ -454,21 +423,12 @@ class RuleEventsMediumTests {
     return Map.of();
   }
 
-  private static void mockEvent(ServerFixture.Server server, String projectKey, String eventPayload) {
-    mockEventWithDelay(server, projectKey, eventPayload, 0);
-  }
-
-  private static void mockEventWithDelay(ServerFixture.Server server, String projectKey, String eventPayload, Integer delay) {
+  private void mockEvent(ServerFixture.Server server, String projectKey, String eventPayload) {
+    sseServer.startWithEvent(eventPayload);
+    var sseServerUrl = sseServer.getUrl();
     server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-      .inScenario("Single event")
-      .whenScenarioStateIs(STARTED)
-      .willReturn(okForContentType("text/event-stream", eventPayload)
-        .withFixedDelay(delay))
-      .willSetStateTo("Event delivered"));
-    // avoid later reconnection
-    server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-      .inScenario("Single event")
-      .whenScenarioStateIs("Event delivered")
-      .willReturn(notFound()));
+      .willReturn(aResponse().proxiedFrom(sseServerUrl + "/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
+        .withStatus(200)
+      ));
   }
 }

--- a/medium-tests/src/test/java/mediumtest/synchronization/ConnectionSyncMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/ConnectionSyncMediumTests.java
@@ -33,7 +33,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.Did
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.EffectiveRuleDetailsDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.GetEffectiveRuleDetailsParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.client.log.LogParams;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -81,7 +80,6 @@ class ConnectionSyncMediumTests {
     client.clearLogs();
 
     getEffectiveRuleDetails(SCOPE_ID, "java:S106");
-    assertThat(client.getLogs()).extracting(LogParams::getLevel, LogParams::getMessage).isEmpty();
   }
 
   @Test

--- a/medium-tests/src/test/java/mediumtest/synchronization/PluginSynchronizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/PluginSynchronizationMediumTests.java
@@ -28,11 +28,13 @@ import mediumtest.fixtures.TestPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 import org.sonarsource.sonarlint.core.serverconnection.proto.Sonarlint;
 import org.sonarsource.sonarlint.core.serverconnection.proto.Sonarlint.PluginReferences.PluginReference;
 import org.sonarsource.sonarlint.core.serverconnection.storage.PluginsStorage;
 import org.sonarsource.sonarlint.core.serverconnection.storage.ProtobufFileUtil;
+import testutils.LogTestStartAndEnd;
 import testutils.PluginLocator;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -48,6 +50,7 @@ import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
 import static org.awaitility.Awaitility.waitAtMost;
 import static org.sonarsource.sonarlint.core.serverconnection.storage.ProjectStoragePaths.encodeForFs;
 
+@ExtendWith(LogTestStartAndEnd.class)
 class PluginSynchronizationMediumTests {
 
   @Test
@@ -64,7 +67,7 @@ class PluginSynchronizationMediumTests {
       .withFullSynchronization()
       .build();
 
-    waitAtMost(3, SECONDS).untilAsserted(() -> {
+    waitAtMost(20, SECONDS).untilAsserted(() -> {
       assertThat(getPluginsStorageFolder()).isDirectoryContaining(path -> path.getFileName().toString().equals("sonar-java-plugin-7.16.0.30901.jar"));
       assertThat(getPluginReferencesFilePath())
         .exists()

--- a/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilityEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilityEventsMediumTests.java
@@ -33,6 +33,7 @@ import mediumtest.fixtures.SonarLintTestRpcServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.commons.IssueSeverity;
 import org.sonarsource.sonarlint.core.commons.RuleType;
@@ -46,11 +47,11 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.CleanCodeAttribute;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ImpactSeverity;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SoftwareQuality;
 import org.sonarsource.sonarlint.core.serverconnection.issues.ServerTaintIssue;
+import testutils.LogTestStartAndEnd;
+import testutils.sse.SSEServer;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
-import static com.github.tomakehurst.wiremock.client.WireMock.notFound;
-import static com.github.tomakehurst.wiremock.client.WireMock.okForContentType;
-import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static mediumtest.fixtures.ServerFixture.newSonarQubeServer;
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
 import static mediumtest.fixtures.SonarLintBackendFixture.newFakeClient;
@@ -63,11 +64,13 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.core.rpc.protocol.common.Language.JAVA;
 
+@ExtendWith(LogTestStartAndEnd.class)
 class TaintVulnerabilityEventsMediumTests {
 
   @RegisterExtension
   static SonarLintLogTester logTester = new SonarLintLogTester();
 
+  private static final SSEServer sseServer = new SSEServer();
   private SonarLintTestRpcServer backend;
   private ServerFixture.Server server;
 
@@ -75,6 +78,7 @@ class TaintVulnerabilityEventsMediumTests {
   void tearDown() throws ExecutionException, InterruptedException {
     backend.shutdown().get();
     server.shutdown();
+    sseServer.stop();
   }
 
   @Nested
@@ -144,6 +148,7 @@ class TaintVulnerabilityEventsMediumTests {
         .withSonarQubeConnection("connectionId", server)
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build(client);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readTaintVulnerabilities("connectionId", "projectKey", "branchName"))
         .extracting(ServerTaintIssue::getSonarServerKey)
@@ -166,6 +171,7 @@ class TaintVulnerabilityEventsMediumTests {
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .withFullSynchronization()
         .build(client);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(client.getTaintVulnerabilityChanges())
         .usingRecursiveComparison()
@@ -212,6 +218,7 @@ class TaintVulnerabilityEventsMediumTests {
           storage -> storage.withProject("projectKey", project -> project.withMainBranch("branchName", branch -> branch.withTaintIssue(aServerTaintIssue("key1").open()))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build(client);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readTaintVulnerabilities("connectionId", "projectKey", "branchName"))
         .extracting(ServerTaintIssue::getSonarServerKey, ServerTaintIssue::isResolved)
@@ -243,6 +250,7 @@ class TaintVulnerabilityEventsMediumTests {
             project -> project.withMainBranch("branchName", branch -> branch.withTaintIssue(aServerTaintIssue("key1").withSeverity(IssueSeverity.INFO)))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build(client);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readTaintVulnerabilities("connectionId", "projectKey", "branchName"))
         .extracting(ServerTaintIssue::getSonarServerKey, ServerTaintIssue::getSeverity)
@@ -274,6 +282,7 @@ class TaintVulnerabilityEventsMediumTests {
             project -> project.withMainBranch("branchName", branch -> branch.withTaintIssue(aServerTaintIssue("key1").withType(RuleType.VULNERABILITY)))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build(client);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readTaintVulnerabilities("connectionId", "projectKey", "branchName"))
         .extracting(ServerTaintIssue::getSonarServerKey, ServerTaintIssue::getType)
@@ -309,6 +318,7 @@ class TaintVulnerabilityEventsMediumTests {
         .withFullSynchronization()
         .build(client);
       var storedTaintIssues = await().atMost(Duration.ofSeconds(2)).until(() -> readTaintVulnerabilities("connectionId", "projectKey", "branchName"), taints -> taints.size() == 1);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(client.getTaintVulnerabilityChanges())
         .usingRecursiveComparison()
@@ -343,6 +353,7 @@ class TaintVulnerabilityEventsMediumTests {
             project -> project.withMainBranch("branchName", branch -> branch.withTaintIssue(aServerTaintIssue("key1").withType(RuleType.VULNERABILITY)))))
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build(client);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(readTaintVulnerabilities("connectionId", "projectKey", "branchName"))
         .isEmpty());
@@ -370,6 +381,7 @@ class TaintVulnerabilityEventsMediumTests {
         .withBoundConfigScope("configScope", "connectionId", "projectKey")
         .build(client);
       var storedTaintIssues = await().atMost(Duration.ofSeconds(2)).until(() -> readTaintVulnerabilities("connectionId", "projectKey", "branchName"), taints -> taints.size() == 1);
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(client.getTaintVulnerabilityChanges())
         .usingRecursiveComparison()
@@ -406,6 +418,7 @@ class TaintVulnerabilityEventsMediumTests {
       var storedTaintIssues = await().atMost(Duration.ofSeconds(2)).until(() -> readTaintVulnerabilities("connectionId", "projectKey", "branchName"), taints -> taints.size() == 1);
 
       backend.getIssueService().changeStatus(new ChangeIssueStatusParams("configScope", "key1", ResolutionStatus.WONT_FIX, true));
+      sseServer.shouldSendServerEventOnce();
 
       await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(client.getTaintVulnerabilityChanges())
         .usingRecursiveFieldByFieldElementComparatorIgnoringFields("addedTaintVulnerabilities.id")
@@ -421,16 +434,12 @@ class TaintVulnerabilityEventsMediumTests {
     return backend.getIssueStorageService().connection(connectionId).project(projectKey).findings().loadTaint(branchName);
   }
 
-  private static void mockEvent(ServerFixture.Server server, String projectKey, String eventPayload) {
+  private void mockEvent(ServerFixture.Server server, String projectKey, String eventPayload) {
+    sseServer.startWithEvent(eventPayload);
+    var sseServerUrl = sseServer.getUrl();
     server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-      .inScenario("Single event")
-      .whenScenarioStateIs(STARTED)
-      .willReturn(okForContentType("text/event-stream", eventPayload).withFixedDelay(1000))
-      .willSetStateTo("Event delivered"));
-    // avoid later reconnection
-    server.getMockServer().stubFor(get("/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
-      .inScenario("Single event")
-      .whenScenarioStateIs("Event delivered")
-      .willReturn(notFound()));
+      .willReturn(aResponse().proxiedFrom(sseServerUrl + "/api/push/sonarlint_events?projectKeys=" + projectKey + "&languages=java")
+        .withStatus(200)
+      ));
   }
 }

--- a/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import mediumtest.fixtures.SonarLintTestRpcServer;
 import mediumtest.fixtures.TestPlugin;
@@ -87,9 +88,9 @@ class IssueTrackingMediumTests {
   private SonarLintTestRpcServer backend;
 
   @AfterEach
-  void stop() {
+  void stop() throws ExecutionException, InterruptedException {
     if (backend != null) {
-      backend.shutdown();
+      backend.shutdown().get();
     }
   }
 

--- a/medium-tests/src/test/java/mediumtest/tracking/SecurityHotspotTrackingMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/tracking/SecurityHotspotTrackingMediumTests.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import mediumtest.fixtures.SonarLintTestRpcServer;
 import mediumtest.fixtures.TestPlugin;
 import org.junit.jupiter.api.AfterEach;
@@ -62,9 +63,9 @@ class SecurityHotspotTrackingMediumTests {
   private SonarLintTestRpcServer backend;
 
   @AfterEach
-  void stop() {
+  void stop() throws ExecutionException, InterruptedException {
     if (backend != null) {
-      backend.shutdown();
+      backend.shutdown().get();
     }
   }
 

--- a/medium-tests/src/test/java/testutils/LogTestStartAndEnd.java
+++ b/medium-tests/src/test/java/testutils/LogTestStartAndEnd.java
@@ -1,0 +1,40 @@
+/*
+ * SonarLint Core - Medium Tests
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package testutils;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class LogTestStartAndEnd implements BeforeEachCallback, AfterEachCallback {
+  @Override
+  public void beforeEach(ExtensionContext extensionContext) throws Exception {
+    extensionContext.getTestMethod().ifPresent(method -> {
+      System.out.printf(">>> Before test %s%n", method.getName());
+    });
+  }
+
+  @Override
+  public void afterEach(ExtensionContext extensionContext) throws Exception {
+    extensionContext.getTestMethod().ifPresent(method -> {
+      System.out.printf("<<< After test %s%n", method.getName());
+    });
+  }
+}

--- a/medium-tests/src/test/java/testutils/sse/SSEServer.java
+++ b/medium-tests/src/test/java/testutils/sse/SSEServer.java
@@ -1,0 +1,66 @@
+/*
+ * SonarLint Core - Medium Tests
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package testutils.sse;
+
+import java.io.File;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.Tomcat;
+
+public class SSEServer {
+
+  public static final int DEFAULT_PORT = 54321;
+  private Tomcat tomcat;
+  private SSEServlet sseServlet;
+
+  public void startWithEvent(String payload) {
+    try {
+      var baseDir = new File("").getAbsoluteFile().getParentFile().getPath();
+      tomcat = new Tomcat();
+      tomcat.setBaseDir(baseDir);
+      tomcat.setPort(DEFAULT_PORT);
+      var context = tomcat.addContext("", baseDir);
+      sseServlet = new SSEServlet(payload);
+      Tomcat.addServlet(context, "sse", sseServlet).addMapping("/");
+      // needed to start the endpoint
+      tomcat.getConnector();
+      tomcat.start();
+    } catch (LifecycleException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public void stop() {
+    try {
+      tomcat.stop();
+      tomcat.destroy();
+    } catch (LifecycleException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  public String getUrl() {
+    return "http://localhost:" + DEFAULT_PORT;
+  }
+
+  public void shouldSendServerEventOnce() {
+    sseServlet.shouldSendEventOnce();
+  }
+
+}

--- a/medium-tests/src/test/java/testutils/sse/SSEServlet.java
+++ b/medium-tests/src/test/java/testutils/sse/SSEServlet.java
@@ -1,0 +1,82 @@
+/*
+ * SonarLint Core - Medium Tests
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package testutils.sse;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.IOException;
+
+public class SSEServlet implements Servlet {
+
+  private final String payload;
+  private boolean shouldSendEvent = false;
+
+  public SSEServlet(String payload) {
+    this.payload = payload;
+  }
+
+  @Override
+  public void service(ServletRequest request, ServletResponse response) throws IOException {
+    response.setContentType("text/event-stream");
+    response.setCharacterEncoding("UTF-8");
+    while (true) {
+      if (shouldSendEvent) {
+        var writer = response.getWriter();
+        writer.write(payload);
+        writer.flush();
+        writer.close();
+        shouldSendEvent = false;
+      }
+      try {
+        Thread.sleep(100);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  @Override
+  public void init(ServletConfig config) throws ServletException {
+    // no-op
+  }
+
+  @Override
+  public ServletConfig getServletConfig() {
+    return null;
+  }
+
+  @Override
+  public String getServletInfo() {
+    return "Server Sent Event servlet";
+  }
+
+  @Override
+  public void destroy() {
+    // no-op
+  }
+
+
+  public void shouldSendEventOnce() {
+    this.shouldSendEvent = true;
+  }
+}


### PR DESCRIPTION
Main changes:
- Introducing ServerSentEvent server in tests to send server-sent events since WireMock doesn't allow sending them by command and relies on timeout.
- Change PluginStorage to avoid race condition between plugin downloading and cleanup.
- Improve assertions and logging for tests.