### PR TITLE
NO-JIRA: Removed doublet from API_CHANGES.md

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -48,20 +48,6 @@
   * `analyzeOpenFiles` forces analysis of all files that were reported as opened using `org.sonarsource.sonarlint.core.rpc.protocol.backend.file.FileRpcService#didOpenFile`
   * `analyzeVCSChangedFiles` forces analysis of modified and not committed files
 
-## New features
-
-* Add `showFixSuggestion` method to `org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcClient`
-  * It's only available when the feature flag `canOpenFixSuggestion` is enabled
-  * When using this method, you will receive a single fix suggestion for a specific issue that should be displayed to the user
-  * The user should have the possibility to accept or decline the fix suggestion
-  * The fix suggestion can be displayed at different locations in the file
-
-* Add `fixSuggestionResolved` method to `org.sonarsource.sonarlint.core.rpc.protocol.backend.telemetry.TelemetryRpcService`
-  * You should use this method whenever a fix suggestion has been accepted or declined
-  * If the fix has multiple changes (snippets), you should call the method once for each
-  * The `indexSnippet` should be filled if possible, it corresponds to the snippet index in the list of changes
-  * If you do not know if the fix was accepted or declined at the snippet level, you should call the method once for the whole fix
-
 # 10.3.2 
 
 ## Breaking changes


### PR DESCRIPTION
This content was twice in the file for the 10.4 release. The newer one is still kept above.