### PR TITLE
SLCORE-835: Revert removing GitUtils (and test)

### DIFF
--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/GitUtils.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/GitUtils.java
@@ -1,0 +1,133 @@
+/*
+ * SonarLint Core - Java Client Utils
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.client.utils;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.RepositoryBuilder;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.RevWalkUtils;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
+
+import static java.util.Comparator.naturalOrder;
+
+public class GitUtils {
+
+  private GitUtils() {
+    // util class
+  }
+
+  @CheckForNull
+  public static Repository getRepositoryForDir(Path projectDir, ClientLogOutput clientLogOutput) {
+    try {
+      var builder = new RepositoryBuilder()
+        .findGitDir(projectDir.toFile())
+        .setMustExist(true);
+      if (builder.getGitDir() == null) {
+        clientLogOutput.log("Not inside a Git work tree: " + projectDir, ClientLogOutput.Level.ERROR);
+        return null;
+      }
+      return builder.build();
+    } catch (IOException e) {
+      clientLogOutput.log("Couldn't access repository for path " + projectDir, ClientLogOutput.Level.ERROR);
+      clientLogOutput.log(ClientLogOutput.stackTraceToString(e), ClientLogOutput.Level.ERROR);
+    }
+    return null;
+  }
+
+  @CheckForNull
+  public static String electBestMatchingServerBranchForCurrentHead(Repository repo, Set<String> serverCandidateNames, @Nullable String serverMainBranch,
+    ClientLogOutput clientLogOutput) {
+    try {
+
+      String currentBranch = repo.getBranch();
+      if (currentBranch != null && serverCandidateNames.contains(currentBranch)) {
+        return currentBranch;
+      }
+
+      var head = repo.exactRef(Constants.HEAD);
+      if (head == null) {
+        // Not sure if this is possible to not have a HEAD, but just in case
+        return null;
+      }
+
+      Map<Integer, Set<String>> branchesPerDistance = new HashMap<>();
+      for (String serverBranchName : serverCandidateNames) {
+        var shortBranchName = Repository.shortenRefName(serverBranchName);
+        var localFullBranchName = Constants.R_HEADS + shortBranchName;
+
+        var branchRef = repo.exactRef(localFullBranchName);
+        if (branchRef == null) {
+          continue;
+        }
+
+        int distance = distance(repo, head, branchRef);
+        branchesPerDistance.computeIfAbsent(distance, d -> new HashSet<>()).add(serverBranchName);
+      }
+      if (branchesPerDistance.isEmpty()) {
+        return null;
+      }
+
+      int minDistance = branchesPerDistance.keySet().stream().min(naturalOrder()).get();
+      var bestCandidates = branchesPerDistance.get(minDistance);
+      if (serverMainBranch != null && bestCandidates.contains(serverMainBranch)) {
+        // Favor the main branch when there are multiple candidates with the same distance
+        return serverMainBranch;
+      }
+      return bestCandidates.iterator().next();
+    } catch (IOException e) {
+      clientLogOutput.log("Couldn't find best matching branch", ClientLogOutput.Level.ERROR);
+      clientLogOutput.log(ClientLogOutput.stackTraceToString(e), ClientLogOutput.Level.ERROR);
+      return null;
+    }
+  }
+
+  private static int distance(Repository repository, Ref from, Ref to) throws IOException {
+
+    try (var walk = new RevWalk(repository)) {
+
+      var fromCommit = walk.parseCommit(from.getObjectId());
+      var toCommit = walk.parseCommit(to.getObjectId());
+
+      walk.setRevFilter(RevFilter.MERGE_BASE);
+      walk.markStart(fromCommit);
+      walk.markStart(toCommit);
+      var mergeBase = walk.next();
+
+      walk.reset();
+      walk.setRevFilter(RevFilter.ALL);
+      int aheadCount = RevWalkUtils.count(walk, fromCommit, mergeBase);
+      int behindCount = RevWalkUtils.count(walk, toCommit,
+        mergeBase);
+
+      return aheadCount + behindCount;
+    }
+  }
+
+}

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/GitUtilsTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/GitUtilsTests.java
@@ -1,0 +1,191 @@
+/*
+ * SonarLint Core - Java Client Utils
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.client.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import org.eclipse.jgit.lib.RefDatabase;
+import org.eclipse.jgit.lib.Repository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static java.lang.String.format;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GitUtilsTests {
+
+  private ClientLogOutput fakeClientLogger = (m, l) -> {
+  };
+
+  @Test
+  void noGitRepoShouldBeNull(@TempDir File projectDir) throws IOException {
+    javaUnzip("no-git-repo.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "no-git-repo");
+    Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger);
+    assertThat(repo).isNull();
+  }
+
+  @Test
+  void gitRepoShouldBeNotNull(@TempDir File projectDir) throws IOException {
+    javaUnzip("dummy-git.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "dummy-git");
+    try (Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger)) {
+      Set<String> serverCandidateNames = Set.of("foo", "bar", "master");
+
+      String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, serverCandidateNames, "master", fakeClientLogger);
+      assertThat(branch).isEqualTo("master");
+    }
+  }
+
+  @Test
+  void shouldElectAnalyzedBranch(@TempDir File projectDir) throws IOException {
+    javaUnzip("analyzed-branch.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "analyzed-branch");
+    try (Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger)) {
+      Set<String> serverCandidateNames = Set.of("foo", "closest_branch", "master");
+
+      String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, serverCandidateNames, "master", fakeClientLogger);
+      assertThat(branch).isEqualTo("closest_branch");
+    }
+  }
+
+  @Test
+  void shouldReturnNullIfNonePresentInLocalGit(@TempDir File projectDir) throws IOException {
+    javaUnzip("analyzed-branch.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "analyzed-branch");
+    try (Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger)) {
+      Set<String> serverCandidateNames = Set.of("unknown1", "unknown2", "unknown3");
+
+      String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, serverCandidateNames, "master", fakeClientLogger);
+      assertThat(branch).isNull();
+    }
+  }
+
+  @Test
+  void shouldElectClosestBranch(@TempDir File projectDir) throws IOException {
+    javaUnzip("closest-branch.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "closest-branch");
+
+    try (Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger)) {
+
+      Set<String> serverCandidateNames = Set.of("foo", "closest_branch", "master");
+
+      String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, serverCandidateNames, "master", fakeClientLogger);
+      assertThat(branch).isEqualTo("closest_branch");
+    }
+  }
+
+  @Test
+  void shouldElectClosestBranch_even_if_no_main_branch(@TempDir File projectDir) throws IOException {
+    javaUnzip("closest-branch.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "closest-branch");
+
+    try (Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger)) {
+
+      Set<String> serverCandidateNames = Set.of("foo", "closest_branch", "master");
+
+      String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, serverCandidateNames, null, fakeClientLogger);
+      assertThat(branch).isEqualTo("closest_branch");
+    }
+  }
+
+  @Test
+  void shouldElectMainBranchForNonAnalyzedChildBranch(@TempDir File projectDir) throws IOException {
+    javaUnzip("child-from-non-analyzed.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "child-from-non-analyzed");
+    try (Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger)) {
+
+      Set<String> serverCandidateNames = Set.of("foo", "branch_to_analyze", "master");
+
+      String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, serverCandidateNames, "master", fakeClientLogger);
+      assertThat(branch).isEqualTo("master");
+    }
+  }
+
+  @Test
+  void shouldReturnNullOnException() throws IOException {
+    Repository repo = mock(Repository.class);
+    RefDatabase db = mock(RefDatabase.class);
+    when(repo.getRefDatabase()).thenReturn(db);
+    when(db.exactRef(anyString())).thenThrow(new IOException());
+
+    String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, Set.of("foo", "bar", "master"), "master", fakeClientLogger);
+
+    assertThat(branch).isNull();
+  }
+
+  @Test
+  void shouldFavorCurrentBranchIfMultipleCandidates(@TempDir File projectDir) throws IOException {
+    // Both main and same-as-master branches are pointing to HEAD, but same-as-master is the currently checked out branch
+    javaUnzip("two-branches-for-head.zip", projectDir);
+    Path path = Paths.get(projectDir.getPath(), "two-branches-for-head");
+    try (Repository repo = GitUtils.getRepositoryForDir(path, fakeClientLogger)) {
+
+      Set<String> serverCandidateNames = Set.of("main", "same-as-master", "another");
+
+      String branch = GitUtils.electBestMatchingServerBranchForCurrentHead(repo, serverCandidateNames, "main", fakeClientLogger);
+      assertThat(branch).isEqualTo("same-as-master");
+    }
+  }
+
+  public void javaUnzip(String zipFileName, File toDir) throws IOException {
+    File testRepos = new File("src/test/test-repos");
+    File zipFile = new File(testRepos, zipFileName);
+    javaUnzip(zipFile, toDir);
+  }
+
+  private static void javaUnzip(File zip, File toDir) {
+    try {
+      try (ZipFile zipFile = new ZipFile(zip)) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+          ZipEntry entry = entries.nextElement();
+          File to = new File(toDir, entry.getName());
+          if (entry.isDirectory()) {
+            forceMkdir(to);
+          } else {
+            File parent = to.getParentFile();
+            forceMkdir(parent);
+
+            Files.copy(zipFile.getInputStream(entry), to.toPath());
+          }
+        }
+      }
+    } catch (Exception e) {
+      throw new IllegalStateException(format("Fail to unzip %s to %s", zip, toDir), e);
+    }
+  }
+
+  private static void forceMkdir(final File directory) throws IOException {
+    if ((directory != null) && (!directory.mkdirs() && !directory.isDirectory())) {
+      throw new IOException("Cannot create directory '" + directory + "'.");
+    }
+  }
+}


### PR DESCRIPTION
This reverts the removal of the GitUtils class inside the "sonarlint-java-client-utils" module that is still used on SonarLint for Eclipse. As no replacement was introduced, this had to be put back.

Referencing the commit that removed it: [082c0cac9a6a873b4c1d71782dd0433a5d45d47e](https://github.com/SonarSource/sonarlint-core/commit/082c0cac9a6a873b4c1d71782dd0433a5d45d47e#diff-f5665894ddbe8c7c0d31c280d252be39012e245178ab1ddf1f659afdb2afabcf)