### PR TITLE
SLCORE-919 Files are ignored by application of .gitignore when they should not

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
@@ -1,0 +1,84 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) 2016-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons.util;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+
+public class FileUtils {
+
+  private static final SonarLintLogger LOG = SonarLintLogger.get();
+
+  private FileUtils() {
+    // utility class
+  }
+
+  public static String getFileRelativePath(Path gitRepoBaseDir, URI fileUri, boolean addCommonPath) {
+    var filePath = Path.of(fileUri);
+    LOG.debug("Relativizing path: {} for git repo {}", filePath, gitRepoBaseDir);
+
+    var filePathDirectories = getPathDirectories(filePath);
+    var baseDirDirectories = getPathDirectories(gitRepoBaseDir);
+    return findFuzzyRelativeFilePath(baseDirDirectories, filePathDirectories, addCommonPath);
+  }
+
+  public static List<String> getPathDirectories(Path file) {
+    var directories = new ArrayList<String>();
+    do {
+      directories.add(file.getFileName().toString());
+      file = file.getParent();
+    } while (file.getParent() != null);
+    if (file.getFileName() != null) {
+      directories.add(file.getFileName().toString());
+    }
+    Collections.reverse(directories);
+    return directories;
+  }
+
+  public static String findFuzzyRelativeFilePath(List<String> baseDir, List<String> filePath, boolean addCommonPath) {
+    var relativeFilePath = new ArrayList<String>();
+    var baseDirPointer = 0;
+    var filePathPointer = 0;
+
+    while (baseDirPointer < baseDir.size() && filePathPointer < filePath.size()) {
+      var baseDirElement = baseDir.get(baseDirPointer);
+      var filePathElement = filePath.get(filePathPointer);
+      if (!baseDirElement.equals(filePathElement)) {
+        filePathPointer++;
+      } else {
+        baseDirPointer++;
+        filePathPointer++;
+        if (addCommonPath) {
+          relativeFilePath.add(filePathElement);
+        }
+      }
+    }
+    while (filePathPointer < filePath.size()) {
+      relativeFilePath.add(filePath.get(filePathPointer));
+      filePathPointer++;
+    }
+    return String.join("/", relativeFilePath);
+  }
+
+}

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
@@ -49,9 +49,6 @@ public class FileUtils {
       directories.add(file.getFileName().toString());
       file = file.getParent();
     } while (file.getParent() != null);
-    if (file.getFileName() != null) {
-      directories.add(file.getFileName().toString());
-    }
     Collections.reverse(directories);
     return directories;
   }

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
@@ -56,7 +56,6 @@ public class GitUtils {
 
   private static final SonarLintLogger LOG = SonarLintLogger.get();
 
-
   private GitUtils() {
     // Utility class
   }
@@ -142,14 +141,14 @@ public class GitUtils {
       var gitRepo = buildGitRepository(baseDir);
       var gitRepoRelativeProjectBaseDir = getRelativePath(gitRepo, baseDir);
       var ignoreNode = buildIgnoreNode(gitRepo);
-      return new SonarLintGitIgnore(ignoreNode, gitRepoRelativeProjectBaseDir);
+      return new SonarLintGitIgnore(ignoreNode, gitRepoRelativeProjectBaseDir, baseDir);
     } catch (GitRepoNotFoundException e) {
       LOG.info("Git Repository not found for {}. The path {} is not in a Git repository", baseDir, e.getPath());
     } catch (Exception e) {
       LOG.warn("Error occurred while reading .gitignore file: ", e);
       LOG.warn("Building empty ignore node with no rules. Files checked against this node will be considered as not ignored.");
     }
-    return new SonarLintGitIgnore(new IgnoreNode(), baseDir);
+    return new SonarLintGitIgnore(new IgnoreNode(), null, baseDir);
   }
 
   private static Path getRelativePath(Repository gitRepo, Path projectBaseDir) {

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarsource.sonarlint.core.commons.log.LogOutput;
@@ -61,6 +62,7 @@ import static org.sonarsource.sonarlint.core.commons.testutils.GitUtils.modifyFi
 import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.blameWithFilesGitCommand;
 import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.getVSCChangedFiles;
 
+@ExtendWith(LogTestStartAndEnd.class)
 class GitUtilsTest {
 
   @RegisterExtension
@@ -277,6 +279,16 @@ class GitUtilsTest {
 
     assertThat(sonarLintGitIgnore.isIgnored(URI.create("temp:///file/path"), false)).isFalse();
     assertThat(sonarLintGitIgnore.isIgnored(URI.create("http:///localhost:12345/file/path"), false)).isFalse();
+  }
+
+  @Test
+  void should_respect_gitignore_rules() throws IOException {
+    Files.write(projectDirPath.resolve(GITIGNORE_FILENAME), List.of("app/", "!frontend/app/"), java.nio.file.StandardOpenOption.CREATE);
+    var sonarLintGitIgnore = GitUtils.createSonarLintGitIgnore(projectDirPath);
+
+    assertThat(sonarLintGitIgnore.isIgnored(projectDirPath.resolve("frontend/app/should_not_be_ignored.js").toUri(), false)).isFalse();
+    assertThat(sonarLintGitIgnore.isIgnored(projectDirPath.resolve("should_be_ignored.js").toUri(), false)).isFalse();
+    assertThat(sonarLintGitIgnore.isIgnored(projectDirPath.resolve("app/should_be_ignored.js").toUri(), false)).isTrue();
   }
 
   @Test

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
@@ -295,9 +295,9 @@ class GitUtilsTest {
   void createSonarLintGitIgnore_works_for_bare_repos_too() {
     var sonarLintGitIgnore = GitUtils.createSonarLintGitIgnore(bareRepoPath);
 
-    assertThat(sonarLintGitIgnore.isFileIgnored(Path.of("file.txt").toUri())).isFalse();
-    assertThat(sonarLintGitIgnore.isFileIgnored(Path.of("file.tmp").toUri())).isTrue();
-    assertThat(sonarLintGitIgnore.isFileIgnored(Path.of("file.log").toUri())).isTrue();
+    assertThat(sonarLintGitIgnore.isFileIgnored(bareRepoPath.resolve("file.txt").toUri())).isFalse();
+    assertThat(sonarLintGitIgnore.isFileIgnored(bareRepoPath.resolve("file.tmp").toUri())).isTrue();
+    assertThat(sonarLintGitIgnore.isFileIgnored(bareRepoPath.resolve("file.log").toUri())).isTrue();
   }
 
   @Test

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/LogTestStartAndEnd.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/LogTestStartAndEnd.java
@@ -1,5 +1,5 @@
 /*
- * SonarLint Core - Medium Tests
+ * SonarLint Core - Commons
  * Copyright (C) 2016-2024 SonarSource SA
  * mailto:info AT sonarsource DOT com
  *
@@ -17,7 +17,8 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package testutils;
+
+package org.sonarsource.sonarlint.core.commons;
 
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;

--- a/medium-tests/src/test/java/mediumtest/analysis/AnalysisMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/AnalysisMediumTests.java
@@ -67,7 +67,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.RuleType;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SoftwareQuality;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TextRangeDto;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import testutils.OnDiskTestClientInputFile;
 
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;

--- a/medium-tests/src/test/java/mediumtest/analysis/AnalysysForcedByClientMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/AnalysysForcedByClientMediumTests.java
@@ -42,7 +42,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeVCSCh
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidOpenFileParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 
 import static mediumtest.fixtures.ServerFixture.newSonarQubeServer;
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotEventsMediumTests.java
@@ -46,7 +46,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.HotspotStatus
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
 import org.sonarsource.sonarlint.core.serverapi.hotspot.ServerHotspot;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import testutils.sse.SSEServer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotLocalDetectionSupportMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotLocalDetectionSupportMediumTests.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcServer;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckLocalDetectionSupportedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckLocalDetectionSupportedResponse;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 
 import static mediumtest.fixtures.SonarLintBackendFixture.newBackend;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/medium-tests/src/test/java/mediumtest/issues/IssueEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/IssueEventsMediumTests.java
@@ -42,7 +42,7 @@ import org.sonarsource.sonarlint.core.commons.api.TextRange;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
 import org.sonarsource.sonarlint.core.serverconnection.issues.ServerIssue;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import testutils.sse.SSEServer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/medium-tests/src/test/java/mediumtest/rules/RuleEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/rules/RuleEventsMediumTests.java
@@ -40,7 +40,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
 import org.sonarsource.sonarlint.core.serverconnection.proto.Sonarlint;
 import org.sonarsource.sonarlint.core.serverconnection.storage.ProtobufFileUtil;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import testutils.sse.SSEServer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
@@ -57,7 +57,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.Son
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TaintVulnerabilityDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TextRangeWithHashDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.IssueSeverity;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import testutils.sse.SSEServer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;

--- a/medium-tests/src/test/java/mediumtest/synchronization/PluginSynchronizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/synchronization/PluginSynchronizationMediumTests.java
@@ -34,7 +34,7 @@ import org.sonarsource.sonarlint.core.serverconnection.proto.Sonarlint;
 import org.sonarsource.sonarlint.core.serverconnection.proto.Sonarlint.PluginReferences.PluginReference;
 import org.sonarsource.sonarlint.core.serverconnection.storage.PluginsStorage;
 import org.sonarsource.sonarlint.core.serverconnection.storage.ProtobufFileUtil;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import testutils.PluginLocator;
 
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilityEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilityEventsMediumTests.java
@@ -47,7 +47,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.common.CleanCodeAttribute;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ImpactSeverity;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SoftwareQuality;
 import org.sonarsource.sonarlint.core.serverconnection.issues.ServerTaintIssue;
-import testutils.LogTestStartAndEnd;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import testutils.sse.SSEServer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;


### PR DESCRIPTION
In case the git repo path is the same as the base project dir (which should be very often), `gitRepoRelativeProjectBaseDir` was resolved to an empty path, so the file path was resolved as an absolute one, not a relative one. So, matching wasn't working.
I've tested manually with the provided reproducer repo:
https://github.com/jblievremont/sample-gitignore-priority
Now it behaves as expected.

UPD:
The problem was that we were supposed to do very different things for the case when we used base project dir as a base and in the case when it's a git directory relative to the base project dir. We need to resolve the relative file path to compute if it's ignored, but we should do it in a bit different way. Previously, we had one code doing it, and it was incorrect for one case or another.