### PR TITLE
BUILD-6160 downgrade maven-javadoc-plugin to 3.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
+          <version>3.8.0</version>
           <configuration>
             <source>11</source>
           </configuration>


### PR DESCRIPTION
This is a temporary workaround for https://sonarsource.atlassian.net/browse/BUILD-6160 to allow releasing.
A later fix will be committed in the parent-oss POM and this workaround will be removable.

Issue reproduced by https://github.com/SonarSource/sonarlint-core/pull/1089/checks?check_run_id=29575053853
Workaround tested with https://github.com/SonarSource/sonarlint-core/pull/1089/checks?check_run_id=29575934360
