### PR TITLE
BUILD-6160 emptyJavadoc

### DIFF
--- a/client/java-client-dependencies/pom.xml
+++ b/client/java-client-dependencies/pom.xml
@@ -28,24 +28,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>empty-javadoc-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <classifier>javadoc</classifier>
-              <classesDirectory>${basedir}/javadoc</classesDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>

--- a/client/java-client-osgi/pom.xml
+++ b/client/java-client-osgi/pom.xml
@@ -42,24 +42,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>empty-javadoc-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <classifier>javadoc</classifier>
-              <classesDirectory>${basedir}/javadoc</classesDirectory>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.8.0</version>
           <configuration>
             <source>11</source>
           </configuration>


### PR DESCRIPTION
[BUILD-6160](https://sonarsource.atlassian.net/browse/BUILD-6160)

Proper fix to the broken promotion.

The breakage was due to duplicated Javadoc artifacts generated and attached to the build.
As of maven-javadoc-plugin 3.10.0, the empty Javadoc is generated by default.

As suggested in https://github.com/apache/maven-javadoc-plugin/pull/65 by the following sentence:
> Add generateIfEmpty property to javadoc:jar goal, defaulting to false for backwards compatibility.

maven-javadoc-plugin 3.10.0 defaults to true, with no customization property.

This fix was confirmed by https://cirrus-ci.com/build/5445574646824960



[BUILD-6160]: https://sonarsource.atlassian.net/browse/BUILD-6160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ