### PR TITLE
SLCORE-942: Don't show exception when no Gitignore found

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
@@ -21,6 +21,7 @@ package org.sonarsource.sonarlint.core.commons.util.git;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -145,6 +146,8 @@ public class GitUtils {
       return new SonarLintGitIgnore(ignoreNode, gitRepoRelativeProjectBaseDir);
     } catch (GitRepoNotFoundException e) {
       LOG.info("Git Repository not found for {}. The path {} is not in a Git repository", baseDir, e.getPath());
+    } catch (FileNotFoundException e) {
+      LOG.info(".gitignore file was not found for {}", baseDir);
     } catch (Exception e) {
       LOG.warn("Error occurred while reading .gitignore file: ", e);
       LOG.warn("Building empty ignore node with no rules. Files checked against this node will be considered as not ignored.");

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
@@ -246,9 +246,9 @@ class GitUtilsTest {
       .hasSize(1)
       .containsExactly(fileAUri);
   }
-
+  
   @Test
-  void should_consider_all_files_not_ignored_on_exception() throws IOException {
+  void should_consider_all_files_not_ignored_on_gitignore() throws IOException {
     createFile(projectDirPath, "fileA", "line1", "line2", "line3");
     createFile(projectDirPath, "fileB", "line1", "line2", "line3");
     createFile(projectDirPath, "fileC", "line1", "line2", "line3");
@@ -262,9 +262,8 @@ class GitUtilsTest {
 
     var sonarLintGitIgnore = GitUtils.createSonarLintGitIgnore(projectDirPath);
 
-    assertThat(logTester.logs(LogOutput.Level.WARN))
-      .anyMatch(s -> s.contains("Error occurred while reading .gitignore file"))
-      .anyMatch(s -> s.contains("Building empty ignore node with no rules. Files checked against this node will be considered as not ignored"));
+    assertThat(logTester.logs(LogOutput.Level.INFO))
+      .anyMatch(s -> s.contains(".gitignore file was not found for "));
 
     assertThat(Stream.of(fileAUri, fileBUri, fileCUri).filter(not(sonarLintGitIgnore::isFileIgnored)).collect(Collectors.toList()))
       .hasSize(3)


### PR DESCRIPTION
[SLCORE-942](https://sonarsource.atlassian.net/browse/SLCORE-942)

When no ".gitignore" file was found, just inform about it instead of showing the error message and and misleading information that is only relevant for when actual exceptions happen.

[SLCORE-942]: https://sonarsource.atlassian.net/browse/SLCORE-942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ