### PR TITLE
SLCORE-935: Clean temp directory after 7 days

### DIFF
--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolderProvider.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/global/GlobalTempFolderProvider.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Bean;
 public class GlobalTempFolderProvider {
 
   private static final SonarLintLogger LOG = SonarLintLogger.get();
-  private static final long CLEAN_MAX_AGE = TimeUnit.DAYS.toMillis(21);
+  private static final long CLEAN_MAX_AGE = TimeUnit.DAYS.toMillis(7);
   private static final String TMP_NAME_PREFIX = ".sonarlinttmp_";
 
   private GlobalTempFolder tempFolder;


### PR DESCRIPTION
[SLCORE-935](https://sonarsource.atlassian.net/browse/SLCORE-935)

We clean the temporary directory more often to have smaller footprint than only doing it for files older than 21 days.

[SLCORE-935]: https://sonarsource.atlassian.net/browse/SLCORE-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ