### PR TITLE
SLCORE-927 Reactivate git blaming for bare repositories

### DIFF
--- a/backend/commons/pom.xml
+++ b/backend/commons/pom.xml
@@ -18,7 +18,7 @@
     <dependency>
         <groupId>org.sonarsource.git.blame</groupId>
         <artifactId>git-files-blame</artifactId>
-      <version>1.0.3.1673</version>
+      <version>1.1.0.1835</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
@@ -87,11 +87,7 @@ public class GitUtils {
   public static SonarLintBlameResult blameWithFilesGitCommand(Path projectBaseDir, Set<Path> projectBaseRelativeFilePaths, @Nullable UnaryOperator<String> fileContentProvider) {
     var gitRepo = buildGitRepository(projectBaseDir);
 
-    if (gitRepo.isBare()) {
-      throw new IllegalStateException("GitRepo is a bare repository");
-    }
-
-    var gitRepoRelativeProjectBaseDir = gitRepo.getWorkTree().toPath().relativize(projectBaseDir);
+    var gitRepoRelativeProjectBaseDir = getRelativePath(gitRepo, projectBaseDir);
 
     var gitRepoRelativeFilePaths = projectBaseRelativeFilePaths.stream()
       .map(gitRepoRelativeProjectBaseDir::resolve)

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/GitUtilsTest.java
@@ -53,7 +53,6 @@ import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jgit.lib.Constants.GITIGNORE_FILENAME;
 import static org.eclipse.jgit.util.FileUtils.RECURSIVE;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.sonarsource.sonarlint.core.commons.testutils.GitUtils.addFileToGitIgnoreAndCommit;
 import static org.sonarsource.sonarlint.core.commons.testutils.GitUtils.commit;
 import static org.sonarsource.sonarlint.core.commons.testutils.GitUtils.createFile;
@@ -76,7 +75,11 @@ class GitUtilsTest {
 
   @BeforeAll
   public static void beforeAll() throws GitAPIException, IOException {
-    setUpBareRepo(Map.of(".gitignore", "*.log\n*.tmp\n"));
+    setUpBareRepo(Map.of(
+      ".gitignore", "*.log\n*.tmp\n",
+      "fileA", "lineA1\nlineA2\n",
+      "fileB", "lineB1\nlineB2\n"
+    ));
   }
 
   @AfterAll
@@ -321,12 +324,13 @@ class GitUtilsTest {
   }
 
   @Test
-  void git_blame_throws_illegal_state_exception_if_repo_is_bare() {
-    Set<Path> emptySet = Set.of();
+  void git_blame_works_for_bare_repos_too() {
+    var sonarLintBlameResult = blameWithFilesGitCommand(bareRepoPath, Stream.of("fileA", "fileB").map(Path::of).collect(Collectors.toSet()));
 
-    var e = assertThrows(IllegalStateException.class, () -> GitUtils.blameWithFilesGitCommand(bareRepoPath, emptySet));
-
-    assertThat(e).hasMessage("GitRepo is a bare repository");
+    assertThat(sonarLintBlameResult.getLatestChangeDateForLinesInFile(Path.of("fileA"), List.of(1, 2))).isPresent();
+    assertThat(sonarLintBlameResult.getLatestChangeDateForLinesInFile(Path.of("fileA"), List.of(3))).isEmpty();
+    assertThat(sonarLintBlameResult.getLatestChangeDateForLinesInFile(Path.of("fileB"), List.of(1, 2))).isPresent();
+    assertThat(sonarLintBlameResult.getLatestChangeDateForLinesInFile(Path.of("fileB"), List.of(3))).isEmpty();
   }
 
   private static void setUpBareRepo(Map<String, String> filePathContentMap) throws IOException, GitAPIException {


### PR DESCRIPTION
[SLCORE-927](https://sonarsource.atlassian.net/browse/SLCORE-927)


# For SonarSourcers:

- [x] Prefix the commit message with the ticket number, i.e. `SLCORE-XXXX` if you already have a ticket in Jira
- [ ] For standalone PRs without issue in Jira:
    - [ ] Mention Epic ID in this descrition to create a new Task in Jira
    - [ ] Mention Issue ID in this descrition to create a new Sub-Task in Jira
    - [ ] Do not mention any Jira issue to create a new Task in Jira without a parent
- [ ] When changing an API:
    - [ ] Explain in the JavaDoc the purpose of the new API
    - [ ] Document the change in [API_CHANGES.md](https://github.com/SonarSource/sonarlint-core/blob/master/API_CHANGES.md)
    - [ ] If the change breaks the current API, explicitly communicate those to the impacted consumers prior to merging (eg. IDE squad)
- [ ] Make sure the tests adhere to the convention:
    - [ ] All test method names should use `snake_case`, for example: `test_validate_input`.
- [ ] Make sure checks are green: build passes, Quality Gate is green

# For external contributors:

In addition to the above, please review our [contribution guidelines](https://github.com/SonarSource/sonarlint-core/blob/master/docs/contributing.md) and ensure your pull request adheres to the following guidelines:

- [ ] Please explain your motives to contribute this change: what problem you are trying to fix, what improvement you are trying to make
- [ ] Use the following formatting style: [SonarSource/sonar-developer-toolset](https://github.com/SonarSource/sonar-developer-toolset#code-style)
- [ ] Provide a unit test for any code you changed


[SLCORE-927]: https://sonarsource.atlassian.net/browse/SLCORE-927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ