### PR TITLE
SLCORE-1029: Shade/relocate JGit into OSGi bundle

### DIFF
--- a/client/java-client-dependencies/pom.xml
+++ b/client/java-client-dependencies/pom.xml
@@ -22,6 +22,16 @@
       <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
       <version>${lsp4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit</artifactId>
+      <version>${jgit.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -48,6 +58,8 @@
             <includes>
               <include>com.google.code.gson:gson</include>
               <include>org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc</include>
+              <include>org.eclipse.jgit:org.eclipse.jgit</include>
+              <include>org.slf4j:slf4j-api</include>
             </includes>
           </artifactSet>
 
@@ -59,6 +71,8 @@
               <includes>
                 <include>com.google.gson.**</include>
                 <include>org.eclipse.lsp4j.**</include>
+                <include>org.eclipse.jgit.**</include>
+                <include>org.slf4j.**</include>
               </includes>
             </relocation>
           </relocations>
@@ -69,11 +83,13 @@
               <artifact>*:*</artifact>
               <excludes>
                 <exclude>module-info.class</exclude>
+                <exclude>about.html</exclude>
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>
                 <exclude>META-INF/LICENSE*</exclude>
                 <exclude>META-INF/NOTICE*</exclude>
+                <exclude>OSGI-INF/</exclude>
                 <exclude>LICENSE*</exclude>
                 <exclude>NOTICE*</exclude>
                 <exclude>*.proto</exclude>

--- a/client/java-client-osgi/java-client-osgi.bnd
+++ b/client/java-client-osgi/java-client-osgi.bnd
@@ -8,9 +8,10 @@ Export-Package: org.sonarsource.sonarlint.core.client.legacy.*;version="${projec
   org.sonarsource.sonarlint.core.rpc.client.*;version="${project.version}",\
   org.sonarsource.sonarlint.core.rpc.protocol.*;version="${project.version}",\
   org.sonarsource.sonarlint.shaded.com.google.gson.*;version="${gson.version}",\
-  org.sonarsource.sonarlint.shaded.org.eclipse.lsp4j.jsonrpc.*;version="${lsp4j.version}",
-Import-Package: javax.annotation.*;resolution:=optional,\
-  org.eclipse.jgit.*;resolution:=optional,
+  org.sonarsource.sonarlint.shaded.org.eclipse.lsp4j.jsonrpc.*;version="${lsp4j.version}",\
+  org.sonarsource.sonarlint.shaded.org.eclipse.jgit.*;version="${jgit.version}",\
+  org.sonarsource.sonarlint.shaded.org.slf4j.*;version="${slf4j.version}",
+Import-Package: javax.annotation.*;resolution:=optional,
 
 # BND configuration to export packages from 'sonarlint-analysis-engine.jar' / 'sonarlint-common.jar' / 'sonarlint-plugins-commons.jar'
 # without copying them from the included JAR archive (resource, see instruction below) to the normal JAR archive!

--- a/client/java-client-osgi/pom.xml
+++ b/client/java-client-osgi/pom.xml
@@ -137,6 +137,8 @@
               <includes>
                 <include>com.google.gson.**</include>
                 <include>org.eclipse.lsp4j.**</include>
+                <include>org.eclipse.jgit.**</include>
+                <include>org.slf4j.**</include>
               </includes>
             </relocation>
           </relocations>

--- a/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
+++ b/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
@@ -837,8 +837,13 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
 
       assertThat(taintVulnerability.getType()).isEqualTo(org.sonarsource.sonarlint.core.rpc.protocol.common.RuleType.VULNERABILITY);
       assertThat(taintVulnerability.getRuleDescriptionContextKey()).isEqualTo("java_se");
-      if (ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(10, 2)) {
+      if (ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(10, 8)) {
         assertThat(taintVulnerability.getCleanCodeAttribute()).isEqualTo(CleanCodeAttribute.COMPLETE);
+        // In SQ 10.8+, old MAJOR severity maps to overridden MEDIUM impact
+        assertThat(taintVulnerability.getImpacts()).containsExactly(entry(SoftwareQuality.SECURITY, ImpactSeverity.MEDIUM));
+      } else if (ORCHESTRATOR.getServer().version().isGreaterThanOrEquals(10, 2)) {
+        assertThat(taintVulnerability.getCleanCodeAttribute()).isEqualTo(CleanCodeAttribute.COMPLETE);
+        // In 10.2 <= SQ < 10.8, the impact severity is not overridden
         assertThat(taintVulnerability.getImpacts()).containsExactly(entry(SoftwareQuality.SECURITY, ImpactSeverity.HIGH));
       } else {
         assertThat(taintVulnerability.getCleanCodeAttribute()).isNull();


### PR DESCRIPTION
[SLCORE-1029](https://sonarsource.atlassian.net/browse/SLCORE-1029)

Shading/relocating JGit (and its required dependency SLF4J) into the OSGi bundle in order to work properly on Eclipse again for the patch release 10.9.1 planned, see [SonarSource/sonarlint-eclipse#761](https://github.com/SonarSource/sonarlint-eclipse/pull/761).
On SonarLint for Eclipse the incompatible dependency with EGit/JGit (bundled with the IDE, not from us, requiring Java 17 now) is dropped and replaced by this.

In order to satisfy the pipeline gods a test was fixed in a separate cherry-picked commit for ITs against SQ DEV.

[SLCORE-1029]: https://sonarsource.atlassian.net/browse/SLCORE-1029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ