### PR TITLE
SLCORE-1048 Use fixed development reference for SQ instead of version number

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -188,7 +188,7 @@ qa_task:
           SONARCLOUD_IT_PASSWORD: VAULT[development/team/sonarlint/kv/data/sonarcloud-it data.password]
           QA_CATEGORY: SonarCloud
       -  env:
-          SQ_VERSION: "10.8.0.99052"
+          SQ_VERSION: "DEV[10.8]"
           JDK_VERSION: "17"
           CATEGORY: "-DexcludedGroups=SonarCloud"
           QA_CATEGORY: SQDogfood


### PR DESCRIPTION
[SLCORE-1048](https://sonarsource.atlassian.net/browse/SLCORE-1048)

This is done by other repos as well for now until Orchestrator is fixed.

[SLCORE-1048]: https://sonarsource.atlassian.net/browse/SLCORE-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ