### PR TITLE
SLCORE-1049: Fix condition for using SonarText from server

### DIFF
--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/LocalStorageSynchronizer.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/LocalStorageSynchronizer.java
@@ -55,7 +55,7 @@ public class LocalStorageSynchronizer {
     // On SonarQube server 10.4+ and SonarQube Cloud, we need to use the server's text analyzer
     // to support commercial rules (SQC and SQS 10.8+ DE+) and custom secrets (SQS 10.4+ EE+)
     var useSecretsFromServer = serverApi.isSonarCloud()
-      && version.compareToIgnoreQualifier(CUSTOM_SECRETS_MIN_SQ_VERSION) >= 0;
+      || version.compareToIgnoreQualifier(CUSTOM_SECRETS_MIN_SQ_VERSION) >= 0;
     return pluginsSynchronizer.synchronize(serverApi, useSecretsFromServer, cancelMonitor);
   }
 


### PR DESCRIPTION
[SLCORE-1049](https://sonarsource.atlassian.net/browse/SLCORE-1049)

On SonarQube Cloud OR SonarQube Server 10.4+ we download specific version of the SonarText analyzer in Connected Mode.

[SLCORE-1049]: https://sonarsource.atlassian.net/browse/SLCORE-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ