### PR TITLE
SLCORE-716: Move most of the code base to Java 17

### DIFF
--- a/client/java-client-dependencies/pom.xml
+++ b/client/java-client-dependencies/pom.xml
@@ -10,6 +10,14 @@
   <artifactId>sonarlint-java-client-dependencies</artifactId>
   <name>SonarLint Core - Java Client dependencies</name>
   <description>Dependencies used by the Java Clients, shaded and relocated together</description>
+  
+  <properties>
+    <!--
+      As this is a dependency of the SonarLint Core OSGi bundle that is used on
+      SonarQube for Eclipse, we have to stick to Java 11 for the compiler!
+    -->
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/client/java-client-osgi/java-client-osgi.bnd
+++ b/client/java-client-osgi/java-client-osgi.bnd
@@ -3,8 +3,7 @@
 
 # Manifest entries to configure the OSGi attributes for the normal JAR archive
 Bundle-SymbolicName: ${project.groupId}.${project.artifactId}
-Export-Package: org.sonarsource.sonarlint.core.commons.api.*;version="${project.version}",\
-  org.sonarsource.sonarlint.core.client.utils.*;version="${project.version}",\
+Export-Package: org.sonarsource.sonarlint.core.client.utils.*;version="${project.version}",\
   org.sonarsource.sonarlint.core.rpc.client.*;version="${project.version}",\
   org.sonarsource.sonarlint.core.rpc.protocol.*;version="${project.version}",\
   org.sonarsource.sonarlint.shaded.com.google.gson.*;version="${gson.version}",\

--- a/client/java-client-osgi/pom.xml
+++ b/client/java-client-osgi/pom.xml
@@ -14,11 +14,6 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>sonarlint-commons</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>sonarlint-java-client-dependencies</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/client/java-client-osgi/pom.xml
+++ b/client/java-client-osgi/pom.xml
@@ -10,6 +10,14 @@
   <artifactId>sonarlint-java-client-osgi</artifactId>
   <name>SonarLint Core - Java Client OSGi</name>
   <description>Common SonarLint features bundled for OSGi</description>
+  
+  <properties>
+    <!--
+      As this creates the OSGi bundle that is used on SonarQube for Eclipse, we
+      have to stick to Java 11 for the compiler!
+    -->
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/client/java-client-utils/pom.xml
+++ b/client/java-client-utils/pom.xml
@@ -10,6 +10,14 @@
   <artifactId>sonarlint-java-client-utils</artifactId>
   <name>SonarLint Core - Java Client Utils</name>
   <description>Utility classes for Java clients</description>
+  
+  <properties>
+    <!--
+      As this is a dependency of the SonarLint Core OSGi bundle that is used on
+      SonarQube for Eclipse, we have to stick to Java 11 for the compiler!
+    -->
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/client/rpc-java-client/pom.xml
+++ b/client/rpc-java-client/pom.xml
@@ -10,6 +10,15 @@
   <artifactId>sonarlint-rpc-java-client</artifactId>
   <name>SonarLint Core - RPC Java Client</name>
   <description>Java client for SonarLint RPC</description>
+  
+  <properties>
+    <!--
+      As this is a dependency of the SonarLint Core OSGi bundle that is used on
+      SonarQube for Eclipse, we have to stick to Java 11 for the compiler!
+    -->
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
+  
   <dependencies>
     <dependency>
       <groupId>com.google.code.findbugs</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,13 @@
   <properties>
     <license.name>GNU LGPL v3</license.name>
     
-    <maven.compiler.release>11</maven.compiler.release>
+    <!--
+      Most of SonarLint Core is build using Java 17 except for the modules that
+      are dependencies for the SonarLint Core OSGi bundle that is used on
+      SonarQube for Eclipse which itself compiles with Java 11!
+    -->
+    <maven.compiler.release>17</maven.compiler.release>
+    
     <sonar-plugin-api.version>11.1.0.2693</sonar-plugin-api.version>
     <sonar-markdown.version>9.4.0.54424</sonar-markdown.version>
     <sonar-scanner-protocol.version>9.9.0.65466</sonar-scanner-protocol.version>

--- a/rpc-protocol/pom.xml
+++ b/rpc-protocol/pom.xml
@@ -12,6 +12,14 @@
   <artifactId>sonarlint-rpc-protocol</artifactId>
   <name>SonarLint Core - RPC Protocol</name>
   <description>Protocol used to communicate with clients (IDEs) through RPC</description>
+  
+  <properties>
+    <!--
+      As this is a dependency of the SonarLint Core OSGi bundle that is used on
+      SonarQube for Eclipse, we have to stick to Java 11 for the compiler!
+    -->
+    <maven.compiler.release>11</maven.compiler.release>
+  </properties>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
[SLCORE-716](https://sonarsource.atlassian.net/browse/SLCORE-716)

## Summary

Remove the `sonarlint-commons` module from the OSGi bundle that is used by SonarQube for Eclipse as it is not required anymore.

Move all but the modules required for the OSGi bundle to Java 17.

[SLCORE-716]: https://sonarsource.atlassian.net/browse/SLCORE-716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ