### PR TITLE
SLCORE-1140: Don't log an error when not in Git repository

### DIFF
--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/GitUtils.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/GitUtils.java
@@ -50,7 +50,7 @@ public class GitUtils {
         .findGitDir(projectDir.toFile())
         .setMustExist(true);
       if (builder.getGitDir() == null) {
-        clientLogOutput.log("Not inside a Git work tree: " + projectDir, ClientLogOutput.Level.ERROR);
+        clientLogOutput.log("Not inside a Git work tree: " + projectDir, ClientLogOutput.Level.DEBUG);
         return null;
       }
       return builder.build();


### PR DESCRIPTION
[SLCORE-1140](https://sonarsource.atlassian.net/browse/SLCORE-1140)

Currently when users are not in a Git repository there is an error logged for every action trying to invoke Git. This is too noisy and misleading as this is not an actual error.

[SLCORE-1140]: https://sonarsource.atlassian.net/browse/SLCORE-1140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ