### PR TITLE
SLCORE-1141: Don't log an error when closed projects removed

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
@@ -85,7 +85,7 @@ public class ConfigurationService {
   public void didRemoveConfigurationScope(String removedId) {
     var removed = repository.remove(removedId);
     if (removed == null) {
-      LOG.error("Attempt to remove configuration scope '{}' that was not registered", removedId);
+      LOG.debug("Attempt to remove configuration scope '{}' that was not registered", removedId);
     } else {
       applicationEventPublisher.publishEvent(new ConfigurationScopeRemovedEvent(removed.getScope(), removed.getBindingConfiguration()));
     }

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
@@ -135,7 +135,8 @@ class ConfigurationServiceTests {
     underTest.didRemoveConfigurationScope("id2");
 
     assertThat(repository.getConfigScopeIds()).containsOnly("id1");
-    assertThat(logTester.logs(LogOutput.Level.ERROR)).containsExactly("Attempt to remove configuration scope 'id2' that was not registered");
+    assertThat(logTester.logs(LogOutput.Level.DEBUG)).contains("Attempt to remove configuration scope 'id2' that was not registered");
+    assertThat(logTester.logs(LogOutput.Level.ERROR)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
[SLCORE-1141](https://sonarsource.atlassian.net/browse/SLCORE-1141)

Currently, when users close projects in the Eclipse IDE or when projects are removed on disk but the workspace reference is still in the workspace and the user then deletes this very project from the workspace, an error is logged.

As this is a valid situation in Eclipse, rather log a debug message and not an error as nothing is actually failing.

[SLCORE-1141]: https://sonarsource.atlassian.net/browse/SLCORE-1141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ