### PR TITLE
SLCORE-1133: Rely on native Git if possible for blaming

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParser.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParser.java
@@ -1,0 +1,84 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons.util.git;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Path;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.sonar.scm.git.blame.BlameResult;
+import org.sonarsource.sonarlint.core.commons.SonarLintBlameResult;
+
+public class BlameParser {
+
+  public static SonarLintBlameResult parseBlameOutput(String blameOutput, String currentFilePath, Path projectBaseDir) throws IOException, ParseException {
+    BlameResult blameResult = new BlameResult();
+    BlameResult.FileBlame currentFileBlame = new BlameResult.FileBlame(currentFilePath, countCommitterTimeOccurrences(blameOutput));
+    blameResult.getFileBlameByPath().put(currentFilePath, currentFileBlame);
+    String[] fileSections = blameOutput.split("filename ");
+    int currentLineNumber = 0;
+
+    for (String fileSection : fileSections) {
+      if (fileSection.isBlank()) {
+        continue;
+      }
+
+      try (BufferedReader reader = new BufferedReader(new StringReader(fileSection))) {
+        String line;
+
+        while ((line = reader.readLine()) != null) {
+          if (line.startsWith("author ")) {
+            String author = line.substring(7);
+            currentFileBlame.getAuthorEmails()[currentLineNumber] = author;
+          } else if (line.startsWith("author-time ")) {
+            long epochSeconds = Long.parseLong(line.substring(12));
+            Date commitDate = new Date(epochSeconds * 1000);
+            currentFileBlame.getCommitDates()[currentLineNumber] = commitDate;
+          } else if (line.startsWith("commit ")) {
+            String commitHash = line.substring(7);
+            currentFileBlame.getCommitHashes()[currentLineNumber] = commitHash;
+          }
+        }
+      }
+      currentLineNumber++;
+    }
+
+    return new SonarLintBlameResult(blameResult, projectBaseDir);
+  }
+
+  public static int countCommitterTimeOccurrences(String blameOutput) {
+    Pattern pattern = Pattern.compile("^committer-time ", Pattern.MULTILINE);
+    Matcher matcher = pattern.matcher(blameOutput);
+    int count = 0;
+    while (matcher.find()) {
+      count++;
+    }
+    return count;
+  }
+
+  private static int countLines(String blameOutput) {
+    return blameOutput.split("\n").length;
+  }
+
+}

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParser.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParser.java
@@ -23,41 +23,36 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Path;
-import java.text.ParseException;
 import java.util.Date;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.sonar.scm.git.blame.BlameResult;
 import org.sonarsource.sonarlint.core.commons.SonarLintBlameResult;
 
 public class BlameParser {
-
-  public static SonarLintBlameResult parseBlameOutput(String blameOutput, String currentFilePath, Path projectBaseDir) throws IOException, ParseException {
-    BlameResult blameResult = new BlameResult();
-    BlameResult.FileBlame currentFileBlame = new BlameResult.FileBlame(currentFilePath, countCommitterTimeOccurrences(blameOutput));
+  private BlameParser() {
+    // Utility class
+  }
+  
+  public static SonarLintBlameResult parseBlameOutput(String blameOutput, String currentFilePath, Path projectBaseDir) throws IOException {
+    var blameResult = new BlameResult();
+    var currentFileBlame = new BlameResult.FileBlame(currentFilePath, countCommitterTimeOccurrences(blameOutput));
     blameResult.getFileBlameByPath().put(currentFilePath, currentFileBlame);
-    String[] fileSections = blameOutput.split("filename ");
-    int currentLineNumber = 0;
+    var fileSections = blameOutput.split("filename ");
+    var currentLineNumber = 0;
 
-    for (String fileSection : fileSections) {
+    for (var fileSection : fileSections) {
       if (fileSection.isBlank()) {
         continue;
       }
 
-      try (BufferedReader reader = new BufferedReader(new StringReader(fileSection))) {
+      try (var reader = new BufferedReader(new StringReader(fileSection))) {
         String line;
 
         while ((line = reader.readLine()) != null) {
-          if (line.startsWith("author ")) {
-            String author = line.substring(7);
-            currentFileBlame.getAuthorEmails()[currentLineNumber] = author;
-          } else if (line.startsWith("author-time ")) {
-            long epochSeconds = Long.parseLong(line.substring(12));
-            Date commitDate = new Date(epochSeconds * 1000);
+          if (line.startsWith("author-time ")) {
+            var epochSeconds = Long.parseLong(line.substring(12));
+            var commitDate = new Date(epochSeconds * 1000);
             currentFileBlame.getCommitDates()[currentLineNumber] = commitDate;
-          } else if (line.startsWith("commit ")) {
-            String commitHash = line.substring(7);
-            currentFileBlame.getCommitHashes()[currentLineNumber] = commitHash;
           }
         }
       }
@@ -68,17 +63,12 @@ public class BlameParser {
   }
 
   public static int countCommitterTimeOccurrences(String blameOutput) {
-    Pattern pattern = Pattern.compile("^committer-time ", Pattern.MULTILINE);
-    Matcher matcher = pattern.matcher(blameOutput);
-    int count = 0;
+    var pattern = Pattern.compile("^committer-time ", Pattern.MULTILINE);
+    var matcher = pattern.matcher(blameOutput);
+    var count = 0;
     while (matcher.find()) {
       count++;
     }
     return count;
   }
-
-  private static int countLines(String blameOutput) {
-    return blameOutput.split("\n").length;
-  }
-
 }

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
@@ -29,7 +29,6 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -61,6 +60,7 @@ import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import static java.util.Optional.ofNullable;
 import static org.eclipse.jgit.lib.Constants.GITIGNORE_FILENAME;
 import static org.sonarsource.sonarlint.core.commons.util.git.BlameParser.parseBlameOutput;
+import static org.sonarsource.sonarlint.core.commons.util.git.WinGitUtils.locateGitOnWindows;
 
 public class GitUtils {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
@@ -161,23 +161,6 @@ public class GitUtils {
       checkedForNativeGitExecutable = true;
     }
     return nativeGitExecutable;
-  }
-
-  private static String locateGitOnWindows() throws IOException {
-    // Windows will search current directory in addition to the PATH variable, which is unsecure.
-    // To avoid it we use where.exe to find git binary only in PATH.
-    LOG.debug("Looking for git command in the PATH using where.exe (Windows)");
-    var whereCommandResult = new LinkedList<String>();
-    new ProcessWrapperFactory()
-      .create(null, whereCommandResult::add, "C:\\Windows\\System32\\where.exe", "$PATH:git.exe")
-      .execute();
-
-    if (!whereCommandResult.isEmpty()) {
-      var out = whereCommandResult.get(0).trim();
-      LOG.debug("Found git.exe at {}", out);
-      return out;
-    }
-    throw new IllegalStateException("git.exe not found in PATH. PATH value was: " + System.getProperty("PATH"));
   }
 
   private static String getGitExecutable() throws IOException {

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtils.java
@@ -27,9 +27,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.text.ParseException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -38,10 +37,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FilenameUtils;
-import org.eclipse.jgit.api.BlameCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.blame.BlameResult;
 import org.eclipse.jgit.diff.RawTextComparator;
 import org.eclipse.jgit.ignore.IgnoreNode;
 import org.eclipse.jgit.lib.Constants;
@@ -49,7 +46,6 @@ import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.RepositoryBuilder;
-import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.sonar.scm.git.blame.RepositoryBlameCommand;
@@ -62,8 +58,11 @@ import static org.eclipse.jgit.lib.Constants.GITIGNORE_FILENAME;
 import static org.sonarsource.sonarlint.core.commons.util.git.BlameParser.parseBlameOutput;
 
 public class GitUtils {
-
   private static final SonarLintLogger LOG = SonarLintLogger.get();
+  
+  // So we only have to make the expensive call once (or at most twice) to get the native Git executable!
+  private static boolean checkedForNativeGitExecutable = false;
+  private static String nativeGitExecutable = null;
 
   private GitUtils() {
     // Utility class
@@ -91,9 +90,16 @@ public class GitUtils {
       return List.of();
     }
   }
+  
+  public static SonarLintBlameResult getBlameResult(Path projectBaseDir, Set<Path> projectBaseRelativeFilePaths, @Nullable UnaryOperator<String> fileContentProvider) {
+    try {
+      return blameFromNativeCommand(projectBaseDir, projectBaseRelativeFilePaths);
+    } catch (IllegalStateException ignored) {
+      return blameWithFilesGitCommand(projectBaseDir, projectBaseRelativeFilePaths, fileContentProvider);
+    }
+  }
 
   public static SonarLintBlameResult blameWithFilesGitCommand(Path projectBaseDir, Set<Path> projectBaseRelativeFilePaths, @Nullable UnaryOperator<String> fileContentProvider) {
-    long startTime = System.currentTimeMillis();
     var gitRepo = buildGitRepository(projectBaseDir);
 
     var gitRepoRelativeProjectBaseDir = getRelativePath(gitRepo, projectBaseDir);
@@ -113,31 +119,44 @@ public class GitUtils {
 
     try {
       var blameResult = blameCommand.call();
-      long endTime = System.currentTimeMillis();
-      LOG.info("blameWithFilesGitCommand took " + (endTime - startTime) + " ms");
       return new SonarLintBlameResult(blameResult, gitRepoRelativeProjectBaseDir);
     } catch (GitAPIException e) {
       throw new IllegalStateException("Failed to blame repository files", e);
     }
   }
 
-  private static boolean isGitAvailable() {
-    try {
-      Process process = new ProcessBuilder("git", "--version").start();
-      int exitCode = process.waitFor();
-      return exitCode == 0;
-    } catch (IOException | InterruptedException e) {
-      return false;
+  /**
+   *  Get the native Git executable by checking for the version of both `git` and `git.exe`. We cache this information
+   *  to run these expensive processes more than once (or twice in case of Windows).
+   */
+  private static String getNativeGitExecutable() {
+    if (!checkedForNativeGitExecutable) {
+      for (var executable : List.of("git", "git.exe")) {
+        try {
+          var process = new ProcessBuilder(executable, "--version").start();
+          var exitCode = process.waitFor();
+          if (exitCode == 0) {
+            nativeGitExecutable = executable;
+            break;
+          }
+        } catch (IOException | InterruptedException e) {
+          // Do log the exception stacktrace here as it might not be due to the command not being found but rather something like the
+          // Windows Execution Policy preventing it or something else. In this case this is extremely useful for debugging!
+          LOG.debug("Checking for native Git executable '" + executable+ "' failed with an exception", e);
+        }
+      }
+      checkedForNativeGitExecutable = true;
     }
+    return nativeGitExecutable;
   }
 
   private static String executeGitCommand(Path workingDir, String... command) throws IOException, InterruptedException {
-    var processBuilder = new ProcessBuilder(command);
-    processBuilder.directory(workingDir.toFile());
-    processBuilder.redirectErrorStream(true);
+    var processBuilder = new ProcessBuilder(command)
+      .directory(workingDir.toFile())
+      .redirectErrorStream(true);
     var process = processBuilder.start();
-    StringBuilder output = new StringBuilder();
-    try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+    var output = new StringBuilder();
+    try (var reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
       String line;
       while ((line = reader.readLine()) != null) {
         output.append(line).append(System.lineSeparator());
@@ -151,45 +170,19 @@ public class GitUtils {
   }
 
   public static SonarLintBlameResult blameFromNativeCommand(Path projectBaseDir, Set<Path> projectBaseRelativeFilePaths) {
-    if (isGitAvailable()) {
-      long startTime = System.currentTimeMillis();
+    var nativeExecutable = getNativeGitExecutable();
+    if (nativeExecutable != null) {
       for (var relativeFilePath : projectBaseRelativeFilePaths) {
         try {
-          var result = parseBlameOutput(executeGitCommand(projectBaseDir, "git", "blame", projectBaseDir.resolve(relativeFilePath).toString(), "--line-porcelain", "--encoding=UTF-8"), projectBaseDir.resolve(relativeFilePath).toString(), projectBaseDir);
-          long endTime = System.currentTimeMillis();
-          LOG.info("blameFromNativeCommand took " + (endTime - startTime) + " ms");
-          return result;
+          return parseBlameOutput(executeGitCommand(projectBaseDir,
+              nativeExecutable, "blame", projectBaseDir.resolve(relativeFilePath).toString(), "--line-porcelain", "--encoding=UTF-8"),
+            projectBaseDir.resolve(relativeFilePath).toString(), projectBaseDir);
         } catch (IOException | InterruptedException e) {
-          LOG.debug("Native git command error: ", e);
-        } catch (ParseException e) {
           throw new IllegalStateException("Failed to blame repository files", e);
         }
       }
     }
-    throw new IllegalStateException("Failed to blame repository files");
-  }
-
-  public static void blameFile(Path projectBaseDir, Set<Path> projectBaseRelativeFilePaths) {
-    long startTime = System.currentTimeMillis();
-    try {
-      var repository = buildGitRepository(projectBaseDir);
-      for (var relativeFilePath : projectBaseRelativeFilePaths) {
-        var blameCommand = new BlameCommand(repository);
-        blameCommand.setFilePath(relativeFilePath.toString());
-        var blameResult = blameCommand.call();
-
-        if (blameResult != null) {
-          for (int i = 0; i < blameResult.getResultContents().size(); i++) {
-            var commit = blameResult.getSourceCommit(i);
-            LOG.info("Line " + (i + 1) + " of file " + relativeFilePath + " was last modified by " + commit.getAuthorIdent().getName() + " on " + commit.getAuthorIdent().getWhen());
-          }
-        }
-      }
-      long endTime = System.currentTimeMillis();
-      LOG.info("blameFile took " + (endTime - startTime) + " ms");
-    } catch (GitAPIException e) {
-      e.printStackTrace();
-    }
+    throw new IllegalStateException("There is no native Git available");
   }
 
   private static Path getRelativePath(Repository gitRepo, Path projectBaseDir) {

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/ProcessWrapperFactory.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/ProcessWrapperFactory.java
@@ -1,0 +1,104 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons.util.git;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+
+import static java.lang.String.format;
+import static java.lang.String.join;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class ProcessWrapperFactory {
+  private static final SonarLintLogger LOG = SonarLintLogger.get();
+
+  public ProcessWrapperFactory() {
+    // nothing to do
+  }
+
+  public ProcessWrapper create(@Nullable Path baseDir, Consumer<String> stdOutLineConsumer, String... command) {
+    return new ProcessWrapper(baseDir, stdOutLineConsumer, Map.of(), command);
+  }
+
+  public ProcessWrapper create(@Nullable Path baseDir, Consumer<String> stdOutLineConsumer, Map<String, String> envVariables, String... command) {
+    return new ProcessWrapper(baseDir, stdOutLineConsumer, envVariables, command);
+  }
+
+  static class ProcessWrapper {
+
+    private final Path baseDir;
+    private final Consumer<String> stdOutLineConsumer;
+    private final String[] command;
+    private final Map<String, String> envVariables = new HashMap<>();
+
+    ProcessWrapper(@Nullable Path baseDir, Consumer<String> stdOutLineConsumer, Map<String, String> envVariables, String... command) {
+      this.baseDir = baseDir;
+      this.stdOutLineConsumer = stdOutLineConsumer;
+      this.envVariables.putAll(envVariables);
+      this.command = command;
+    }
+
+    private static void processInputStream(InputStream inputStream, Consumer<String> stringConsumer) {
+      try (var scanner = new Scanner(new InputStreamReader(inputStream, UTF_8))) {
+        scanner.useDelimiter("\n");
+        while (scanner.hasNext()) {
+          stringConsumer.accept(scanner.next());
+        }
+      }
+    }
+
+    public void execute() throws IOException {
+      ProcessBuilder pb = new ProcessBuilder()
+        .command(command)
+        .directory(baseDir != null ? baseDir.toFile() : null);
+      envVariables.forEach(pb.environment()::put);
+
+      Process p = pb.start();
+      try {
+        processInputStream(p.getInputStream(), stdOutLineConsumer);
+
+        processInputStream(p.getErrorStream(), line -> {
+          if (!line.isBlank()) {
+            LOG.debug(line);
+          }
+        });
+
+        int exit = p.waitFor();
+        if (exit != 0) {
+          throw new IllegalStateException(format("Command execution exited with code: %d", exit));
+        }
+      } catch (InterruptedException e) {
+        LOG.warn(format("Command [%s] interrupted", join(" ", command)), e);
+        Thread.currentThread().interrupt();
+      } finally {
+        p.destroy();
+      }
+    }
+  }
+
+}

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/WinGitUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/WinGitUtils.java
@@ -1,0 +1,49 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons.util.git;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+
+public class WinGitUtils {
+  private static final SonarLintLogger LOG = SonarLintLogger.get();
+
+  private WinGitUtils() {
+    // utils
+  }
+
+  public static String locateGitOnWindows() throws IOException {
+    // Windows will search current directory in addition to the PATH variable, which is unsecure.
+    // To avoid it we use where.exe to find git binary only in PATH.
+    LOG.debug("Looking for git command in the PATH using where.exe (Windows)");
+    var whereCommandResult = new LinkedList<String>();
+    new ProcessWrapperFactory()
+      .create(null, whereCommandResult::add, "C:\\Windows\\System32\\where.exe", "$PATH:git.exe")
+      .execute();
+
+    if (!whereCommandResult.isEmpty()) {
+      var out = whereCommandResult.get(0).trim();
+      LOG.debug("Found git.exe at {}", out);
+      return out;
+    }
+    throw new IllegalStateException("git.exe not found in PATH. PATH value was: " + System.getProperty("PATH"));
+  }
+}

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtilsTest.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/GitUtilsTest.java
@@ -17,7 +17,7 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonarsource.sonarlint.core.commons;
+package org.sonarsource.sonarlint.core.commons.util.git;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,9 +44,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import org.sonarsource.sonarlint.core.commons.log.LogOutput;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
-import org.sonarsource.sonarlint.core.commons.util.git.GitUtils;
 
 import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/ProcessWrapperFactoryTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/ProcessWrapperFactoryTests.java
@@ -23,12 +23,16 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.LinkedList;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ProcessWrapperFactoryTests {
-
+  @RegisterExtension
+  private static final SonarLintLogTester logTester = new SonarLintLogTester();
 
   @Test
   void it_should_execute_git(@TempDir Path baseDir) throws IOException {
@@ -36,5 +40,12 @@ class ProcessWrapperFactoryTests {
     new ProcessWrapperFactory().create(baseDir, gitCommandResult::add, "git", "--version").execute();
 
     assertThat(gitCommandResult).hasSize(1);
+  }
+
+  @Test
+  void it_should_throw(@TempDir Path baseDir) {
+    var processWrapper = new ProcessWrapperFactory().create(baseDir, new LinkedList<String>()::add, "git", "-version");
+
+    assertThrows(IllegalStateException.class, processWrapper::execute);
   }
 }

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/ProcessWrapperFactoryTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/ProcessWrapperFactoryTests.java
@@ -1,0 +1,40 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons.util.git;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.LinkedList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class ProcessWrapperFactoryTests {
+
+
+  @Test
+  void it_should_execute_git(@TempDir Path baseDir) throws IOException {
+    var gitCommandResult = new LinkedList<String>();
+    new ProcessWrapperFactory().create(baseDir, gitCommandResult::add, "git", "--version").execute();
+
+    assertThat(gitCommandResult).hasSize(1);
+  }
+}

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TrackingService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TrackingService.java
@@ -64,6 +64,8 @@ import org.springframework.context.event.EventListener;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
+import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.blameFile;
+import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.blameFromNativeCommand;
 import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.blameWithFilesGitCommand;
 
 public class TrackingService {
@@ -271,7 +273,9 @@ public class TrackingService {
     var baseDir = getBaseDir(configurationScopeId);
     if (baseDir != null) {
       try {
-        var sonarLintBlameResult = blameWithFilesGitCommand(baseDir, fileRelativePaths, fileContentProvider);
+        var sonarLintBlameResult2 = blameWithFilesGitCommand(baseDir, fileRelativePaths, fileContentProvider);
+        var sonarLintBlameResult = blameFromNativeCommand(baseDir, fileRelativePaths);
+        //blameFile(baseDir, fileRelativePaths);
         return (filePath, lineNumbers) -> determineIntroductionDate(filePath, lineNumbers, sonarLintBlameResult);
       } catch (GitRepoNotFoundException e) {
         LOG.info("Git Repository not found for {}. The path {} is not in a Git repository", configurationScopeId, e.getPath());

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TrackingService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TrackingService.java
@@ -279,6 +279,7 @@ public class TrackingService {
         LOG.error("Cannot access blame info for " + configurationScopeId, e);
       }
     }
+    LOG.debug("Git blame is not working. Falling back to detection date as the introduction date");
     // we keep the detection date as the introduction date
     return (filePath, lineNumber) -> Instant.now();
   }

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TrackingService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TrackingService.java
@@ -64,9 +64,7 @@ import org.springframework.context.event.EventListener;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
-import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.blameFile;
-import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.blameFromNativeCommand;
-import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.blameWithFilesGitCommand;
+import static org.sonarsource.sonarlint.core.commons.util.git.GitUtils.getBlameResult;
 
 public class TrackingService {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
@@ -273,9 +271,7 @@ public class TrackingService {
     var baseDir = getBaseDir(configurationScopeId);
     if (baseDir != null) {
       try {
-        var sonarLintBlameResult2 = blameWithFilesGitCommand(baseDir, fileRelativePaths, fileContentProvider);
-        var sonarLintBlameResult = blameFromNativeCommand(baseDir, fileRelativePaths);
-        //blameFile(baseDir, fileRelativePaths);
+        var sonarLintBlameResult = getBlameResult(baseDir, fileRelativePaths, fileContentProvider);
         return (filePath, lineNumbers) -> determineIntroductionDate(filePath, lineNumbers, sonarLintBlameResult);
       } catch (GitRepoNotFoundException e) {
         LOG.info("Git Repository not found for {}. The path {} is not in a Git repository", configurationScopeId, e.getPath());

--- a/medium-tests/src/test/java/mediumtest/analysis/AnalysisTriggeringMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/analysis/AnalysisTriggeringMediumTests.java
@@ -28,7 +28,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.sonarsource.sonarlint.core.commons.LogTestStartAndEnd;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.DidChangeAutomaticAnalysisSettingParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidCloseFileParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidOpenFileParams;
@@ -52,7 +54,9 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static utils.AnalysisUtils.createFile;
 import static utils.AnalysisUtils.getPublishedIssues;
+import static utils.AnalysisUtils.waitForRaisedIssues;
 
+@ExtendWith(LogTestStartAndEnd.class)
 class AnalysisTriggeringMediumTests {
 
   private static final String CONFIG_SCOPE_ID = "CONFIG_SCOPE_ID";
@@ -183,6 +187,7 @@ class AnalysisTriggeringMediumTests {
           </project>""", null, true)),
         Collections.emptyList()));
 
+    waitForRaisedIssues(client, CONFIG_SCOPE_ID);
     publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)
@@ -287,6 +292,7 @@ class AnalysisTriggeringMediumTests {
     backend.getRulesService().updateStandaloneRulesConfiguration(new UpdateStandaloneRulesConfigurationParams(Map.of("xml:S3420",
       new StandaloneRuleConfigDto(true, Map.of()))));
 
+    waitForRaisedIssues(client, CONFIG_SCOPE_ID);
     publishedIssues = getPublishedIssues(client, CONFIG_SCOPE_ID);
     assertThat(publishedIssues)
       .containsOnlyKeys(fileUri)

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,8 @@
 
     <!-- Exclude Maven Shade plug-in dependency as the test is done via the Maven build itself ... -->
     <sonar.coverage.exclusions>buildSrc/maven-shade-ext-bnd-transformer/**</sonar.coverage.exclusions>
+    <!-- We don't compute coverage on windows UTs   -->
+    <sonar.coverage.exclusions>backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/WinGitUtils.java</sonar.coverage.exclusions>
     <!-- Exclude from the duplication detection deprecated DTOs that were replaced by new types. They should be removed in 10.3 -->
     <sonar.cpd.exclusions>rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/analysis/*Dto.java</sonar.cpd.exclusions>
   </properties>


### PR DESCRIPTION
[SLCORE-1133](https://sonarsource.atlassian.net/browse/SLCORE-1133)

Cache the Git executable and leverage it if possible first for blaming. If there is an issue, fallback to the implementation based on `git-files-blame` / `JGit`.

Supersedes #1192 

[SLCORE-1133]: https://sonarsource.atlassian.net/browse/SLCORE-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ