### PR TITLE
SLCORE-1152: Don't log an error when projects removed

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
@@ -110,7 +110,7 @@ public class ConfigurationService {
   private BindingConfigChangedEvent bind(String configurationScopeId, BindingConfigurationDto bindingConfiguration) {
     var previousBindingConfig = repository.getBindingConfiguration(configurationScopeId);
     if (previousBindingConfig == null) {
-      LOG.error("Attempt to update binding in configuration scope '{}' that was not registered", configurationScopeId);
+      LOG.debug("Attempt to update binding in configuration scope '{}' that was not registered", configurationScopeId);
       return null;
     }
     var newBindingConfig = adapt(bindingConfiguration);

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
@@ -172,7 +172,8 @@ class ConfigurationServiceTests {
 
     underTest.didUpdateBinding("id2", BINDING_DTO_2);
 
-    assertThat(logTester.logs(LogOutput.Level.ERROR)).containsExactly("Attempt to update binding in configuration scope 'id2' that was not registered");
+    assertThat(logTester.logs(LogOutput.Level.DEBUG)).contains("Attempt to update binding in configuration scope 'id2' that was not registered");
+    assertThat(logTester.logs(LogOutput.Level.ERROR)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
[SLCORE-1152](https://sonarsource.atlassian.net/browse/SLCORE-1152)

Currently, when users remove a project that is bound to a connection, an error is logged.

As this is a valid situation in Eclipse, rather log a debug message and not an error as nothing is actually failing.

[SLCORE-1152]: https://sonarsource.atlassian.net/browse/SLCORE-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ