### PR TITLE
SLCORE-1153: Don't log an error on ProtBuf check for analysis readiness

### DIFF
--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorage.java
@@ -60,7 +60,7 @@ public class AnalyzerConfigurationStorage {
     try {
       return Optional.of(read());
     } catch (Exception e) {
-      LOG.error("Could not load analyzer configuration storage", e);
+      LOG.debug("Could not load analyzer configuration storage", e);
       return Optional.empty();
     }
   }

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/PluginsStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/PluginsStorage.java
@@ -55,7 +55,7 @@ public class PluginsStorage {
       rwLock.read(() -> ProtobufFileUtil.readFile(pluginReferencesFilePath, Sonarlint.PluginReferences.parser()));
       return true;
     } catch (Exception e) {
-      LOG.error("Could not load plugins storage", e);
+      LOG.debug("Could not load plugins storage", e);
       return false;
     }
   }


### PR DESCRIPTION
[SLCORE-1153](https://sonarsource.atlassian.net/browse/SLCORE-1153)

This is just a noisy error when creating a connection and binding a project to determine whether the analysis is yet ready. 

[SLCORE-1153]: https://sonarsource.atlassian.net/browse/SLCORE-1153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ