### PR TITLE
[DO NOT MERGE] Enable debugging for Sentry

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/monitoring/MonitoringService.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/monitoring/MonitoringService.java
@@ -72,6 +72,8 @@ public class MonitoringService {
     sentryOptions.setTag("architecture", SystemUtils.OS_ARCH);
     sentryOptions.addInAppInclude("org.sonarsource.sonarlint");
     sentryOptions.setTracesSampleRate(getTracesSampleRate());
+    // TODO Remove this or hide it behind a flag/property/env variable
+    sentryOptions.setDebug(true);
     return sentryOptions;
   }
 


### PR DESCRIPTION
This is an experiment to enable Sentry's debug flag (to try to understand why SLVS events are not sent).