### PR TITLE
SLCORE-1154: Clients can specify an alternative US region environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ scripts/patches/*license*.txt
 
 # Visual Studio
 .vs
+
+# Run configurations
+.run

--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -2,8 +2,8 @@
 
 ## New features
 
-* Add a new constructor to `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto` to accept region specific URIs (in a DTO each).
-    * Per region a `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto` must be provided that contains the *base*, *API* and *WebSocket* URIs.
+* Add a new constructor to `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto` to accept a map of `SonarCloudRegion` to `SonarQubeCloudRegionDto`.
+    *  Per region a `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto` must be provided that contains the *base*, *API* and *WebSocket* URIs.
     * `null` values are accepted for every URI - it will internally fallback to the actual region URIs for a `null` value encountered.
 
 ## Deprecation

--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -1,5 +1,11 @@
 # 10.17
 
+## Breaking Changes
+
+* Change `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto` to accept region specific URIs (in a DTO each) in the constructor.
+    * Per region a `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto` must be provided that contains the *base*, *API* and *WebSocket* URIs.
+    * `null` values are accepted for every URI as well for the whole region DTO object - it will internally fallback to the actual region URIs for a `null` value encountered.
+
 ## Deprecation
 
 * Deprecate the `org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.ConnectionRpcService.checkSmartNotificationsSupported` method. It always returns that notifications are supported.

--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -1,10 +1,10 @@
 # 10.17
 
-## Breaking Changes
+## New features
 
-* Change `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto` to accept region specific URIs (in a DTO each) in the constructor.
+* Add a new constructor to `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto` to accept region specific URIs (in a DTO each).
     * Per region a `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto` must be provided that contains the *base*, *API* and *WebSocket* URIs.
-    * `null` values are accepted for every URI as well for the whole region DTO object - it will internally fallback to the actual region URIs for a `null` value encountered.
+    * `null` values are accepted for every URI - it will internally fallback to the actual region URIs for a `null` value encountered.
 
 ## Deprecation
 

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironment.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironment.java
@@ -20,70 +20,65 @@
 package org.sonarsource.sonarlint.core;
 
 import java.net.URI;
-import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 
 import static org.apache.commons.lang.StringUtils.removeEnd;
 
 public class SonarCloudActiveEnvironment {
-  @Nullable
   private SonarQubeCloudRegionDto alternativeEuRegion;
-  @Nullable
   private SonarQubeCloudRegionDto alternativeUsRegion;
 
   public static SonarCloudActiveEnvironment prod() {
-    return new SonarCloudActiveEnvironment();
-  }
-
-  public SonarCloudActiveEnvironment() {
+    return new SonarCloudActiveEnvironment(new SonarQubeCloudRegionDto(null, null, null),
+      new SonarQubeCloudRegionDto(null, null, null));
   }
   
-  public SonarCloudActiveEnvironment(@Nullable SonarQubeCloudRegionDto alternativeEuRegion, @Nullable SonarQubeCloudRegionDto alternativeUsRegion) {
+  public SonarCloudActiveEnvironment(SonarQubeCloudRegionDto alternativeEuRegion, SonarQubeCloudRegionDto alternativeUsRegion) {
     this.alternativeEuRegion = alternativeEuRegion;
     this.alternativeUsRegion = alternativeUsRegion;
   }
 
   public URI getUri(SonarCloudRegion region) {
-    if (region.equals(SonarCloudRegion.EU)) {
-      return alternativeEuRegion != null && alternativeEuRegion.getUri() != null
-        ? alternativeEuRegion.getUri()
-        : SonarCloudRegion.EU.getProductionUri();
+    if (region.equals(SonarCloudRegion.US)) {
+      return alternativeUsRegion.getUri() != null
+        ? alternativeUsRegion.getUri()
+        : SonarCloudRegion.US.getProductionUri();
     }
-    return alternativeUsRegion != null && alternativeUsRegion.getUri() != null
-      ? alternativeUsRegion.getUri()
-      : SonarCloudRegion.US.getProductionUri();
+    return alternativeEuRegion.getUri() != null
+      ? alternativeEuRegion.getUri()
+      : SonarCloudRegion.EU.getProductionUri();
   }
 
   public URI getApiUri(SonarCloudRegion region) {
-    if (region.equals(SonarCloudRegion.EU)) {
-      return alternativeEuRegion != null && alternativeEuRegion.getApiUri() != null
-        ? alternativeEuRegion.getApiUri()
-        : SonarCloudRegion.EU.getApiProductionUri();
+    if (region.equals(SonarCloudRegion.US)) {
+      return alternativeUsRegion.getApiUri() != null
+        ? alternativeUsRegion.getApiUri()
+        : SonarCloudRegion.US.getApiProductionUri();
     }
-    return alternativeUsRegion != null && alternativeUsRegion.getApiUri() != null
-      ? alternativeUsRegion.getApiUri()
-      : SonarCloudRegion.US.getApiProductionUri();
+    return alternativeEuRegion.getApiUri() != null
+      ? alternativeEuRegion.getApiUri()
+      : SonarCloudRegion.EU.getApiProductionUri();
   }
 
   public URI getWebSocketsEndpointUri(SonarCloudRegion region) {
-    if (region.equals(SonarCloudRegion.EU)) {
-      return alternativeEuRegion != null && alternativeEuRegion.getWebSocketsEndpointUri() != null
-        ? alternativeEuRegion.getWebSocketsEndpointUri()
-        : SonarCloudRegion.EU.getWebSocketUri();
+    if (region.equals(SonarCloudRegion.US)) {
+      return alternativeUsRegion.getWebSocketsEndpointUri() != null
+        ? alternativeUsRegion.getWebSocketsEndpointUri()
+        : SonarCloudRegion.US.getWebSocketUri();
     }
-    return alternativeUsRegion != null && alternativeUsRegion.getWebSocketsEndpointUri() != null
-      ? alternativeUsRegion.getWebSocketsEndpointUri()
-      : SonarCloudRegion.US.getWebSocketUri();
+    return alternativeEuRegion.getWebSocketsEndpointUri() != null
+      ? alternativeEuRegion.getWebSocketsEndpointUri()
+      : SonarCloudRegion.EU.getWebSocketUri();
   }
 
   public boolean isSonarQubeCloud(String uri) {
     var cleanedUri = removeEnd(uri, "/");
-    if (isAlternativeEuUri(cleanedUri) || isAlternativeUsUri(cleanedUri)) {
+    if (isAlternativeUsUri(cleanedUri) || isAlternativeEuUri(cleanedUri)) {
       return true;
     }
     
-    return removeEnd(SonarCloudRegion.EU.getProductionUri().toString(), "/").equals(cleanedUri) ||
-      removeEnd(SonarCloudRegion.US.getProductionUri().toString(), "/").equals(cleanedUri);
+    return removeEnd(SonarCloudRegion.US.getProductionUri().toString(), "/").equals(cleanedUri) ||
+      removeEnd(SonarCloudRegion.EU.getProductionUri().toString(), "/").equals(cleanedUri);
   }
 
   /**
@@ -91,26 +86,24 @@ public class SonarCloudActiveEnvironment {
    */
   public SonarCloudRegion getRegionOrThrow(String uri) {
     var cleanedUri = removeEnd(uri, "/");
-    if (isAlternativeEuUri(cleanedUri) ||
-      removeEnd(SonarCloudRegion.EU.getProductionUri().toString(), "/").equals(cleanedUri)) {
-      return SonarCloudRegion.EU;
-    } else if (isAlternativeUsUri(cleanedUri) ||
+    if (isAlternativeUsUri(cleanedUri) ||
       removeEnd(SonarCloudRegion.US.getProductionUri().toString(), "/").equals(cleanedUri)) {
       return SonarCloudRegion.US;
+    } else if (isAlternativeEuUri(cleanedUri) ||
+      removeEnd(SonarCloudRegion.EU.getProductionUri().toString(), "/").equals(cleanedUri)) {
+      return SonarCloudRegion.EU;
     }
     
     throw new IllegalArgumentException("URI should be a known SonarCloud URI");
   }
   
   private boolean isAlternativeEuUri(String uri) {
-    return alternativeEuRegion != null
-      && alternativeEuRegion.getUri() != null
+    return alternativeEuRegion.getUri() != null
       && removeEnd(alternativeEuRegion.getUri().toString(), "/").equals(uri);
   }
 
   private boolean isAlternativeUsUri(String uri) {
-    return alternativeUsRegion != null
-      && alternativeUsRegion.getUri() != null
+    return alternativeUsRegion.getUri() != null
       && removeEnd(alternativeUsRegion.getUri().toString(), "/").equals(uri);
   }
 }

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
@@ -209,7 +209,7 @@ public class SonarLintSpringAppConfig {
   SonarCloudActiveEnvironment provideSonarCloudActiveEnvironment(InitializeParams params) {
     var alternativeSonarCloudEnv = params.getAlternativeSonarCloudEnvironment();
     return alternativeSonarCloudEnv == null ? SonarCloudActiveEnvironment.prod()
-      : new SonarCloudActiveEnvironment(alternativeSonarCloudEnv.getUri(), alternativeSonarCloudEnv.getApiUri(), alternativeSonarCloudEnv.getWebSocketsEndpointUri());
+      : new SonarCloudActiveEnvironment(alternativeSonarCloudEnv.getEuRegion(), alternativeSonarCloudEnv.getUsRegion());
   }
 
   @Bean

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
@@ -209,7 +209,7 @@ public class SonarLintSpringAppConfig {
   SonarCloudActiveEnvironment provideSonarCloudActiveEnvironment(InitializeParams params) {
     var alternativeSonarCloudEnv = params.getAlternativeSonarCloudEnvironment();
     return alternativeSonarCloudEnv == null ? SonarCloudActiveEnvironment.prod()
-      : new SonarCloudActiveEnvironment(alternativeSonarCloudEnv.getEuRegion(), alternativeSonarCloudEnv.getUsRegion());
+      : new SonarCloudActiveEnvironment(alternativeSonarCloudEnv.getAlternateRegionUris());
   }
 
   @Bean

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironmentTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironmentTests.java
@@ -1,0 +1,126 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SonarCloudActiveEnvironmentTests {
+  private static URI baseUri = URI.create("baseUri");
+  private static URI apiUri = URI.create("apiUri");
+  private static URI webSocketUri = URI.create("webSocketUri");
+  
+  private static SonarQubeCloudRegionDto regionWithBaseUri = new SonarQubeCloudRegionDto(baseUri, null, null);
+  private static SonarQubeCloudRegionDto regionWithApiUri = new SonarQubeCloudRegionDto(null, apiUri, null);
+  private static SonarQubeCloudRegionDto regionWithWebSocketUri = new SonarQubeCloudRegionDto(null, null, webSocketUri);
+  
+  @Test
+  void test_getUri() {
+    assertThat(new SonarCloudActiveEnvironment(null, null).getUri(SonarCloudRegion.EU))
+      .isEqualTo(SonarCloudRegion.EU.getProductionUri());
+    assertThat(new SonarCloudActiveEnvironment(null, null).getUri(SonarCloudRegion.US))
+      .isEqualTo(SonarCloudRegion.US.getProductionUri());
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null).getUri(SonarCloudRegion.EU))
+      .isEqualTo(baseUri);
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri).getUri(SonarCloudRegion.US))
+      .isEqualTo(baseUri);
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, null).getUri(SonarCloudRegion.EU))
+      .isEqualTo(SonarCloudRegion.EU.getProductionUri());
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithApiUri).getUri(SonarCloudRegion.US))
+      .isEqualTo(SonarCloudRegion.US.getProductionUri());
+  }
+
+  @Test
+  void test_getApiUri() {
+    assertThat(new SonarCloudActiveEnvironment(null, null).getApiUri(SonarCloudRegion.EU))
+      .isEqualTo(SonarCloudRegion.EU.getApiProductionUri());
+    assertThat(new SonarCloudActiveEnvironment(null, null).getApiUri(SonarCloudRegion.US))
+      .isEqualTo(SonarCloudRegion.US.getApiProductionUri());
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, null).getApiUri(SonarCloudRegion.EU))
+      .isEqualTo(apiUri);
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithApiUri).getApiUri(SonarCloudRegion.US))
+      .isEqualTo(apiUri);
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null).getApiUri(SonarCloudRegion.EU))
+      .isEqualTo(SonarCloudRegion.EU.getApiProductionUri());
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri).getApiUri(SonarCloudRegion.US))
+      .isEqualTo(SonarCloudRegion.US.getApiProductionUri());
+  }
+
+  @Test
+  void test_getWebSocketsEndpointUri() {
+    assertThat(new SonarCloudActiveEnvironment(null, null).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+      .isEqualTo(SonarCloudRegion.EU.getWebSocketUri());
+    assertThat(new SonarCloudActiveEnvironment(null, null).getWebSocketsEndpointUri(SonarCloudRegion.US))
+      .isEqualTo(SonarCloudRegion.US.getWebSocketUri());
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithWebSocketUri, null).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+      .isEqualTo(webSocketUri);
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithWebSocketUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
+      .isEqualTo(webSocketUri);
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+      .isEqualTo(SonarCloudRegion.EU.getWebSocketUri());
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
+      .isEqualTo(SonarCloudRegion.US.getWebSocketUri());
+  }
+  
+  @Test
+  void test_isSonarQubeCloud() {
+    assertThat(new SonarCloudActiveEnvironment(null, null).isSonarQubeCloud("aaaa")).isFalse();
+
+    assertThat(new SonarCloudActiveEnvironment(null, null)
+      .isSonarQubeCloud(SonarCloudRegion.EU.getProductionUri().toString())).isTrue();
+    assertThat(new SonarCloudActiveEnvironment(null, null)
+      .isSonarQubeCloud(SonarCloudRegion.US.getProductionUri().toString())).isTrue();
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null)
+      .isSonarQubeCloud(baseUri.toString())).isTrue();
+    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, null)
+      .isSonarQubeCloud(SonarCloudRegion.EU.getProductionUri().toString())).isTrue();
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri)
+      .isSonarQubeCloud(baseUri.toString())).isTrue();
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithApiUri)
+      .isSonarQubeCloud(SonarCloudRegion.US.getProductionUri().toString())).isTrue();
+  }
+
+  @Test
+  void test_getRegionOrThrow() {
+    assertThatThrownBy(() -> new SonarCloudActiveEnvironment(null, null).getRegionOrThrow("aaaa"))
+      .isInstanceOf(IllegalArgumentException.class);
+
+    assertThat(new SonarCloudActiveEnvironment(null, null)
+      .getRegionOrThrow(SonarCloudRegion.EU.getProductionUri().toString())).isEqualTo(SonarCloudRegion.EU);
+    assertThat(new SonarCloudActiveEnvironment(null, null)
+      .getRegionOrThrow(SonarCloudRegion.US.getProductionUri().toString())).isEqualTo(SonarCloudRegion.US);
+
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null)
+      .getRegionOrThrow(baseUri.toString())).isEqualTo(SonarCloudRegion.EU);
+    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri)
+      .getRegionOrThrow(baseUri.toString())).isEqualTo(SonarCloudRegion.US);
+  }
+}

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironmentTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironmentTests.java
@@ -34,93 +34,94 @@ class SonarCloudActiveEnvironmentTests {
   private static SonarQubeCloudRegionDto regionWithBaseUri = new SonarQubeCloudRegionDto(baseUri, null, null);
   private static SonarQubeCloudRegionDto regionWithApiUri = new SonarQubeCloudRegionDto(null, apiUri, null);
   private static SonarQubeCloudRegionDto regionWithWebSocketUri = new SonarQubeCloudRegionDto(null, null, webSocketUri);
+  private static SonarQubeCloudRegionDto empty = new SonarQubeCloudRegionDto(null, null, null);
   
   @Test
   void test_getUri() {
-    assertThat(new SonarCloudActiveEnvironment(null, null).getUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(empty, empty).getUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(null, null).getUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, empty).getUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getProductionUri());
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null).getUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty).getUri(SonarCloudRegion.EU))
       .isEqualTo(baseUri);
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri).getUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri).getUri(SonarCloudRegion.US))
       .isEqualTo(baseUri);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, null).getUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, empty).getUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithApiUri).getUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithApiUri).getUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getProductionUri());
   }
 
   @Test
   void test_getApiUri() {
-    assertThat(new SonarCloudActiveEnvironment(null, null).getApiUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(empty, empty).getApiUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getApiProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(null, null).getApiUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, empty).getApiUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getApiProductionUri());
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, null).getApiUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, empty).getApiUri(SonarCloudRegion.EU))
       .isEqualTo(apiUri);
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithApiUri).getApiUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithApiUri).getApiUri(SonarCloudRegion.US))
       .isEqualTo(apiUri);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null).getApiUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty).getApiUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getApiProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri).getApiUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri).getApiUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getApiProductionUri());
   }
 
   @Test
   void test_getWebSocketsEndpointUri() {
-    assertThat(new SonarCloudActiveEnvironment(null, null).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(empty, empty).getWebSocketsEndpointUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getWebSocketUri());
-    assertThat(new SonarCloudActiveEnvironment(null, null).getWebSocketsEndpointUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, empty).getWebSocketsEndpointUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getWebSocketUri());
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithWebSocketUri, null).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(regionWithWebSocketUri, empty).getWebSocketsEndpointUri(SonarCloudRegion.EU))
       .isEqualTo(webSocketUri);
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithWebSocketUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithWebSocketUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
       .isEqualTo(webSocketUri);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty).getWebSocketsEndpointUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getWebSocketUri());
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getWebSocketUri());
   }
   
   @Test
   void test_isSonarQubeCloud() {
-    assertThat(new SonarCloudActiveEnvironment(null, null).isSonarQubeCloud("aaaa")).isFalse();
+    assertThat(new SonarCloudActiveEnvironment(empty, empty).isSonarQubeCloud("aaaa")).isFalse();
 
-    assertThat(new SonarCloudActiveEnvironment(null, null)
+    assertThat(new SonarCloudActiveEnvironment(empty, empty)
       .isSonarQubeCloud(SonarCloudRegion.EU.getProductionUri().toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(null, null)
+    assertThat(new SonarCloudActiveEnvironment(empty, empty)
       .isSonarQubeCloud(SonarCloudRegion.US.getProductionUri().toString())).isTrue();
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null)
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty)
       .isSonarQubeCloud(baseUri.toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, null)
+    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, empty)
       .isSonarQubeCloud(SonarCloudRegion.EU.getProductionUri().toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri)
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri)
       .isSonarQubeCloud(baseUri.toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithApiUri)
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithApiUri)
       .isSonarQubeCloud(SonarCloudRegion.US.getProductionUri().toString())).isTrue();
   }
 
   @Test
   void test_getRegionOrThrow() {
-    assertThatThrownBy(() -> new SonarCloudActiveEnvironment(null, null).getRegionOrThrow("aaaa"))
+    assertThatThrownBy(() -> new SonarCloudActiveEnvironment(empty, empty).getRegionOrThrow("aaaa"))
       .isInstanceOf(IllegalArgumentException.class);
 
-    assertThat(new SonarCloudActiveEnvironment(null, null)
+    assertThat(new SonarCloudActiveEnvironment(empty, empty)
       .getRegionOrThrow(SonarCloudRegion.EU.getProductionUri().toString())).isEqualTo(SonarCloudRegion.EU);
-    assertThat(new SonarCloudActiveEnvironment(null, null)
+    assertThat(new SonarCloudActiveEnvironment(empty, empty)
       .getRegionOrThrow(SonarCloudRegion.US.getProductionUri().toString())).isEqualTo(SonarCloudRegion.US);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, null)
+    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty)
       .getRegionOrThrow(baseUri.toString())).isEqualTo(SonarCloudRegion.EU);
-    assertThat(new SonarCloudActiveEnvironment(null, regionWithBaseUri)
+    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri)
       .getRegionOrThrow(baseUri.toString())).isEqualTo(SonarCloudRegion.US);
   }
 }

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironmentTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironmentTests.java
@@ -20,6 +20,7 @@
 package org.sonarsource.sonarlint.core;
 
 import java.net.URI;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 
@@ -34,94 +35,123 @@ class SonarCloudActiveEnvironmentTests {
   private static SonarQubeCloudRegionDto regionWithBaseUri = new SonarQubeCloudRegionDto(baseUri, null, null);
   private static SonarQubeCloudRegionDto regionWithApiUri = new SonarQubeCloudRegionDto(null, apiUri, null);
   private static SonarQubeCloudRegionDto regionWithWebSocketUri = new SonarQubeCloudRegionDto(null, null, webSocketUri);
-  private static SonarQubeCloudRegionDto empty = new SonarQubeCloudRegionDto(null, null, null);
   
   @Test
   void test_getUri() {
-    assertThat(new SonarCloudActiveEnvironment(empty, empty).getUri(SonarCloudRegion.EU))
+    assertThat(SonarCloudActiveEnvironment.prod().getUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(empty, empty).getUri(SonarCloudRegion.US))
+    assertThat(SonarCloudActiveEnvironment.prod().getUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getProductionUri());
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty).getUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithBaseUri))
+      .getUri(SonarCloudRegion.EU))
       .isEqualTo(baseUri);
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri).getUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithBaseUri))
+      .getUri(SonarCloudRegion.US))
       .isEqualTo(baseUri);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, empty).getUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithApiUri))
+      .getUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithApiUri).getUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithApiUri))
+      .getUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getProductionUri());
   }
 
   @Test
   void test_getApiUri() {
-    assertThat(new SonarCloudActiveEnvironment(empty, empty).getApiUri(SonarCloudRegion.EU))
+    assertThat(SonarCloudActiveEnvironment.prod().getApiUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getApiProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(empty, empty).getApiUri(SonarCloudRegion.US))
+    assertThat(SonarCloudActiveEnvironment.prod().getApiUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getApiProductionUri());
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, empty).getApiUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithApiUri))
+      .getApiUri(SonarCloudRegion.EU))
       .isEqualTo(apiUri);
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithApiUri).getApiUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithApiUri))
+      .getApiUri(SonarCloudRegion.US))
       .isEqualTo(apiUri);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty).getApiUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithBaseUri))
+      .getApiUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getApiProductionUri());
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri).getApiUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithBaseUri))
+      .getApiUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getApiProductionUri());
   }
 
   @Test
   void test_getWebSocketsEndpointUri() {
-    assertThat(new SonarCloudActiveEnvironment(empty, empty).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+    assertThat(SonarCloudActiveEnvironment.prod().getWebSocketsEndpointUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getWebSocketUri());
-    assertThat(new SonarCloudActiveEnvironment(empty, empty).getWebSocketsEndpointUri(SonarCloudRegion.US))
+    assertThat(SonarCloudActiveEnvironment.prod().getWebSocketsEndpointUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getWebSocketUri());
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithWebSocketUri, empty).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithWebSocketUri)).
+      getWebSocketsEndpointUri(SonarCloudRegion.EU))
       .isEqualTo(webSocketUri);
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithWebSocketUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithWebSocketUri))
+      .getWebSocketsEndpointUri(SonarCloudRegion.US))
       .isEqualTo(webSocketUri);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty).getWebSocketsEndpointUri(SonarCloudRegion.EU))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithApiUri))
+      .getWebSocketsEndpointUri(SonarCloudRegion.EU))
       .isEqualTo(SonarCloudRegion.EU.getWebSocketUri());
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri).getWebSocketsEndpointUri(SonarCloudRegion.US))
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithApiUri))
+      .getWebSocketsEndpointUri(SonarCloudRegion.US))
       .isEqualTo(SonarCloudRegion.US.getWebSocketUri());
   }
   
   @Test
   void test_isSonarQubeCloud() {
-    assertThat(new SonarCloudActiveEnvironment(empty, empty).isSonarQubeCloud("aaaa")).isFalse();
+    assertThat(SonarCloudActiveEnvironment.prod().isSonarQubeCloud("aaaa")).isFalse();
 
-    assertThat(new SonarCloudActiveEnvironment(empty, empty)
+    assertThat(SonarCloudActiveEnvironment.prod()
       .isSonarQubeCloud(SonarCloudRegion.EU.getProductionUri().toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(empty, empty)
+    assertThat(SonarCloudActiveEnvironment.prod()
       .isSonarQubeCloud(SonarCloudRegion.US.getProductionUri().toString())).isTrue();
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty)
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithBaseUri))
       .isSonarQubeCloud(baseUri.toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(regionWithApiUri, empty)
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithApiUri))
       .isSonarQubeCloud(SonarCloudRegion.EU.getProductionUri().toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri)
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithBaseUri))
       .isSonarQubeCloud(baseUri.toString())).isTrue();
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithApiUri)
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithApiUri))
       .isSonarQubeCloud(SonarCloudRegion.US.getProductionUri().toString())).isTrue();
   }
 
   @Test
   void test_getRegionOrThrow() {
-    assertThatThrownBy(() -> new SonarCloudActiveEnvironment(empty, empty).getRegionOrThrow("aaaa"))
+    assertThatThrownBy(() -> SonarCloudActiveEnvironment.prod().getRegionOrThrow("aaaa"))
       .isInstanceOf(IllegalArgumentException.class);
 
-    assertThat(new SonarCloudActiveEnvironment(empty, empty)
+    assertThat(SonarCloudActiveEnvironment.prod()
       .getRegionOrThrow(SonarCloudRegion.EU.getProductionUri().toString())).isEqualTo(SonarCloudRegion.EU);
-    assertThat(new SonarCloudActiveEnvironment(empty, empty)
+    assertThat(SonarCloudActiveEnvironment.prod()
       .getRegionOrThrow(SonarCloudRegion.US.getProductionUri().toString())).isEqualTo(SonarCloudRegion.US);
 
-    assertThat(new SonarCloudActiveEnvironment(regionWithBaseUri, empty)
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.EU, regionWithBaseUri))
       .getRegionOrThrow(baseUri.toString())).isEqualTo(SonarCloudRegion.EU);
-    assertThat(new SonarCloudActiveEnvironment(empty, regionWithBaseUri)
+    assertThat(new SonarCloudActiveEnvironment(
+      Map.of(org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion.US, regionWithBaseUri))
       .getRegionOrThrow(baseUri.toString())).isEqualTo(SonarCloudRegion.US);
   }
 }

--- a/its/tests/src/test/java/its/SonarCloudTests.java
+++ b/its/tests/src/test/java/its/SonarCloudTests.java
@@ -90,7 +90,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.FeatureFla
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.HttpConfigurationDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.InitializeParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.GetEffectiveRuleDetailsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.ListAllParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.hotspot.RaisedHotspotDto;
@@ -164,9 +163,7 @@ class SonarCloudTests extends AbstractConnectedTests {
     var featureFlags = new FeatureFlagsDto(false, true, true, false, true, true, false, true, false, true, false);
     backend.initialize(
       new InitializeParams(IT_CLIENT_INFO, IT_TELEMETRY_ATTRIBUTES, HttpConfigurationDto.defaultConfig(),
-        new SonarCloudAlternativeEnvironmentDto(new SonarQubeCloudRegionDto(SONARCLOUD_STAGING_URL, SONARCLOUD_STAGING_API_URL, SONARCLOUD_WEBSOCKETS_STAGING_URL),
-          new SonarQubeCloudRegionDto(null, null, null)),
-        featureFlags,
+        new SonarCloudAlternativeEnvironmentDto(SONARCLOUD_STAGING_URL, SONARCLOUD_STAGING_API_URL, SONARCLOUD_WEBSOCKETS_STAGING_URL), featureFlags,
         sonarUserHome.resolve("storage"),
         sonarUserHome.resolve("work"), emptySet(), PluginLocator.getEmbeddedPluginsByKeyForTests(), languages, emptySet(), emptySet(), emptyList(),
         List.of(new SonarCloudConnectionConfigurationDto(CONNECTION_ID, SONARCLOUD_ORGANIZATION, SonarCloudRegion.EU, true)), sonarUserHome.toString(),

--- a/its/tests/src/test/java/its/SonarCloudTests.java
+++ b/its/tests/src/test/java/its/SonarCloudTests.java
@@ -90,6 +90,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.FeatureFla
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.HttpConfigurationDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.InitializeParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.rules.GetEffectiveRuleDetailsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.ListAllParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.hotspot.RaisedHotspotDto;
@@ -163,7 +164,8 @@ class SonarCloudTests extends AbstractConnectedTests {
     var featureFlags = new FeatureFlagsDto(false, true, true, false, true, true, false, true, false, true, false);
     backend.initialize(
       new InitializeParams(IT_CLIENT_INFO, IT_TELEMETRY_ATTRIBUTES, HttpConfigurationDto.defaultConfig(),
-        new SonarCloudAlternativeEnvironmentDto(SONARCLOUD_STAGING_URL, SONARCLOUD_STAGING_API_URL, SONARCLOUD_WEBSOCKETS_STAGING_URL), featureFlags,
+        new SonarCloudAlternativeEnvironmentDto(new SonarQubeCloudRegionDto(SONARCLOUD_STAGING_URL, SONARCLOUD_STAGING_API_URL, SONARCLOUD_WEBSOCKETS_STAGING_URL), null),
+        featureFlags,
         sonarUserHome.resolve("storage"),
         sonarUserHome.resolve("work"), emptySet(), PluginLocator.getEmbeddedPluginsByKeyForTests(), languages, emptySet(), emptySet(), emptyList(),
         List.of(new SonarCloudConnectionConfigurationDto(CONNECTION_ID, SONARCLOUD_ORGANIZATION, SonarCloudRegion.EU, true)), sonarUserHome.toString(),

--- a/its/tests/src/test/java/its/SonarCloudTests.java
+++ b/its/tests/src/test/java/its/SonarCloudTests.java
@@ -164,7 +164,8 @@ class SonarCloudTests extends AbstractConnectedTests {
     var featureFlags = new FeatureFlagsDto(false, true, true, false, true, true, false, true, false, true, false);
     backend.initialize(
       new InitializeParams(IT_CLIENT_INFO, IT_TELEMETRY_ATTRIBUTES, HttpConfigurationDto.defaultConfig(),
-        new SonarCloudAlternativeEnvironmentDto(new SonarQubeCloudRegionDto(SONARCLOUD_STAGING_URL, SONARCLOUD_STAGING_API_URL, SONARCLOUD_WEBSOCKETS_STAGING_URL), null),
+        new SonarCloudAlternativeEnvironmentDto(new SonarQubeCloudRegionDto(SONARCLOUD_STAGING_URL, SONARCLOUD_STAGING_API_URL, SONARCLOUD_WEBSOCKETS_STAGING_URL),
+          new SonarQubeCloudRegionDto(null, null, null)),
         featureFlags,
         sonarUserHome.resolve("storage"),
         sonarUserHome.resolve("work"), emptySet(), PluginLocator.getEmbeddedPluginsByKeyForTests(), languages, emptySet(), emptySet(), emptyList(),

--- a/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
@@ -19,13 +19,11 @@
  */
 package mediumtest;
 
-import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.binding.GetSharedConnectedModeConfigFileParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.binding.GetSharedConnectedModeConfigFileResponse;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
@@ -63,7 +61,7 @@ class SharedConnectedModeSettingsMediumTests {
     var server = harness.newFakeSonarCloudServer(organizationKey).start();
 
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection(connectionId, organizationKey)
       .withBoundConfigScope(configScopeId, connectionId, projectKey)
       .withTelemetryEnabled()
@@ -95,7 +93,7 @@ class SharedConnectedModeSettingsMediumTests {
     var server = harness.newFakeSonarCloudServer(organizationKey).start();
 
     var backend = harness.newBackend()
-      .withSonarQubeCloudUsRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection(connectionId, organizationKey)
       .withBoundConfigScope(configScopeId, connectionId, projectKey)
       .withTelemetryEnabled()

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionGetAllProjectsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionGetAllProjectsMediumTests.java
@@ -19,12 +19,14 @@
  */
 package mediumtest.connection;
 
+import java.net.URI;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarCloudConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarQubeConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.FuzzySearchProjectsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetAllProjectsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetAllProjectsResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.SonarProjectDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -56,7 +58,7 @@ class ConnectionGetAllProjectsMediumTests {
   void it_should_return_an_empty_response_if_no_projects_in_sonarcloud_organization(SonarLintTestHarness harness) {
     var server = harness.newFakeSonarCloudServer("myOrg").start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .start();
 
     var response = getAllProjects(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU));
@@ -123,7 +125,7 @@ class ConnectionGetAllProjectsMediumTests {
       .withProject("projectKey2", project -> project.withName("MyProject2"))
       .start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .start();
 
     var response = getAllProjects(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU));

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionGetAllProjectsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionGetAllProjectsMediumTests.java
@@ -19,14 +19,12 @@
  */
 package mediumtest.connection;
 
-import java.net.URI;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarCloudConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarQubeConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.FuzzySearchProjectsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetAllProjectsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetAllProjectsResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.SonarProjectDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -58,7 +56,7 @@ class ConnectionGetAllProjectsMediumTests {
   void it_should_return_an_empty_response_if_no_projects_in_sonarcloud_organization(SonarLintTestHarness harness) {
     var server = harness.newFakeSonarCloudServer("myOrg").start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .start();
 
     var response = getAllProjects(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU));
@@ -125,7 +123,7 @@ class ConnectionGetAllProjectsMediumTests {
       .withProject("projectKey2", project -> project.withName("MyProject2"))
       .start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .start();
 
     var response = getAllProjects(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU));

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionGetProjectNameByKeyMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionGetProjectNameByKeyMediumTests.java
@@ -19,14 +19,12 @@
  */
 package mediumtest.connection;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarCloudConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarQubeConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetProjectNamesByKeyParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetProjectNamesByKeyResponse;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -60,7 +58,7 @@ class ConnectionGetProjectNameByKeyMediumTests {
   void it_should_return_null_if_no_projects_in_sonarcloud_organization(SonarLintTestHarness harness) {
     var server = harness.newFakeSonarCloudServer("myOrg").start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .start();
 
     var response = getProjectNamesByKey(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU), List.of(
@@ -97,7 +95,7 @@ class ConnectionGetProjectNameByKeyMediumTests {
       .withProject("projectKey3", project -> project.withName("MyProject3"))
       .start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .start();
 
     var response = getProjectNamesByKey(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU),

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionGetProjectNameByKeyMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionGetProjectNameByKeyMediumTests.java
@@ -19,12 +19,14 @@
  */
 package mediumtest.connection;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarCloudConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarQubeConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetProjectNamesByKeyParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.projects.GetProjectNamesByKeyResponse;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -58,7 +60,7 @@ class ConnectionGetProjectNameByKeyMediumTests {
   void it_should_return_null_if_no_projects_in_sonarcloud_organization(SonarLintTestHarness harness) {
     var server = harness.newFakeSonarCloudServer("myOrg").start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .start();
 
     var response = getProjectNamesByKey(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU), List.of(
@@ -95,7 +97,7 @@ class ConnectionGetProjectNameByKeyMediumTests {
       .withProject("projectKey3", project -> project.withName("MyProject3"))
       .start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .start();
 
     var response = getProjectNamesByKey(backend, new TransientSonarCloudConnectionDto("myOrg", Either.forLeft(new TokenDto("token")), SonarCloudRegion.EU),

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionValidatorMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionValidatorMediumTests.java
@@ -20,12 +20,10 @@
 package mediumtest.connection;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import java.net.URI;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarCloudConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarQubeConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.validate.ValidateConnectionParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -50,7 +48,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnection_ok(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(serverMock.baseUrl())
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -65,7 +63,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnectionOrganizationNotFound(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(serverMock.baseUrl())
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -83,7 +81,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnection_ok_with_org(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(serverMock.baseUrl())
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -107,7 +105,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnection_ok_without_org(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(serverMock.baseUrl())
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -121,7 +119,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testUnsupportedServer(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(serverMock.baseUrl())
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"6.7\",\"status\": \"UP\"}")));
@@ -135,7 +133,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testClientError(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(serverMock.baseUrl())
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withStatus(400)));
@@ -150,7 +148,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testResponseError(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(serverMock.baseUrl())
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": }")));

--- a/medium-tests/src/test/java/mediumtest/connection/ConnectionValidatorMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/ConnectionValidatorMediumTests.java
@@ -20,10 +20,12 @@
 package mediumtest.connection;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarCloudConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.common.TransientSonarQubeConnectionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.validate.ValidateConnectionParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -48,7 +50,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnection_ok(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(serverMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -63,7 +65,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnectionOrganizationNotFound(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(serverMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -81,7 +83,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnection_ok_with_org(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(serverMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -105,7 +107,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testConnection_ok_without_org(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(serverMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"9.9\",\"status\": \"UP\"}")));
@@ -119,7 +121,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testUnsupportedServer(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(serverMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": \"20160308094653\",\"version\": \"6.7\",\"status\": \"UP\"}")));
@@ -133,7 +135,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testClientError(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(serverMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withStatus(400)));
@@ -148,7 +150,7 @@ class ConnectionValidatorMediumTests {
   @SonarLintTest
   void testResponseError(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(serverMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(serverMock.baseUrl()), null, null))
       .start();
     serverMock.stubFor(get("/api/system/status")
       .willReturn(aResponse().withBody("{\"id\": }")));

--- a/medium-tests/src/test/java/mediumtest/connection/OrganizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/OrganizationMediumTests.java
@@ -20,7 +20,6 @@
 package mediumtest.connection;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.ExecutionException;
@@ -30,7 +29,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.FuzzyS
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.GetOrganizationParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.ListUserOrganizationsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.OrganizationDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -62,7 +60,7 @@ class OrganizationMediumTests {
     var fakeClient = harness.newFakeClient()
       .build();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
       .start(fakeClient);
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?member=true&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()
@@ -76,7 +74,7 @@ class OrganizationMediumTests {
   @SonarLintTest
   void it_should_list_user_organizations(SonarLintTestHarness harness) throws ExecutionException, InterruptedException {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
       .start();
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?member=true&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()
@@ -111,7 +109,7 @@ class OrganizationMediumTests {
   @SonarLintTest
   void it_should_get_organizations_by_key(SonarLintTestHarness harness) throws ExecutionException, InterruptedException {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
       .start();
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?organizations=myCustomOrg&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()
@@ -138,7 +136,7 @@ class OrganizationMediumTests {
   @SonarLintTest
   void it_should_fuzzy_search_and_cache_organizations_on_sonarcloud(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
       .start();
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?member=true&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()

--- a/medium-tests/src/test/java/mediumtest/connection/OrganizationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/connection/OrganizationMediumTests.java
@@ -20,6 +20,7 @@
 package mediumtest.connection;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.concurrent.ExecutionException;
@@ -29,6 +30,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.FuzzyS
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.GetOrganizationParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.ListUserOrganizationsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.OrganizationDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -60,7 +62,7 @@ class OrganizationMediumTests {
     var fakeClient = harness.newFakeClient()
       .build();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(sonarcloudMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
       .start(fakeClient);
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?member=true&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()
@@ -74,7 +76,7 @@ class OrganizationMediumTests {
   @SonarLintTest
   void it_should_list_user_organizations(SonarLintTestHarness harness) throws ExecutionException, InterruptedException {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(sonarcloudMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
       .start();
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?member=true&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()
@@ -109,7 +111,7 @@ class OrganizationMediumTests {
   @SonarLintTest
   void it_should_get_organizations_by_key(SonarLintTestHarness harness) throws ExecutionException, InterruptedException {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(sonarcloudMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
       .start();
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?organizations=myCustomOrg&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()
@@ -136,7 +138,7 @@ class OrganizationMediumTests {
   @SonarLintTest
   void it_should_fuzzy_search_and_cache_organizations_on_sonarcloud(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(sonarcloudMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
       .start();
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?member=true&ps=500&p=1")
       .willReturn(aResponse().withStatus(200).withResponseBody(protobufBody(Organizations.SearchWsResponse.newBuilder()

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotCheckStatusChangePermittedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotCheckStatusChangePermittedMediumTests.java
@@ -19,7 +19,6 @@
  */
 package mediumtest.hotspots;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -28,7 +27,6 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckStatusChangePermittedResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.HotspotStatus;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
@@ -55,7 +53,7 @@ class HotspotCheckStatusChangePermittedMediumTests {
   void it_should_return_3_statuses_for_sonarcloud(SonarLintTestHarness harness) {
     var server = harness.newFakeSonarCloudServer().withProject("projectKey", project -> project.withDefaultBranch(branch -> branch.withHotspot("hotspotKey"))).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "orgKey")
       .start();
 

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotCheckStatusChangePermittedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotCheckStatusChangePermittedMediumTests.java
@@ -19,6 +19,7 @@
  */
 package mediumtest.hotspots;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -27,6 +28,7 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.CheckStatusChangePermittedResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.HotspotStatus;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
@@ -53,7 +55,7 @@ class HotspotCheckStatusChangePermittedMediumTests {
   void it_should_return_3_statuses_for_sonarcloud(SonarLintTestHarness harness) {
     var server = harness.newFakeSonarCloudServer().withProject("projectKey", project -> project.withDefaultBranch(branch -> branch.withHotspot("hotspotKey"))).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "orgKey")
       .start();
 

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotStatusChangeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotStatusChangeMediumTests.java
@@ -20,7 +20,6 @@
 package mediumtest.hotspots;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -28,7 +27,6 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.Disabled;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.ChangeHotspotStatusParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.HotspotStatus;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
@@ -84,7 +82,7 @@ class HotspotStatusChangeMediumTests {
     var server = harness.newFakeSonarCloudServer().start();
 
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "orgKey")
       .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
       .start();

--- a/medium-tests/src/test/java/mediumtest/hotspots/HotspotStatusChangeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/hotspots/HotspotStatusChangeMediumTests.java
@@ -20,6 +20,7 @@
 package mediumtest.hotspots;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -27,6 +28,7 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.Disabled;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.ChangeHotspotStatusParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.hotspot.HotspotStatus;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
@@ -82,7 +84,7 @@ class HotspotStatusChangeMediumTests {
     var server = harness.newFakeSonarCloudServer().start();
 
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "orgKey")
       .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
       .start();

--- a/medium-tests/src/test/java/mediumtest/http/SslMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/SslMediumTests.java
@@ -20,7 +20,6 @@
 package mediumtest.http;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -43,7 +42,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.GetOrganizationParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.http.X509CertificateDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
@@ -111,7 +109,7 @@ class SslMediumTests {
     void it_should_not_trust_server_self_signed_certificate_by_default(SonarLintTestHarness harness) {
       var fakeClient = harness.newFakeClient().build();
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
         .start(fakeClient);
 
       var future = backend.getConnectionService().getOrganization(new GetOrganizationParams(Either.forLeft(new TokenDto("token")), "myOrg", SonarCloudRegion.EU));
@@ -125,7 +123,7 @@ class SslMediumTests {
       var fakeClient = harness.newFakeClient().build();
 
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
         .start(fakeClient);
 
       when(fakeClient.checkServerTrusted(any(), any()))
@@ -197,7 +195,7 @@ class SslMediumTests {
     void it_should_fail_if_client_certificate_not_provided(SonarLintTestHarness harness) {
       var fakeClient = harness.newFakeClient().build();
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
         .start(fakeClient);
 
       when(fakeClient.checkServerTrusted(any(), any()))
@@ -216,7 +214,7 @@ class SslMediumTests {
       var fakeClient = harness.newFakeClient().build();
       var backend = harness.newBackend()
         .withKeyStore(toPath(Objects.requireNonNull(SslMediumTests.class.getResource("/ssl/client.p12"))), "pwdClientCertP12", null)
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
         .start(fakeClient);
 
       when(fakeClient.checkServerTrusted(any(), any()))

--- a/medium-tests/src/test/java/mediumtest/http/SslMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/SslMediumTests.java
@@ -20,6 +20,7 @@
 package mediumtest.http;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
@@ -42,6 +43,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.GetOrganizationParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.http.X509CertificateDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
@@ -109,7 +111,7 @@ class SslMediumTests {
     void it_should_not_trust_server_self_signed_certificate_by_default(SonarLintTestHarness harness) {
       var fakeClient = harness.newFakeClient().build();
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarcloudMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
         .start(fakeClient);
 
       var future = backend.getConnectionService().getOrganization(new GetOrganizationParams(Either.forLeft(new TokenDto("token")), "myOrg", SonarCloudRegion.EU));
@@ -123,7 +125,7 @@ class SslMediumTests {
       var fakeClient = harness.newFakeClient().build();
 
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarcloudMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
         .start(fakeClient);
 
       when(fakeClient.checkServerTrusted(any(), any()))
@@ -195,7 +197,7 @@ class SslMediumTests {
     void it_should_fail_if_client_certificate_not_provided(SonarLintTestHarness harness) {
       var fakeClient = harness.newFakeClient().build();
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarcloudMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
         .start(fakeClient);
 
       when(fakeClient.checkServerTrusted(any(), any()))
@@ -214,7 +216,7 @@ class SslMediumTests {
       var fakeClient = harness.newFakeClient().build();
       var backend = harness.newBackend()
         .withKeyStore(toPath(Objects.requireNonNull(SslMediumTests.class.getResource("/ssl/client.p12"))), "pwdClientCertP12", null)
-        .withSonarCloudUrl(sonarcloudMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
         .start(fakeClient);
 
       when(fakeClient.checkServerTrusted(any(), any()))

--- a/medium-tests/src/test/java/mediumtest/http/TimeoutMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/TimeoutMediumTests.java
@@ -20,6 +20,7 @@
 package mediumtest.http;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -27,6 +28,7 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.GetOrganizationParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -58,7 +60,7 @@ class TimeoutMediumTests {
       .build();
     var backend = harness.newBackend()
       .withHttpResponseTimeout(Duration.ofSeconds(1))
-      .withSonarCloudUrl(sonarcloudMock.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
       .start(fakeClient);
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?organizations=myOrg&ps=500&p=1")
       .willReturn(aResponse().withStatus(200)

--- a/medium-tests/src/test/java/mediumtest/http/TimeoutMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/http/TimeoutMediumTests.java
@@ -20,7 +20,6 @@
 package mediumtest.http;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
-import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -28,7 +27,6 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.org.GetOrganizationParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
@@ -60,7 +58,7 @@ class TimeoutMediumTests {
       .build();
     var backend = harness.newBackend()
       .withHttpResponseTimeout(Duration.ofSeconds(1))
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarcloudMock.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(sonarcloudMock.baseUrl())
       .start(fakeClient);
     sonarcloudMock.stubFor(get("/api/organizations/search.protobuf?organizations=myOrg&ps=500&p=1")
       .willReturn(aResponse().withStatus(200)

--- a/medium-tests/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
@@ -19,14 +19,12 @@
  */
 package mediumtest.issues;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckAnticipatedStatusChangeSupportedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckAnticipatedStatusChangeSupportedResponse;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
@@ -61,7 +59,7 @@ class CheckAnticipatedStatusChangeSupportedMediumTests {
   @SonarLintTest
   void it_should_not_be_available_for_sonarcloud(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(mockWebServerExtension.endpointParams().getBaseUrl())
       .withSonarCloudConnection("connectionId", "orgKey")
       .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
       .start();

--- a/medium-tests/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/CheckAnticipatedStatusChangeSupportedMediumTests.java
@@ -19,12 +19,14 @@
  */
 package mediumtest.issues;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckAnticipatedStatusChangeSupportedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckAnticipatedStatusChangeSupportedResponse;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
@@ -59,7 +61,7 @@ class CheckAnticipatedStatusChangeSupportedMediumTests {
   @SonarLintTest
   void it_should_not_be_available_for_sonarcloud(SonarLintTestHarness harness) {
     var backend = harness.newBackend()
-      .withSonarCloudUrl(mockWebServerExtension.endpointParams().getBaseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "orgKey")
       .withBoundConfigScope("configScopeId", "connectionId", "projectKey")
       .start();

--- a/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
@@ -21,6 +21,7 @@ package mediumtest.issues;
 
 import com.google.protobuf.Message;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -44,6 +45,7 @@ import org.sonar.scanner.protocol.Constants;
 import org.sonarsource.sonarlint.core.commons.RuleType;
 import org.sonarsource.sonarlint.core.commons.api.TextRange;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFilesAndTrackParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckStatusChangePermittedResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.ResolutionStatus;
@@ -128,7 +130,7 @@ class CheckResolutionStatusChangePermittedMediumTests {
   void it_should_allow_2_statuses_when_user_has_permission_for_sonarcloud(SonarLintTestHarness harness) {
     fakeServerWithIssue("issueKey", "orgKey", List.of("wontfix", "falsepositive"));
     var backend = harness.newBackend()
-      .withSonarCloudUrl(mockWebServerExtension.endpointParams().getBaseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, null))
       .withSonarCloudConnection(CONNECTION_ID, "orgKey")
       .start();
 

--- a/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
@@ -21,7 +21,6 @@ package mediumtest.issues;
 
 import com.google.protobuf.Message;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -45,7 +44,6 @@ import org.sonar.scanner.protocol.Constants;
 import org.sonarsource.sonarlint.core.commons.RuleType;
 import org.sonarsource.sonarlint.core.commons.api.TextRange;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFilesAndTrackParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckStatusChangePermittedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.CheckStatusChangePermittedResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.ResolutionStatus;
@@ -130,7 +128,7 @@ class CheckResolutionStatusChangePermittedMediumTests {
   void it_should_allow_2_statuses_when_user_has_permission_for_sonarcloud(SonarLintTestHarness harness) {
     fakeServerWithIssue("issueKey", "orgKey", List.of("wontfix", "falsepositive"));
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(mockWebServerExtension.endpointParams().getBaseUrl())
       .withSonarCloudConnection(CONNECTION_ID, "orgKey")
       .start();
 

--- a/medium-tests/src/test/java/mediumtest/issues/IssuesStatusChangeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/IssuesStatusChangeMediumTests.java
@@ -20,6 +20,7 @@
 package mediumtest.issues;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -37,6 +38,7 @@ import org.sonarsource.sonarlint.core.commons.LocalOnlyIssueResolution;
 import org.sonarsource.sonarlint.core.commons.RuleType;
 import org.sonarsource.sonarlint.core.commons.api.TextRangeWithHash;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFilesAndTrackParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.AddIssueCommentParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.ChangeIssueStatusParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.ReopenAllIssuesForFileParams;
@@ -99,7 +101,7 @@ class IssuesStatusChangeMediumTests {
       .withIssueTransitionStatusCode(404)
       .start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection(CONNECTION_ID, "myOrg", true, storageBuilder -> storageBuilder
         .withProject("projectKey", projectStorageBuilder -> projectStorageBuilder.withMainBranch("main")))
       .withBoundConfigScope(CONFIGURATION_SCOPE_ID, CONNECTION_ID, "projectKey")
@@ -119,7 +121,7 @@ class IssuesStatusChangeMediumTests {
         project -> project.withBranch("main"))
       .start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection(CONNECTION_ID, "myOrg", true, storageBuilder -> storageBuilder
         .withProject("projectKey", projectStorageBuilder -> projectStorageBuilder.withMainBranch("main")))
       .withBoundConfigScope(CONFIGURATION_SCOPE_ID, CONNECTION_ID, "projectKey")

--- a/medium-tests/src/test/java/mediumtest/issues/IssuesStatusChangeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/IssuesStatusChangeMediumTests.java
@@ -20,7 +20,6 @@
 package mediumtest.issues;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -38,7 +37,6 @@ import org.sonarsource.sonarlint.core.commons.LocalOnlyIssueResolution;
 import org.sonarsource.sonarlint.core.commons.RuleType;
 import org.sonarsource.sonarlint.core.commons.api.TextRangeWithHash;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFilesAndTrackParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.AddIssueCommentParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.ChangeIssueStatusParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.ReopenAllIssuesForFileParams;
@@ -101,7 +99,7 @@ class IssuesStatusChangeMediumTests {
       .withIssueTransitionStatusCode(404)
       .start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection(CONNECTION_ID, "myOrg", true, storageBuilder -> storageBuilder
         .withProject("projectKey", projectStorageBuilder -> projectStorageBuilder.withMainBranch("main")))
       .withBoundConfigScope(CONFIGURATION_SCOPE_ID, CONNECTION_ID, "projectKey")
@@ -121,7 +119,7 @@ class IssuesStatusChangeMediumTests {
         project -> project.withBranch("main"))
       .start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection(CONNECTION_ID, "myOrg", true, storageBuilder -> storageBuilder
         .withProject("projectKey", projectStorageBuilder -> projectStorageBuilder.withMainBranch("main")))
       .withBoundConfigScope(CONFIGURATION_SCOPE_ID, CONNECTION_ID, "projectKey")

--- a/medium-tests/src/test/java/mediumtest/issues/OpenFixSuggestionInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/OpenFixSuggestionInIdeMediumTests.java
@@ -38,7 +38,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.Bindin
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.DidUpdateBindingParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarCloudConnectionConfigurationDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.binding.AssistBindingResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionResponse;
@@ -102,7 +101,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withTelemetryEnabled()
@@ -130,7 +129,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withSonarCloudConnection(CONNECTION_ID, ORG_KEY)
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()
@@ -167,7 +166,7 @@ class OpenFixSuggestionInIdeMediumTests {
 
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withUnboundConfigScope(CONFIG_SCOPE_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withOpenFixSuggestion()
@@ -192,7 +191,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withUnboundConfigScope("configScopeA", PROJECT_KEY + " 1")
       .withUnboundConfigScope("configScopeB", PROJECT_KEY + " 2")
       .withEmbeddedServer()
@@ -220,7 +219,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withUnboundConfigScope("configScopeParent", PROJECT_KEY)
       .withUnboundConfigScope("configScopeChild", PROJECT_KEY, "configScopeParent")
       .withEmbeddedServer()
@@ -247,7 +246,7 @@ class OpenFixSuggestionInIdeMediumTests {
 
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withUnboundConfigScope(CONFIG_SCOPE_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withOpenFixSuggestion()
@@ -279,7 +278,7 @@ class OpenFixSuggestionInIdeMediumTests {
 
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withUnboundConfigScope(CONFIG_SCOPE_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withOpenFixSuggestion()
@@ -337,7 +336,7 @@ class OpenFixSuggestionInIdeMediumTests {
     var fakeClient = harness.newFakeClient().build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withSonarCloudConnection(CONNECTION_ID, ORG_KEY)
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()
@@ -364,7 +363,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(scServer.baseUrl())
       .withSonarCloudConnection(CONNECTION_ID, ORG_KEY)
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()

--- a/medium-tests/src/test/java/mediumtest/issues/OpenFixSuggestionInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/OpenFixSuggestionInIdeMediumTests.java
@@ -38,6 +38,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.Bindin
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.DidUpdateBindingParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarCloudConnectionConfigurationDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.binding.AssistBindingResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionResponse;
@@ -101,7 +102,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withTelemetryEnabled()
@@ -129,7 +130,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withSonarCloudConnection(CONNECTION_ID, ORG_KEY)
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()
@@ -166,7 +167,7 @@ class OpenFixSuggestionInIdeMediumTests {
 
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withUnboundConfigScope(CONFIG_SCOPE_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withOpenFixSuggestion()
@@ -191,7 +192,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withUnboundConfigScope("configScopeA", PROJECT_KEY + " 1")
       .withUnboundConfigScope("configScopeB", PROJECT_KEY + " 2")
       .withEmbeddedServer()
@@ -219,7 +220,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withUnboundConfigScope("configScopeParent", PROJECT_KEY)
       .withUnboundConfigScope("configScopeChild", PROJECT_KEY, "configScopeParent")
       .withEmbeddedServer()
@@ -246,7 +247,7 @@ class OpenFixSuggestionInIdeMediumTests {
 
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withUnboundConfigScope(CONFIG_SCOPE_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withOpenFixSuggestion()
@@ -278,7 +279,7 @@ class OpenFixSuggestionInIdeMediumTests {
 
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withUnboundConfigScope(CONFIG_SCOPE_ID, PROJECT_KEY)
       .withEmbeddedServer()
       .withOpenFixSuggestion()
@@ -336,7 +337,7 @@ class OpenFixSuggestionInIdeMediumTests {
     var fakeClient = harness.newFakeClient().build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withSonarCloudConnection(CONNECTION_ID, ORG_KEY)
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()
@@ -363,7 +364,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .build();
     var scServer = buildSonarCloudServer(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(scServer.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(scServer.baseUrl()), null, null))
       .withSonarCloudConnection(CONNECTION_ID, ORG_KEY)
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withEmbeddedServer()

--- a/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
@@ -38,7 +38,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.Bindin
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.DidUpdateBindingParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarQubeConnectionConfigurationDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.binding.AssistBindingResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionResponse;
@@ -311,7 +310,7 @@ class OpenIssueInIdeMediumTests {
     var fakeClient = harness.newFakeClient().build();
     var fakeServerWithIssue = fakeServerWithIssue(harness).start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create("https://sonar.my"), null, null))
+      .withSonarQubeCloudEuRegionUri("https://sonar.my")
       .withUnboundConfigScope(CONFIG_SCOPE_ID, SONAR_PROJECT_NAME)
       .withEmbeddedServer()
       .beforeInitialize(createdBackend -> {
@@ -341,7 +340,7 @@ class OpenIssueInIdeMediumTests {
     doThrow(RuntimeException.class).when(fakeClient).assistCreatingConnection(any(), any());
 
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create("https://sonar.my"), null, null))
+      .withSonarQubeCloudEuRegionUri("https://sonar.my")
       .withUnboundConfigScope(CONFIG_SCOPE_ID, SONAR_PROJECT_NAME)
       .withEmbeddedServer()
       .start(fakeClient);

--- a/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
@@ -38,6 +38,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.Bindin
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.DidUpdateBindingParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarQubeConnectionConfigurationDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.binding.AssistBindingResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionResponse;
@@ -310,7 +311,7 @@ class OpenIssueInIdeMediumTests {
     var fakeClient = harness.newFakeClient().build();
     var fakeServerWithIssue = fakeServerWithIssue(harness).start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl("https://sonar.my")
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create("https://sonar.my"), null, null))
       .withUnboundConfigScope(CONFIG_SCOPE_ID, SONAR_PROJECT_NAME)
       .withEmbeddedServer()
       .beforeInitialize(createdBackend -> {
@@ -340,7 +341,7 @@ class OpenIssueInIdeMediumTests {
     doThrow(RuntimeException.class).when(fakeClient).assistCreatingConnection(any(), any());
 
     var backend = harness.newBackend()
-      .withSonarCloudUrl("https://sonar.my")
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create("https://sonar.my"), null, null))
       .withUnboundConfigScope(CONFIG_SCOPE_ID, SONAR_PROJECT_NAME)
       .withEmbeddedServer()
       .start(fakeClient);

--- a/medium-tests/src/test/java/mediumtest/remediation/aicodefix/AiCodeFixMediumTest.java
+++ b/medium-tests/src/test/java/mediumtest/remediation/aicodefix/AiCodeFixMediumTest.java
@@ -19,6 +19,7 @@
  */
 package mediumtest.remediation.aicodefix;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -30,6 +31,7 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidUpdateFileSystemParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.remediation.aicodefix.SuggestFixChangeDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.remediation.aicodefix.SuggestFixParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
@@ -156,7 +158,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -200,7 +202,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(true).enabledForAllProjects()))
@@ -240,7 +242,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(false)))
@@ -280,7 +282,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(true).disabled()))
@@ -320,7 +322,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(true).enabledForProjects("otherProjectKey")))
@@ -397,7 +399,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -429,7 +431,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -461,7 +463,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -506,7 +508,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR"))))
       .withBoundConfigScope("configScope", "connectionId", "projectKey")
@@ -541,7 +543,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR"))))
       .withBoundConfigScope("configScope", "connectionId", "projectKey")
@@ -577,7 +579,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR"))))
       .withBoundConfigScope("configScope", "connectionId", "projectKey")

--- a/medium-tests/src/test/java/mediumtest/remediation/aicodefix/AiCodeFixMediumTest.java
+++ b/medium-tests/src/test/java/mediumtest/remediation/aicodefix/AiCodeFixMediumTest.java
@@ -19,7 +19,6 @@
  */
 package mediumtest.remediation.aicodefix;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
@@ -31,7 +30,6 @@ import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidUpdateFileSystemParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.remediation.aicodefix.SuggestFixChangeDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.remediation.aicodefix.SuggestFixParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
@@ -158,7 +156,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -202,7 +200,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(true).enabledForAllProjects()))
@@ -242,7 +240,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(false)))
@@ -282,7 +280,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(true).disabled()))
@@ -322,7 +320,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.JAVA)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S1220", "MAJOR")))
         .withAiCodeFixSettings(settings -> settings.organizationEligible(true).enabledForProjects("otherProjectKey")))
@@ -399,7 +397,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -431,7 +429,7 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -463,7 +461,8 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
+      .withSonarQubeCloudEuRegionApiUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR")))
         .withAiCodeFixSettings(aiCodeFix -> aiCodeFix
@@ -508,7 +507,8 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
+      .withSonarQubeCloudEuRegionApiUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR"))))
       .withBoundConfigScope("configScope", "connectionId", "projectKey")
@@ -543,7 +543,8 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
+      .withSonarQubeCloudEuRegionApiUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR"))))
       .withBoundConfigScope("configScope", "connectionId", "projectKey")
@@ -579,7 +580,8 @@ public class AiCodeFixMediumTest {
       .build();
     var backend = harness.newBackend()
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), URI.create(server.baseUrl()), null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
+      .withSonarQubeCloudEuRegionApiUri(server.baseUrl())
       .withSonarCloudConnection("connectionId", "organizationKey", true, storage -> storage
         .withProject("projectKey", project -> project.withRuleSet("xml", ruleSet -> ruleSet.withActiveRule("xml:S3421", "MAJOR"))))
       .withBoundConfigScope("configScope", "connectionId", "projectKey")

--- a/medium-tests/src/test/java/mediumtest/rules/RuleDetailsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/rules/RuleDetailsMediumTests.java
@@ -19,7 +19,9 @@
  */
 package mediumtest.rules;
 
+import java.net.URI;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.GetRuleDetailsParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.RuleType;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
@@ -59,7 +61,7 @@ class RuleDetailsMediumTests {
         project -> project.withBranch("branchName"))
       .start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.TEXT)
       .withExtraEnabledLanguagesInConnectedMode(JAVA)
       .withSonarCloudConnection("connectionId",
@@ -80,7 +82,7 @@ class RuleDetailsMediumTests {
         project -> project.withBranch("branchName"))
       .start();
     var backend = harness.newBackend()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withStandaloneEmbeddedPlugin(TestPlugin.PYTHON)
       .withEnabledLanguageInStandaloneMode(Language.IPYTHON)
       .withSonarCloudConnection("connectionId",

--- a/medium-tests/src/test/java/mediumtest/rules/RuleDetailsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/rules/RuleDetailsMediumTests.java
@@ -19,9 +19,7 @@
  */
 package mediumtest.rules;
 
-import java.net.URI;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.GetRuleDetailsParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.RuleType;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
@@ -61,7 +59,7 @@ class RuleDetailsMediumTests {
         project -> project.withBranch("branchName"))
       .start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.TEXT)
       .withExtraEnabledLanguagesInConnectedMode(JAVA)
       .withSonarCloudConnection("connectionId",
@@ -82,7 +80,7 @@ class RuleDetailsMediumTests {
         project -> project.withBranch("branchName"))
       .start();
     var backend = harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withStandaloneEmbeddedPlugin(TestPlugin.PYTHON)
       .withEnabledLanguageInStandaloneMode(Language.IPYTHON)
       .withSonarCloudConnection("connectionId",

--- a/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
@@ -22,7 +22,6 @@ package mediumtest.server.events;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
-import java.net.URI;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
@@ -51,7 +50,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.Did
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarCloudConnectionConfigurationDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarQubeConnectionConfigurationDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TaintVulnerabilityDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TextRangeWithHashDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
@@ -117,7 +115,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_not_subscribe_for_events_if_sonarcloud_connection(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarServerMock.baseUrl())
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -254,7 +252,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_not_subscribe_if_bound_to_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarServerMock.baseUrl())
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -293,7 +291,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_do_nothing_if_scope_was_bound_to_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarServerMock.baseUrl())
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -391,7 +389,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_do_nothing_if_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarServerMock.baseUrl())
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -480,7 +478,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_do_nothing_if_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarServerMock.baseUrl())
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -536,7 +534,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_not_resubscribe_if_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
+        .withSonarQubeCloudEuRegionUri(sonarServerMock.baseUrl())
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()

--- a/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/server/events/ServerSentEventsMediumTests.java
@@ -22,6 +22,7 @@ package mediumtest.server.events;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import java.net.URI;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
@@ -50,6 +51,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.Did
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarCloudConnectionConfigurationDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarQubeConnectionConfigurationDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TaintVulnerabilityDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TextRangeWithHashDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
@@ -115,7 +117,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_not_subscribe_for_events_if_sonarcloud_connection(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarServerMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -252,7 +254,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_not_subscribe_if_bound_to_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarServerMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -291,7 +293,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_do_nothing_if_scope_was_bound_to_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarServerMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -389,7 +391,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_do_nothing_if_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarServerMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -478,7 +480,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_do_nothing_if_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarServerMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()
@@ -534,7 +536,7 @@ class ServerSentEventsMediumTests {
     @SonarLintTest
     void should_not_resubscribe_if_sonarcloud(SonarLintTestHarness harness) {
       var backend = harness.newBackend()
-        .withSonarCloudUrl(sonarServerMock.baseUrl())
+        .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(sonarServerMock.baseUrl()), null, null))
         .withEnabledLanguageInStandaloneMode(JS)
         .withExtraEnabledLanguagesInConnectedMode(JAVA)
         .withServerSentEventsEnabled()

--- a/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
@@ -19,7 +19,6 @@
  */
 package mediumtest.smartnotifications;
 
-import java.net.URI;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -32,7 +31,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.Bindin
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.ConfigurationScopeDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidAddConfigurationScopesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidRemoveConfigurationScopeParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
 import org.sonarsource.sonarlint.core.serverapi.UrlUtils;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
@@ -259,7 +257,7 @@ class SmartNotificationsMediumTests {
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
     harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(mockWebServerExtension.endpointParams().getBaseUrl())
       .withSonarCloudConnectionAndNotifications(CONNECTION_ID, "myOrg", storage -> storage.withProject(PROJECT_KEY, project -> project.withLastSmartNotificationPoll(STORED_DATE)))
       .withBoundConfigScope("scopeId", CONNECTION_ID, PROJECT_KEY)
       .withSmartNotifications()
@@ -283,7 +281,8 @@ class SmartNotificationsMediumTests {
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
     harness.newBackend()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, URI.create(webSocketServer.getUrl())))
+      .withSonarQubeCloudEuRegionUri(mockWebServerExtension.endpointParams().getBaseUrl())
+      .withSonarQubeCloudEuRegionWebSocketUri(webSocketServer.getUrl())
       .withSonarCloudConnectionAndNotifications(CONNECTION_ID, "myOrg", storage -> storage.withProject(PROJECT_KEY, project -> project.withLastSmartNotificationPoll(STORED_DATE)))
       .withBoundConfigScope("scopeId", CONNECTION_ID, PROJECT_KEY)
       .withSmartNotifications()

--- a/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
@@ -19,6 +19,7 @@
  */
 package mediumtest.smartnotifications;
 
+import java.net.URI;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.Bindin
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.ConfigurationScopeDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidAddConfigurationScopesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidRemoveConfigurationScopeParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
 import org.sonarsource.sonarlint.core.serverapi.UrlUtils;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
@@ -257,7 +259,7 @@ class SmartNotificationsMediumTests {
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
     harness.newBackend()
-      .withSonarCloudUrl(mockWebServerExtension.endpointParams().getBaseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, null))
       .withSonarCloudConnectionAndNotifications(CONNECTION_ID, "myOrg", storage -> storage.withProject(PROJECT_KEY, project -> project.withLastSmartNotificationPoll(STORED_DATE)))
       .withBoundConfigScope("scopeId", CONNECTION_ID, PROJECT_KEY)
       .withSmartNotifications()
@@ -281,8 +283,7 @@ class SmartNotificationsMediumTests {
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
     harness.newBackend()
-      .withSonarCloudUrl(mockWebServerExtension.endpointParams().getBaseUrl())
-      .withSonarCloudWebSocketsUrl(webSocketServer.getUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(mockWebServerExtension.endpointParams().getBaseUrl()), null, URI.create(webSocketServer.getUrl())))
       .withSonarCloudConnectionAndNotifications(CONNECTION_ID, "myOrg", storage -> storage.withProject(PROJECT_KEY, project -> project.withLastSmartNotificationPoll(STORED_DATE)))
       .withBoundConfigScope("scopeId", CONNECTION_ID, PROJECT_KEY)
       .withSmartNotifications()

--- a/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
@@ -46,6 +46,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.DidUpd
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.ConfigurationScopeDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidAddConfigurationScopesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidUpdateFileSystemParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedFindingDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedIssueDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.log.LogLevel;
@@ -758,7 +759,7 @@ class IssueTrackingMediumTests {
     var backend = harness.newBackend()
       .withSonarCloudConnection(connectionId, orgKey, true, storage -> {})
       .withFullSynchronization()
-      .withSonarCloudUrl(server.baseUrl())
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
       .withBoundConfigScope(CONFIG_SCOPE_ID, connectionId, projectKey)
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
       .start(client);

--- a/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
@@ -46,7 +46,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.DidUpd
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.ConfigurationScopeDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.scope.DidAddConfigurationScopesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.file.DidUpdateFileSystemParams;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedFindingDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedIssueDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.log.LogLevel;
@@ -759,7 +758,7 @@ class IssueTrackingMediumTests {
     var backend = harness.newBackend()
       .withSonarCloudConnection(connectionId, orgKey, true, storage -> {})
       .withFullSynchronization()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(URI.create(server.baseUrl()), null, null))
+      .withSonarQubeCloudEuRegionUri(server.baseUrl())
       .withBoundConfigScope(CONFIG_SCOPE_ID, connectionId, projectKey)
       .withConnectedEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
       .start(client);

--- a/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
@@ -19,6 +19,7 @@
  */
 package mediumtest.websockets;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -39,6 +40,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.Did
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarCloudConnectionConfigurationDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarQubeConnectionConfigurationDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintBackendFixture;
@@ -1448,7 +1450,8 @@ class WebSocketMediumTests {
   public SonarLintBackendFixture.SonarLintBackendBuilder newBackendWithWebSockets(SonarLintTestHarness harness) {
     return harness.newBackend()
       .withServerSentEventsEnabled()
-      .withSonarCloudWebSocketsUrl(webSocketServer.getUrl());
+      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(null, null, URI.create(webSocketServer.getUrl())))
+      .withSonarQubeCloudUsRegionDto(null);
   }
 
   public static class WebSocketPayloadBuilder {

--- a/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
@@ -19,7 +19,6 @@
  */
 package mediumtest.websockets;
 
-import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -40,7 +39,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.Did
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.DidUpdateConnectionsParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarCloudConnectionConfigurationDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.connection.config.SonarQubeConnectionConfigurationDto;
-import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintBackendFixture;
@@ -1450,8 +1448,7 @@ class WebSocketMediumTests {
   public SonarLintBackendFixture.SonarLintBackendBuilder newBackendWithWebSockets(SonarLintTestHarness harness) {
     return harness.newBackend()
       .withServerSentEventsEnabled()
-      .withSonarQubeCloudEuRegionDto(new SonarQubeCloudRegionDto(null, null, URI.create(webSocketServer.getUrl())))
-      .withSonarQubeCloudUsRegionDto(null);
+      .withSonarQubeCloudEuRegionWebSocketUri(webSocketServer.getUrl());
   }
 
   public static class WebSocketPayloadBuilder {

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/SonarCloudAlternativeEnvironmentDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/SonarCloudAlternativeEnvironmentDto.java
@@ -19,28 +19,41 @@
  */
 package org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize;
 
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import java.net.URI;
 
 /** This contains the alternative environment information for SonarQube Cloud with both the EU and US region */
 public class SonarCloudAlternativeEnvironmentDto {
-  @Nullable
   private final SonarQubeCloudRegionDto euRegion;
-  @Nullable
   private final SonarQubeCloudRegionDto usRegion;
+
+  /**
+   * @deprecated use the other constructor instead
+   */
+  @Deprecated(since = "10.16")
+  public SonarCloudAlternativeEnvironmentDto(URI uri, URI webSocketsEndpointUri) {
+    this(uri, uri, webSocketsEndpointUri);
+  }
+
+  /**
+   *
+   * @deprecated use the other constructor instead
+   * @param uri the base URI, e.g. https://sonarcloud.io
+   * @param apiUri the base URI of new endpoints, e.g. https://api.sonarcloud.io. Must be specified because for some env it cannot be deduced from the base URI (e.g. Dev)
+   */
+  @Deprecated(since = "10.17")
+  public SonarCloudAlternativeEnvironmentDto(URI uri, URI apiUri, URI webSocketsEndpointUri) {
+    this(new SonarQubeCloudRegionDto(uri, apiUri, webSocketsEndpointUri), new SonarQubeCloudRegionDto(null, null, null));
+  }
   
-  public SonarCloudAlternativeEnvironmentDto(@Nullable SonarQubeCloudRegionDto euRegion, @Nullable SonarQubeCloudRegionDto usRegion) {
+  public SonarCloudAlternativeEnvironmentDto(SonarQubeCloudRegionDto euRegion, SonarQubeCloudRegionDto usRegion) {
     this.euRegion = euRegion;
     this.usRegion = usRegion;
   }
-
-  @CheckForNull
+  
   public SonarQubeCloudRegionDto getEuRegion() {
     return euRegion;
   }
 
-  @CheckForNull
   public SonarQubeCloudRegionDto getUsRegion() {
     return usRegion;
   }

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/SonarCloudAlternativeEnvironmentDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/SonarCloudAlternativeEnvironmentDto.java
@@ -20,11 +20,12 @@
 package org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize;
 
 import java.net.URI;
+import java.util.Map;
+import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 
 /** This contains the alternative environment information for SonarQube Cloud with both the EU and US region */
 public class SonarCloudAlternativeEnvironmentDto {
-  private final SonarQubeCloudRegionDto euRegion;
-  private final SonarQubeCloudRegionDto usRegion;
+  private final Map<SonarCloudRegion, SonarQubeCloudRegionDto> alternativeRegionUris;
 
   /**
    * @deprecated use the other constructor instead
@@ -42,19 +43,14 @@ public class SonarCloudAlternativeEnvironmentDto {
    */
   @Deprecated(since = "10.17")
   public SonarCloudAlternativeEnvironmentDto(URI uri, URI apiUri, URI webSocketsEndpointUri) {
-    this(new SonarQubeCloudRegionDto(uri, apiUri, webSocketsEndpointUri), new SonarQubeCloudRegionDto(null, null, null));
+    this(Map.of(SonarCloudRegion.EU, new SonarQubeCloudRegionDto(uri, apiUri, webSocketsEndpointUri)));
   }
   
-  public SonarCloudAlternativeEnvironmentDto(SonarQubeCloudRegionDto euRegion, SonarQubeCloudRegionDto usRegion) {
-    this.euRegion = euRegion;
-    this.usRegion = usRegion;
-  }
-  
-  public SonarQubeCloudRegionDto getEuRegion() {
-    return euRegion;
+  public SonarCloudAlternativeEnvironmentDto(Map<SonarCloudRegion, SonarQubeCloudRegionDto> alternateRegionUris) {
+    this.alternativeRegionUris = alternateRegionUris;
   }
 
-  public SonarQubeCloudRegionDto getUsRegion() {
-    return usRegion;
+  public Map<SonarCloudRegion, SonarQubeCloudRegionDto> getAlternateRegionUris() {
+    return alternativeRegionUris;
   }
 }

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/SonarQubeCloudRegionDto.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/initialize/SonarQubeCloudRegionDto.java
@@ -19,29 +19,43 @@
  */
 package org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize;
 
-
+import java.net.URI;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-/** This contains the alternative environment information for SonarQube Cloud with both the EU and US region */
-public class SonarCloudAlternativeEnvironmentDto {
+/** This is used to configure the required URIs for a SonarQube Cloud Region */
+public class SonarQubeCloudRegionDto {
   @Nullable
-  private final SonarQubeCloudRegionDto euRegion;
+  private final URI uri;
   @Nullable
-  private final SonarQubeCloudRegionDto usRegion;
-  
-  public SonarCloudAlternativeEnvironmentDto(@Nullable SonarQubeCloudRegionDto euRegion, @Nullable SonarQubeCloudRegionDto usRegion) {
-    this.euRegion = euRegion;
-    this.usRegion = usRegion;
+  private final URI apiUri;
+  @Nullable
+  private final URI webSocketsEndpointUri;
+
+  /**
+   *  All of the URIs can be null!
+   *  
+   *  @param uri the base URI, e.g. https://sonarcloud.io
+   *  @param apiUri the base URI of new endpoints, e.g. https://api.sonarcloud.io. Must be specified because for some env it cannot be deduced from the base URI (e.g. Dev)
+   */
+  public SonarQubeCloudRegionDto(@Nullable URI uri, @Nullable URI apiUri, @Nullable URI webSocketsEndpointUri) {
+    this.uri = uri;
+    this.apiUri = apiUri;
+    this.webSocketsEndpointUri = webSocketsEndpointUri;
   }
 
   @CheckForNull
-  public SonarQubeCloudRegionDto getEuRegion() {
-    return euRegion;
+  public URI getUri() {
+    return uri;
   }
 
   @CheckForNull
-  public SonarQubeCloudRegionDto getUsRegion() {
-    return usRegion;
+  public URI getApiUri() {
+    return apiUri;
+  }
+
+  @CheckForNull
+  public URI getWebSocketsEndpointUri() {
+    return webSocketsEndpointUri;
   }
 }

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
@@ -496,11 +496,10 @@ public class SonarLintBackendFixture {
         var clientInfo = new ClientConstantInfoDto(clientName, userAgent, 0);
         var featureFlags = new FeatureFlagsDto(manageSmartNotifications, taintVulnerabilitiesEnabled, synchronizeProjects, startEmbeddedServer, areSecurityHotspotsEnabled,
           manageServerSentEvents, enableDataflowBugDetection, shouldManageFullSynchronization, telemetryEnabled, canOpenFixSuggestion, monitoringEnabled);
-
-        SonarCloudAlternativeEnvironmentDto sonarCloudAlternativeEnvironment = null;
-        if (euRegionDto != null || usRegionDto != null) {
-          sonarCloudAlternativeEnvironment = new SonarCloudAlternativeEnvironmentDto(euRegionDto, usRegionDto);
-        }
+        
+        var actualEuRegionDto = euRegionDto != null ? euRegionDto : new SonarQubeCloudRegionDto(null, null, null);
+        var actualUsRegionDto = usRegionDto != null ? usRegionDto : new SonarQubeCloudRegionDto(null, null, null);
+        var sonarCloudAlternativeEnvironment = new SonarCloudAlternativeEnvironmentDto(actualEuRegionDto, actualUsRegionDto);
 
         var sslConfiguration = new SslConfigurationDto(null, null, null, keyStorePath, keyStorePassword, keyStoreType);
         var httpConfiguration = new HttpConfigurationDto(sslConfiguration, null, null, null, responseTimeout);

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
@@ -46,7 +46,6 @@ import java.util.function.Consumer;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.jetbrains.annotations.NotNull;
-import org.sonarsource.sonarlint.core.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.client.ClientJsonRpcLauncher;
 import org.sonarsource.sonarlint.core.rpc.client.ConfigScopeNotFoundException;
 import org.sonarsource.sonarlint.core.rpc.client.SonarLintCancelChecker;
@@ -65,6 +64,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.Initialize
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.JsTsRequirementsDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.LanguageSpecificRequirements;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarCloudAlternativeEnvironmentDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SslConfigurationDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.TelemetryClientConstantAttributesDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.TelemetryMigrationDto;
@@ -161,8 +161,11 @@ public class SonarLintBackendFixture {
     private boolean isFocusOnNewCode;
     private boolean enableDataflowBugDetection;
 
-    private String sonarCloudUrl;
-    private String sonarCloudWebSocketsUrl;
+    @Nullable
+    private SonarQubeCloudRegionDto euRegionDto;
+    @Nullable
+    private SonarQubeCloudRegionDto usRegionDto;
+    
     private Duration responseTimeout;
     private Path keyStorePath;
     private String keyStorePassword;
@@ -234,14 +237,14 @@ public class SonarLintBackendFixture {
       storages.add(storage);
       return this;
     }
-
-    public SonarLintBackendBuilder withSonarCloudUrl(String sonarCloudUrl) {
-      this.sonarCloudUrl = sonarCloudUrl;
+    
+    public SonarLintBackendBuilder withSonarQubeCloudEuRegionDto(@Nullable SonarQubeCloudRegionDto euRegionDto) {
+      this.euRegionDto = euRegionDto;
       return this;
     }
 
-    public SonarLintBackendBuilder withSonarCloudWebSocketsUrl(String sonarCloudWebSocketsUrl) {
-      this.sonarCloudWebSocketsUrl = sonarCloudWebSocketsUrl;
+    public SonarLintBackendBuilder withSonarQubeCloudUsRegionDto(@Nullable SonarQubeCloudRegionDto usRegionDto) {
+      this.usRegionDto = usRegionDto;
       return this;
     }
 
@@ -495,12 +498,8 @@ public class SonarLintBackendFixture {
           manageServerSentEvents, enableDataflowBugDetection, shouldManageFullSynchronization, telemetryEnabled, canOpenFixSuggestion, monitoringEnabled);
 
         SonarCloudAlternativeEnvironmentDto sonarCloudAlternativeEnvironment = null;
-        if (sonarCloudUrl != null || sonarCloudWebSocketsUrl != null) {
-          var baseUri = sonarCloudUrl == null ? SonarCloudRegion.EU.getProductionUri() : URI.create(sonarCloudUrl);
-          sonarCloudAlternativeEnvironment = new SonarCloudAlternativeEnvironmentDto(
-            baseUri,
-            baseUri,
-            sonarCloudWebSocketsUrl == null ? SonarCloudRegion.EU.getWebSocketUri() : URI.create(sonarCloudWebSocketsUrl));
+        if (euRegionDto != null || usRegionDto != null) {
+          sonarCloudAlternativeEnvironment = new SonarCloudAlternativeEnvironmentDto(euRegionDto, usRegionDto);
         }
 
         var sslConfiguration = new SslConfigurationDto(null, null, null, keyStorePath, keyStorePassword, keyStoreType);

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
@@ -96,6 +96,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.TelemetryCli
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
+import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TokenDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.UsernamePasswordDto;
 import org.sonarsource.sonarlint.core.test.utils.plugins.Plugin;
@@ -162,9 +163,18 @@ public class SonarLintBackendFixture {
     private boolean enableDataflowBugDetection;
 
     @Nullable
-    private SonarQubeCloudRegionDto euRegionDto;
+    private String euRegionUri;
     @Nullable
-    private SonarQubeCloudRegionDto usRegionDto;
+    private String euRegionApiUri;
+    @Nullable
+    private String euRegionWebSocketUri;
+
+    @Nullable
+    private String usRegionUri;
+    @Nullable
+    private String usRegionApiUri;
+    @Nullable
+    private String usRegionWebSocketUri;
     
     private Duration responseTimeout;
     private Path keyStorePath;
@@ -238,13 +248,33 @@ public class SonarLintBackendFixture {
       return this;
     }
     
-    public SonarLintBackendBuilder withSonarQubeCloudEuRegionDto(@Nullable SonarQubeCloudRegionDto euRegionDto) {
-      this.euRegionDto = euRegionDto;
+    public SonarLintBackendBuilder withSonarQubeCloudEuRegionUri(String euRegionUri) {
+      this.euRegionUri = euRegionUri;
       return this;
     }
 
-    public SonarLintBackendBuilder withSonarQubeCloudUsRegionDto(@Nullable SonarQubeCloudRegionDto usRegionDto) {
-      this.usRegionDto = usRegionDto;
+    public SonarLintBackendBuilder withSonarQubeCloudEuRegionApiUri(String euRegionApiUri) {
+      this.euRegionApiUri = euRegionApiUri;
+      return this;
+    }
+
+    public SonarLintBackendBuilder withSonarQubeCloudEuRegionWebSocketUri(String euRegionWebSocketUri) {
+      this.euRegionWebSocketUri = euRegionWebSocketUri;
+      return this;
+    }
+
+    public SonarLintBackendBuilder withSonarQubeCloudUsRegionUri(String usRegionUri) {
+      this.usRegionUri = usRegionUri;
+      return this;
+    }
+
+    public SonarLintBackendBuilder withSonarQubeCloudUsRegionApiUri(String usRegionApiUri) {
+      this.usRegionApiUri = usRegionApiUri;
+      return this;
+    }
+
+    public SonarLintBackendBuilder withSonarQubeCloudUsRegionWebSocketUri(String usRegionWebSocketUri) {
+      this.usRegionWebSocketUri = usRegionWebSocketUri;
       return this;
     }
 
@@ -497,9 +527,12 @@ public class SonarLintBackendFixture {
         var featureFlags = new FeatureFlagsDto(manageSmartNotifications, taintVulnerabilitiesEnabled, synchronizeProjects, startEmbeddedServer, areSecurityHotspotsEnabled,
           manageServerSentEvents, enableDataflowBugDetection, shouldManageFullSynchronization, telemetryEnabled, canOpenFixSuggestion, monitoringEnabled);
         
-        var actualEuRegionDto = euRegionDto != null ? euRegionDto : new SonarQubeCloudRegionDto(null, null, null);
-        var actualUsRegionDto = usRegionDto != null ? usRegionDto : new SonarQubeCloudRegionDto(null, null, null);
-        var sonarCloudAlternativeEnvironment = new SonarCloudAlternativeEnvironmentDto(actualEuRegionDto, actualUsRegionDto);
+        // If more regions are added in the future, extend this by adding a new entry set and add the fields / methods above!
+        var sonarCloudAlternativeEnvironment = new SonarCloudAlternativeEnvironmentDto(Map.of(
+          SonarCloudRegion.EU,
+          new SonarQubeCloudRegionDto(createUriFromString(euRegionUri), createUriFromString(euRegionApiUri), createUriFromString(euRegionWebSocketUri)),
+          SonarCloudRegion.US,
+          new SonarQubeCloudRegionDto(createUriFromString(usRegionUri), createUriFromString(usRegionApiUri), createUriFromString(usRegionWebSocketUri))));
 
         var sslConfiguration = new SslConfigurationDto(null, null, null, keyStorePath, keyStorePassword, keyStoreType);
         var httpConfiguration = new HttpConfigurationDto(sslConfiguration, null, null, null, responseTimeout);
@@ -519,6 +552,10 @@ public class SonarLintBackendFixture {
       } catch (Exception e) {
         throw new IllegalStateException("Cannot initialize the backend", e);
       }
+    }
+    
+    private static URI createUriFromString(@Nullable String uri) {
+      return uri == null ? null : URI.create(uri);
     }
 
     private static SonarLintTestRpcServer createTestBackend(SonarLintRpcClientDelegate client) throws IOException {


### PR DESCRIPTION
[SLCORE-1154](https://sonarsource.atlassian.net/browse/SLCORE-1154)

This extends the already existing alternative SonarQube Cloud environment (the EU region). This has to be implemented on the client side and can/will be re-used for the tests.

I think with that I found a good balance with not changing too much but relying on `DTO`s instead of adding just 3 more strings (`URI`s) to the `SonarCloudAlternativeEnvironmentDto`. The good thing is that the end user does not always have to have both `DTO`s or for one all `URI`s configured but can just change one specific for testing.

[SLCORE-1154]: https://sonarsource.atlassian.net/browse/SLCORE-1154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ