### PR TITLE
SLCORE-1157: Take into account SQ-C region for clues

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
@@ -221,7 +221,7 @@ public class BindingClueProvider {
         return null;
       }
       return new BindingProperties(getAndTrim(properties, "sonar.projectKey"), getAndTrim(properties, "sonar.organization"),
-        getAndTrim(properties, "sonar.host.url"), null, false);
+        getAndTrim(properties, "sonar.host.url"), getAndTrim(properties, "sonar.region"), false);
     }
   }
 
@@ -256,15 +256,14 @@ public class BindingClueProvider {
   @CheckForNull
   private BindingClue computeBindingClue(String filename, BindingProperties scannerProps) {
     if (AUTOSCAN_CONFIG_FILENAME.equals(filename)) {
-      return new SonarCloudBindingClue(scannerProps.projectKey, scannerProps.organization, null, scannerProps.isFromSharedConfiguration);
+      return new SonarCloudBindingClue(scannerProps.projectKey, scannerProps.organization, scannerProps.region, scannerProps.isFromSharedConfiguration);
     }
     if (scannerProps.organization != null) {
       return new SonarCloudBindingClue(scannerProps.projectKey, scannerProps.organization, scannerProps.region, scannerProps.isFromSharedConfiguration);
     }
     if (scannerProps.serverUrl != null) {
       if (sonarCloudActiveEnvironment.isSonarQubeCloud(scannerProps.serverUrl)) {
-        var region = sonarCloudActiveEnvironment.getRegionOrThrow(scannerProps.serverUrl);
-        return new SonarCloudBindingClue(scannerProps.projectKey, null, SonarCloudRegion.valueOf(region.name()), scannerProps.isFromSharedConfiguration);
+        return new SonarCloudBindingClue(scannerProps.projectKey, null, scannerProps.region, scannerProps.isFromSharedConfiguration);
       } else {
         return new SonarQubeBindingClue(scannerProps.projectKey, scannerProps.serverUrl, scannerProps.isFromSharedConfiguration);
       }

--- a/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
@@ -94,7 +94,7 @@ class SharedConnectedModeSettingsMediumTests {
 
     var backend = harness.newBackend()
       .withSonarQubeCloudEuRegionUri(server.baseUrl())
-      .withSonarCloudConnection(connectionId, organizationKey)
+      .withSonarCloudConnection(connectionId, organizationKey, "US")
       .withBoundConfigScope(configScopeId, connectionId, projectKey)
       .withTelemetryEnabled()
       .start();
@@ -102,10 +102,7 @@ class SharedConnectedModeSettingsMediumTests {
     var result = getFileContents(backend, configScopeId);
 
     assertThat(result).succeedsWithin(3, TimeUnit.SECONDS);
-    
-    // This currently returns "EU" instead of "US" but this is what is tested here
-    assertThat(result.get().getJsonFileContent()).isNotEqualTo(expectedFileContent);
-    
+    assertThat(result.get().getJsonFileContent()).isEqualTo(expectedFileContent);
     assertThat(backend.telemetryFilePath())
       .content().asBase64Decoded().asString()
       .contains("\"exportedConnectedModeCount\":1");

--- a/spec/connected_mode/binding_suggestion.adoc
+++ b/spec/connected_mode/binding_suggestion.adoc
@@ -35,6 +35,7 @@ For each xref:../glossary.adoc#configuration_scope[configuration scope]:
 - `sonar.projectKey`
 - `sonar.host.url`
 - `sonar.organization`
+- `sonar.region`
 
 3. For each filename + tuple of properties, try to guess if we are looking for a SonarQube or SonarCloud connection, using the following heuristic:
 - if the file is `.sonarcloud.properties`, this is SonarCloud (AutoScan)
@@ -56,6 +57,7 @@ At the end of this step, we should have a possibly empty list of binding clues h
 |SonarCloud Binding Clue
 |projectKey: string?
 |organization: string?
+|region: string?
 |=======
 
 [%autowidth,options="header"]

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
@@ -280,13 +280,18 @@ public class SonarLintBackendFixture {
 
     public SonarLintBackendBuilder withSonarCloudConnection(String connectionId, String organizationKey, boolean disableNotifications,
       @Nullable Consumer<StorageFixture.StorageBuilder> storageBuilder) {
+      return withSonarCloudConnection(connectionId, organizationKey, SonarCloudRegion.EU.name(), disableNotifications, storageBuilder);
+    }
+
+    public SonarLintBackendBuilder withSonarCloudConnection(String connectionId, String organizationKey, String region, boolean disableNotifications,
+      @Nullable Consumer<StorageFixture.StorageBuilder> storageBuilder) {
       if (storageBuilder != null) {
         var storage = newStorage(connectionId);
         storageBuilder.accept(storage);
         storages.add(storage);
       }
       sonarCloudConnections.add(new SonarCloudConnectionConfigurationDto(connectionId, organizationKey,
-        SonarCloudRegion.EU, disableNotifications));
+        SonarCloudRegion.valueOf(region), disableNotifications));
       return this;
     }
 
@@ -300,6 +305,10 @@ public class SonarLintBackendFixture {
 
     public SonarLintBackendBuilder withSonarCloudConnection(String connectionId, String organizationKey) {
       return withSonarCloudConnection(connectionId, organizationKey, true, null);
+    }
+
+    public SonarLintBackendBuilder withSonarCloudConnection(String connectionId, String organizationKey, String region) {
+      return withSonarCloudConnection(connectionId, organizationKey, region, true, null);
     }
 
     public SonarLintBackendBuilder withUnboundConfigScope(String configurationScopeId) {


### PR DESCRIPTION
[SLCORE-1157](https://sonarsource.atlassian.net/browse/SLCORE-1157)

When trying to guess binding clues, also take into account the region.

[SLCORE-1157]: https://sonarsource.atlassian.net/browse/SLCORE-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ