### PR TITLE
SLCORE-1208: SonarQube Cloud US Region URI

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarCloudRegion.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarCloudRegion.java
@@ -23,7 +23,7 @@ import java.net.URI;
 
 public enum SonarCloudRegion {
   EU("https://sonarcloud.io", "https://api.sonarcloud.io", "wss://events-api.sonarcloud.io/"),
-  US("https://us.sonarcloud.io", "https://api.us.sonarcloud.io", "wss://events-api.us.sonarcloud.io/");
+  US("https://sonarqube.us", "https://api.sonarqube.us", "wss://events-api.sonarqube.us/");
 
   private final URI productionUri;
   private final URI apiProductionUri;


### PR DESCRIPTION
Move to the new SonarQube Cloud US Region URIs that will be used in the tests and on the client side.