### PR TITLE
SLCORE-1234 Keep track of the connections state

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/connection/ServerConnection.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/connection/ServerConnection.java
@@ -38,11 +38,17 @@ public class ServerConnection {
   private ConnectionState state = ConnectionState.ACTIVE;
   @Nullable
   private Instant lastNotificationTime;
+  private final boolean withoutCredentials;
 
   public ServerConnection(String connectionId, ServerApi serverApi, SonarLintRpcClient client) {
+    this(connectionId, serverApi, client, false);
+  }
+
+  public ServerConnection(String connectionId, ServerApi serverApi, SonarLintRpcClient client, boolean withoutCredentials) {
     this.connectionId = connectionId;
     this.serverApi = serverApi;
     this.client = client;
+    this.withoutCredentials = withoutCredentials;
   }
 
   public boolean isSonarCloud() {
@@ -78,6 +84,9 @@ public class ServerConnection {
   }
 
   private boolean shouldNotifyAboutWrongToken() {
+    if (withoutCredentials) {
+      return false;
+    }
     if (state != ConnectionState.INVALID_CREDENTIALS && state != ConnectionState.MISSING_PERMISSION) {
       return false;
     }

--- a/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilitiesMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/taint/vulnerabilities/TaintVulnerabilitiesMediumTests.java
@@ -155,9 +155,7 @@ class TaintVulnerabilitiesMediumTests {
 
     var taintVulnerabilities = refreshAndListAllTaintVulnerabilities(backend, "configScopeId");
 
-    assertThat(taintVulnerabilities)
-      .extracting(TaintVulnerabilityDto::getIntroductionDate)
-      .contains(newestIntroductionDate);
+    assertThat(ChronoUnit.MINUTES.between(taintVulnerabilities.get(0).getIntroductionDate(), newestIntroductionDate)).isZero();
   }
 
   private List<TaintVulnerabilityDto> listAllTaintVulnerabilities(SonarLintTestRpcServer backend, String configScopeId) {

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintBackendFixture.java
@@ -708,7 +708,7 @@ public class SonarLintBackendFixture {
     Map<String, Map<URI, List<RaisedHotspotDto>>> raisedHotspotsByScopeId = new HashMap<>();
     Map<String, Map<String, String>> inferredAnalysisPropertiesByScopeId = new HashMap<>();
     Map<String, Boolean> analysisReadinessPerScopeId = new HashMap<>();
-    Set<String> connectionIdsWithInvalidToken = new HashSet<>();
+    Map<String, Integer> invalidTokenNotificationsCountPerConnectionId = new HashMap<>();
 
     public FakeSonarLintRpcClient(Map<String, Either<TokenDto, UsernamePasswordDto>> credentialsByConnectionId, boolean printLogsToStdOut,
       Map<String, String> matchedBranchPerScopeId, Map<String, Path> baseDirsByConfigScope, Map<String, List<ClientFileDto>> initialFilesByConfigScope,
@@ -783,7 +783,7 @@ public class SonarLintBackendFixture {
 
     @Override
     public void invalidToken(String connectionId) {
-      connectionIdsWithInvalidToken.add(connectionId);
+      invalidTokenNotificationsCountPerConnectionId.merge(connectionId, 1, Integer::sum);
     }
 
     public Map<String, ProgressReport> getProgressReportsByTaskId() {
@@ -994,8 +994,8 @@ public class SonarLintBackendFixture {
       verify(this, timeout(5000)).didSynchronizeConfigurationScopes(any());
     }
 
-    public Set<String> getConnectionIdsWithInvalidToken() {
-      return connectionIdsWithInvalidToken;
+    public Integer getConnectionIdsWithInvalidToken(String connectionId) {
+      return invalidTokenNotificationsCountPerConnectionId.getOrDefault(connectionId, 0);
     }
 
     public static class ProgressReport {


### PR DESCRIPTION
[SLCORE-1234](https://sonarsource.atlassian.net/browse/SLCORE-1234)

Solution is to introduce the cache of ServerConnection objects on the level of ConnectionManager. 

Getting connection without credentials is a creation of one-time use adhoc object to send a request that doesn't require authorization. So connections without credentials are not being stored in cache. And they never send connection error notifications. 


[SLCORE-1234]: https://sonarsource.atlassian.net/browse/SLCORE-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ