### PR TITLE
SLCORE-1261: Warn users that 9.9 LTA will soon be unsupported

### DIFF
--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/VersionTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/VersionTests.java
@@ -24,6 +24,12 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class VersionTests {
+  @Test
+  void test_versioning_changes_handled_correctly() {
+    var newVersion = Version.create("2025.1.0.102418");
+    var oldVersion = Version.create("9.9.0.65466");
+    assertThat(newVersion).isGreaterThan(oldVersion);
+  }
 
   @Test
   void test_fields_of_snapshot_versions() {

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtils.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtils.java
@@ -23,15 +23,16 @@ import org.sonarsource.sonarlint.core.commons.Version;
 
 public class VersionUtils {
 
-  private static final Version CURRENT_LTS = Version.create("9.9");
+  private static final Version CURRENT_LTS = Version.create("2025.1");
   private static final Version MINIMAL_SUPPORTED_VERSION = Version.create("9.9");
 
   private VersionUtils() {
   }
 
   /**
-   * Right now since minimal supported version is equal to current LTS (9.9) this method will always return false.
-   * But it's important to keep it for the future when next LTS will be released, and we will have a grace period again.
+   *  When the CURRENT_LTS matches the MINIMAL_SUPPORTED_VERSION, this method will always return false. If this is not
+   *  the case, it returns true. Therefore for every change in the LTS/LTA and minimal supported version the test at
+   *  {@link VersionUtilsTest#grace_period_should_be_true_if_connected_during_grace_period} has to be adjusted!
    */
   public static boolean isVersionSupportedDuringGracePeriod(Version currentVersion) {
     return currentVersion.compareTo(CURRENT_LTS) < 0 &&

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtilsTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtilsTests.java
@@ -42,8 +42,13 @@ class VersionUtilsTests {
   @Test
   void grace_period_should_be_true_if_connected_during_grace_period() {
     // read isVersionSupportedDuringGracePeriod javadoc
-    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(getMinimalSupportedVersion())).isFalse();
-    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create(getMinimalSupportedVersion().getName() + ".1"))).isFalse();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(getMinimalSupportedVersion())).isTrue();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create(getMinimalSupportedVersion().getName() + ".1"))).isTrue();
   }
-
+  
+  @Test
+  void test_version_in_between_minimal_and_current_LTS() {
+    // read isVersionSupportedDuringGracePeriod javadoc
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("10.4.1"))).isTrue();
+  }
 }


### PR DESCRIPTION
[SLCORE-1261](https://sonarsource.atlassian.net/browse/SLCORE-1261)

With the latest LTA being 2025.1 we should warn every between 9.9 LTA and the new, latest LTA, that they will soon run out of support.


[SLCORE-1261]: https://sonarsource.atlassian.net/browse/SLCORE-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ