### PR TITLE
SLCORE-1264 Ignore Maven Wrapper During SCA Step

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,7 +103,7 @@ test_linux_task:
   <<: *MAVEN_CACHE_DEFINITION
   script:
     - source cirrus-env QA
-    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dcommercial -Dmaven.install.skip=true -Dmaven.deploy.skip=true -Dsonar.coverage.jacoco.xmlReportPaths=$CIRRUS_WORKING_DIR/report-aggregate/target/site/jacoco-aggregate/jacoco.xml
+    - PULL_REQUEST_SHA=$GIT_SHA1 regular_mvn_build_deploy_analyze -P-deploy-sonarsource,-release,-sign -Dcommercial -Dmaven.install.skip=true -Dmaven.deploy.skip=true -Dsonar.coverage.jacoco.xmlReportPaths=$CIRRUS_WORKING_DIR/report-aggregate/target/site/jacoco-aggregate/jacoco.xml -Dsonar.sca.mavenIgnoreWrapper=true
   cleanup_before_cache_script: cleanup_maven_repository
   always:
     junit_artifacts:


### PR DESCRIPTION
[SLCORE-1264](https://sonarsource.atlassian.net/browse/SLCORE-1264)

This PR adds the option in the `test_linux` build step to ignore the Maven Wrapper committed to this project and instead use the provided Maven binary that is being used to run the SQ analysis. This should help prevent the dependency resolution steps during the SCA step in the SQ scanner process from failing to resolve dependency information due to the `MAVEN_CONFIG` option that seems to break the Maven Wrapper calls.

[SLCORE-1264]: https://sonarsource.atlassian.net/browse/SLCORE-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ