### PR TITLE
SLCORE-1276 Add telemetry metrics for usage of analysis reporting

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -15,6 +15,9 @@
 ## New features
 
 * Add a new constructor to `org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.InitializeParams` constructor to provide flags as an enum values list.
+* Add `analysisReportingTriggered` method to `org.sonarsource.sonarlint.core.rpc.protocol.backend.telemetry.TelemetryRpcService`
+  * It is used to report usage of analysis features such as the analysis of VCS changed files, all project files or for the pre-commit analysis
+  * Should not be implemented unless necessary
 
 ## Deprecation
 

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
@@ -167,7 +167,7 @@ public class TelemetryService {
   }
 
   public void analysisReportingTriggered(AnalysisReportingTriggeredParams params) {
-    updateTelemetry(localStorage -> localStorage.analysisReportingTriggered(params.getAnalysisTypeId()));
+    updateTelemetry(localStorage -> localStorage.analysisReportingTriggered(params.getAnalysisType()));
   }
 
   public void fixSuggestionResolved(FixSuggestionResolvedParams params) {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
@@ -42,6 +42,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.Initialize
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.telemetry.GetStatusResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedFindingDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedIssueDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingTriggeredParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionResolvedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.HelpAndFeedbackClickedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
@@ -163,6 +164,10 @@ public class TelemetryService {
 
   public void helpAndFeedbackLinkClicked(HelpAndFeedbackClickedParams params) {
     updateTelemetry(localStorage -> localStorage.helpAndFeedbackLinkClicked(params.getItemId()));
+  }
+
+  public void analysisReportingTriggered(AnalysisReportingTriggeredParams params) {
+    updateTelemetry(localStorage -> localStorage.analysisReportingTriggered(params.getAnalysisTypeId()));
   }
 
   public void fixSuggestionResolved(FixSuggestionResolvedParams params) {

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TelemetryRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TelemetryRpcServiceDelegate.java
@@ -25,6 +25,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.telemetry.TelemetryRp
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddQuickFixAppliedForRuleParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddReportedRulesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisDoneOnSingleLanguageParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingTriggeredParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.DevNotificationsClickedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionResolvedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.HelpAndFeedbackClickedParams;
@@ -89,6 +90,11 @@ class TelemetryRpcServiceDelegate extends AbstractRpcServiceDelegate implements 
   @Override
   public void helpAndFeedbackLinkClicked(HelpAndFeedbackClickedParams params) {
     notify(() -> getBean(TelemetryService.class).helpAndFeedbackLinkClicked(params));
+  }
+
+  @Override
+  public void analysisReportingTriggered(AnalysisReportingTriggeredParams params) {
+    notify(() -> getBean(TelemetryService.class).analysisReportingTriggered(params));
   }
 
   @Override

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryAnalysisReportingCounter.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryAnalysisReportingCounter.java
@@ -1,0 +1,39 @@
+/*
+ * SonarLint Core - Telemetry
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.telemetry;
+
+public class TelemetryAnalysisReportingCounter {
+  private int analysisReportingCount;
+
+  public TelemetryAnalysisReportingCounter() {
+  }
+
+  public TelemetryAnalysisReportingCounter(int analysisReportingTriggered) {
+    this.analysisReportingCount = analysisReportingTriggered;
+  }
+
+  public int getAnalysisReportingCount() {
+    return analysisReportingCount;
+  }
+
+  public void incrementAnalysisReportingCount() {
+    this.analysisReportingCount++;
+  }
+}

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
@@ -60,6 +60,7 @@ public class TelemetryLocalStorage {
   private final Set<String> quickFixesApplied;
   private final Map<String, Integer> quickFixCountByRuleKey;
   private final Map<String, TelemetryHelpAndFeedbackCounter> helpAndFeedbackLinkClickedCount;
+  private final Map<String, TelemetryAnalysisReportingCounter> analysisReportingCount;
   private final Map<String, TelemetryFixSuggestionReceivedCounter> fixSuggestionReceivedCounter;
   private final Map<String, List<TelemetryFixSuggestionResolvedStatus>> fixSuggestionResolved;
   private final Set<UUID> issuesUuidAiFixableSeen;
@@ -82,6 +83,7 @@ public class TelemetryLocalStorage {
     quickFixesApplied = new HashSet<>();
     quickFixCountByRuleKey = new LinkedHashMap<>();
     helpAndFeedbackLinkClickedCount = new LinkedHashMap<>();
+    analysisReportingCount = new LinkedHashMap<>();
     fixSuggestionReceivedCounter = new LinkedHashMap<>();
     fixSuggestionResolved = new LinkedHashMap<>();
     issuesUuidAiFixableSeen = new HashSet<>();
@@ -149,6 +151,10 @@ public class TelemetryLocalStorage {
     return helpAndFeedbackLinkClickedCount;
   }
 
+  public Map<String, TelemetryAnalysisReportingCounter> getAnalysisReportingCount() {
+    return analysisReportingCount;
+  }
+
   public Map<String, TelemetryFixSuggestionReceivedCounter> getFixSuggestionReceivedCounter() {
     return fixSuggestionReceivedCounter;
   }
@@ -201,6 +207,7 @@ public class TelemetryLocalStorage {
     quickFixesApplied.clear();
     quickFixCountByRuleKey.clear();
     helpAndFeedbackLinkClickedCount.clear();
+    analysisReportingCount.clear();
     fixSuggestionReceivedCounter.clear();
     fixSuggestionResolved.clear();
     issuesUuidAiFixableSeen.clear();
@@ -374,6 +381,10 @@ public class TelemetryLocalStorage {
 
   public void helpAndFeedbackLinkClicked(String itemId) {
     this.helpAndFeedbackLinkClickedCount.computeIfAbsent(itemId, k -> new TelemetryHelpAndFeedbackCounter()).incrementHelpAndFeedbackLinkClickedCount();
+  }
+
+  public void analysisReportingTriggered(String analysisTypeId) {
+    this.analysisReportingCount.computeIfAbsent(analysisTypeId, k -> new TelemetryAnalysisReportingCounter()).incrementAnalysisReportingCount();
   }
 
   public void incrementHotspotStatusChangedCount() {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AiSuggestionSource;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingType;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionStatus;
 
 import static java.time.temporal.ChronoUnit.DAYS;
@@ -60,7 +61,7 @@ public class TelemetryLocalStorage {
   private final Set<String> quickFixesApplied;
   private final Map<String, Integer> quickFixCountByRuleKey;
   private final Map<String, TelemetryHelpAndFeedbackCounter> helpAndFeedbackLinkClickedCount;
-  private final Map<String, TelemetryAnalysisReportingCounter> analysisReportingCount;
+  private final Map<AnalysisReportingType, TelemetryAnalysisReportingCounter> analysisReportingCountersByType;
   private final Map<String, TelemetryFixSuggestionReceivedCounter> fixSuggestionReceivedCounter;
   private final Map<String, List<TelemetryFixSuggestionResolvedStatus>> fixSuggestionResolved;
   private final Set<UUID> issuesUuidAiFixableSeen;
@@ -83,7 +84,7 @@ public class TelemetryLocalStorage {
     quickFixesApplied = new HashSet<>();
     quickFixCountByRuleKey = new LinkedHashMap<>();
     helpAndFeedbackLinkClickedCount = new LinkedHashMap<>();
-    analysisReportingCount = new LinkedHashMap<>();
+    analysisReportingCountersByType = new LinkedHashMap<>();
     fixSuggestionReceivedCounter = new LinkedHashMap<>();
     fixSuggestionResolved = new LinkedHashMap<>();
     issuesUuidAiFixableSeen = new HashSet<>();
@@ -151,8 +152,8 @@ public class TelemetryLocalStorage {
     return helpAndFeedbackLinkClickedCount;
   }
 
-  public Map<String, TelemetryAnalysisReportingCounter> getAnalysisReportingCount() {
-    return analysisReportingCount;
+  public Map<AnalysisReportingType, TelemetryAnalysisReportingCounter> getAnalysisReportingCountersByType() {
+    return analysisReportingCountersByType;
   }
 
   public Map<String, TelemetryFixSuggestionReceivedCounter> getFixSuggestionReceivedCounter() {
@@ -207,7 +208,7 @@ public class TelemetryLocalStorage {
     quickFixesApplied.clear();
     quickFixCountByRuleKey.clear();
     helpAndFeedbackLinkClickedCount.clear();
-    analysisReportingCount.clear();
+    analysisReportingCountersByType.clear();
     fixSuggestionReceivedCounter.clear();
     fixSuggestionResolved.clear();
     issuesUuidAiFixableSeen.clear();
@@ -383,8 +384,8 @@ public class TelemetryLocalStorage {
     this.helpAndFeedbackLinkClickedCount.computeIfAbsent(itemId, k -> new TelemetryHelpAndFeedbackCounter()).incrementHelpAndFeedbackLinkClickedCount();
   }
 
-  public void analysisReportingTriggered(String analysisTypeId) {
-    this.analysisReportingCount.computeIfAbsent(analysisTypeId, k -> new TelemetryAnalysisReportingCounter()).incrementAnalysisReportingCount();
+  public void analysisReportingTriggered(AnalysisReportingType analysisType) {
+    this.analysisReportingCountersByType.computeIfAbsent(analysisType, k -> new TelemetryAnalysisReportingCounter()).incrementAnalysisReportingCount();
   }
 
   public void incrementHotspotStatusChangedCount() {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
@@ -50,6 +50,8 @@ public class TelemetryMeasuresBuilder {
 
     addHelpAndFeedbackMeasures(values);
 
+    addAnalysisReportingMeasures(values);
+
     addQuickFixMeasures(values);
 
     addIssuesMeasures(values);
@@ -76,6 +78,18 @@ public class TelemetryMeasuresBuilder {
       .map(e -> new TelemetryMeasuresValue(
         "help_and_feedback." + e.getKey().toLowerCase(Locale.ROOT),
         String.valueOf(e.getValue().getHelpAndFeedbackLinkClickedCount()),
+        INTEGER,
+        DAILY
+      ))
+      .forEach(values::add);
+  }
+
+  private void addAnalysisReportingMeasures(List<TelemetryMeasuresValue> values) {
+    storage.getAnalysisReportingCountersByType().entrySet().stream()
+      .filter(e -> e.getValue().getAnalysisReportingCount() > 0)
+      .map(e -> new TelemetryMeasuresValue(
+        "analysis_reporting." + e.getKey().getId(),
+        String.valueOf(e.getValue().getAnalysisReportingCount()),
         INTEGER,
         DAILY
       ))

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
@@ -109,6 +109,7 @@ class TelemetryHttpClientTests {
       .willReturn(aResponse()));
     var telemetryLocalStorage = new TelemetryLocalStorage();
     telemetryLocalStorage.helpAndFeedbackLinkClicked("docs");
+    telemetryLocalStorage.analysisReportingTriggered("pre_commit");
     telemetryLocalStorage.addQuickFixAppliedForRule("java:S107");
     telemetryLocalStorage.addQuickFixAppliedForRule("python:S107");
     telemetryLocalStorage.addNewlyFoundIssues(1);
@@ -128,6 +129,7 @@ class TelemetryHttpClientTests {
           {"sonarlint_product":"product","os":"%s","dimension":"installation", "metric_values": [
             {"key":"shared_connected_mode.manual","value":"0","type":"integer","granularity":"daily"},
             {"key":"help_and_feedback.docs","value":"1","type":"integer","granularity":"daily"},
+            {"key":"analysis_reporting.pre_commit","value":"1","type":"integer","granularity":"daily"},
             {"key":"quick_fix.applied_count","value":"2","type":"integer","granularity":"daily"},
             {"key":"ide_issues.found","value":"1","type":"integer","granularity":"daily"},
             {"key":"ide_issues.fixed","value":"2","type":"integer","granularity":"daily"}

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
@@ -31,6 +31,7 @@ import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.http.HttpClientProvider;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.InitializeParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.TelemetryClientConstantAttributesDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingType;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.TelemetryClientLiveAttributesResponse;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
@@ -109,7 +110,7 @@ class TelemetryHttpClientTests {
       .willReturn(aResponse()));
     var telemetryLocalStorage = new TelemetryLocalStorage();
     telemetryLocalStorage.helpAndFeedbackLinkClicked("docs");
-    telemetryLocalStorage.analysisReportingTriggered("pre_commit");
+    telemetryLocalStorage.analysisReportingTriggered(AnalysisReportingType.PRE_COMMIT_ANALYSIS_TYPE);
     telemetryLocalStorage.addQuickFixAppliedForRule("java:S107");
     telemetryLocalStorage.addQuickFixAppliedForRule("python:S107");
     telemetryLocalStorage.addNewlyFoundIssues(1);
@@ -129,7 +130,7 @@ class TelemetryHttpClientTests {
           {"sonarlint_product":"product","os":"%s","dimension":"installation", "metric_values": [
             {"key":"shared_connected_mode.manual","value":"0","type":"integer","granularity":"daily"},
             {"key":"help_and_feedback.docs","value":"1","type":"integer","granularity":"daily"},
-            {"key":"analysis_reporting.pre_commit","value":"1","type":"integer","granularity":"daily"},
+            {"key":"analysis_reporting.trigger_count_pre_commit","value":"1","type":"integer","granularity":"daily"},
             {"key":"quick_fix.applied_count","value":"2","type":"integer","granularity":"daily"},
             {"key":"ide_issues.found","value":"1","type":"integer","granularity":"daily"},
             {"key":"ide_issues.fixed","value":"2","type":"integer","granularity":"daily"}

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingType.PRE_COMMIT_ANALYSIS_TYPE;
 
 class TelemetryManagerTests {
   private static final int DEFAULT_NOTIF_CLICKED = 5;
@@ -57,7 +58,6 @@ class TelemetryManagerTests {
 
   private static final String FOO_EVENT = "foo_event";
   private static final String SUGGEST_FEATURE = "suggestFeature";
-  private static final String PRE_COMMIT_ANALYSIS = "trigger_count_pre_commit";
 
   private TelemetryHttpClient client;
   private TelemetryManager telemetryManager;
@@ -207,8 +207,8 @@ class TelemetryManagerTests {
     assertThat(reloaded.notifications().get(FOO_EVENT).getDevNotificationsCount()).isEqualTo(data.notifications().get(FOO_EVENT).getDevNotificationsCount());
     assertThat(reloaded.getHelpAndFeedbackLinkClickedCounter().get(SUGGEST_FEATURE).getHelpAndFeedbackLinkClickedCount())
       .isEqualTo(data.getHelpAndFeedbackLinkClickedCounter().get(SUGGEST_FEATURE).getHelpAndFeedbackLinkClickedCount());
-    assertThat(reloaded.getAnalysisReportingCount().get(PRE_COMMIT_ANALYSIS).getAnalysisReportingCount())
-      .isEqualTo(data.getAnalysisReportingCount().get(PRE_COMMIT_ANALYSIS).getAnalysisReportingCount());
+    assertThat(reloaded.getAnalysisReportingCountersByType().get(PRE_COMMIT_ANALYSIS_TYPE).getAnalysisReportingCount())
+      .isEqualTo(data.getAnalysisReportingCountersByType().get(PRE_COMMIT_ANALYSIS_TYPE).getAnalysisReportingCount());
   }
 
   @Test
@@ -232,7 +232,7 @@ class TelemetryManagerTests {
       data.setNumUseDays(5);
       data.notifications().put(FOO_EVENT, new TelemetryNotificationsCounter(DEFAULT_NOTIF_COUNT, DEFAULT_NOTIF_CLICKED));
       data.getHelpAndFeedbackLinkClickedCounter().put(SUGGEST_FEATURE, new TelemetryHelpAndFeedbackCounter(DEFAULT_HELP_AND_FEEDBACK_COUNT));
-      data.getAnalysisReportingCount().put(PRE_COMMIT_ANALYSIS, new TelemetryAnalysisReportingCounter(DEFAULT_ANALYSIS_REPORTING_COUNT));
+      data.getAnalysisReportingCountersByType().put(PRE_COMMIT_ANALYSIS_TYPE, new TelemetryAnalysisReportingCounter(DEFAULT_ANALYSIS_REPORTING_COUNT));
     });
 
     telemetryManager.uploadAndClearTelemetry(telemetryPayload);
@@ -250,7 +250,7 @@ class TelemetryManagerTests {
     assertThat(reloaded.getFixSuggestionResolved()).isEmpty();
     assertThat(reloaded.openHotspotInBrowserCount()).isZero();
     assertThat(reloaded.getHelpAndFeedbackLinkClickedCounter()).isEmpty();
-    assertThat(reloaded.getAnalysisReportingCount()).isEmpty();
+    assertThat(reloaded.getAnalysisReportingCountersByType()).isEmpty();
   }
 
   private void createAndSaveSampleData(TelemetryLocalStorageManager storage) {
@@ -262,7 +262,7 @@ class TelemetryManagerTests {
       data.setNumUseDays(5);
       data.notifications().put(FOO_EVENT, new TelemetryNotificationsCounter(DEFAULT_NOTIF_COUNT, DEFAULT_NOTIF_CLICKED));
       data.getHelpAndFeedbackLinkClickedCounter().put(SUGGEST_FEATURE, new TelemetryHelpAndFeedbackCounter(DEFAULT_HELP_AND_FEEDBACK_COUNT));
-      data.getAnalysisReportingCount().put(PRE_COMMIT_ANALYSIS, new TelemetryAnalysisReportingCounter(DEFAULT_ANALYSIS_REPORTING_COUNT));
+      data.getAnalysisReportingCountersByType().put(PRE_COMMIT_ANALYSIS_TYPE, new TelemetryAnalysisReportingCounter(DEFAULT_ANALYSIS_REPORTING_COUNT));
     });
   }
 

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
@@ -53,9 +53,11 @@ class TelemetryManagerTests {
   private static final int DEFAULT_NOTIF_CLICKED = 5;
   private static final int DEFAULT_NOTIF_COUNT = 10;
   private static final int DEFAULT_HELP_AND_FEEDBACK_COUNT = 12;
+  private static final int DEFAULT_ANALYSIS_REPORTING_COUNT = 16;
 
   private static final String FOO_EVENT = "foo_event";
   private static final String SUGGEST_FEATURE = "suggestFeature";
+  private static final String PRE_COMMIT_ANALYSIS = "trigger_count_pre_commit";
 
   private TelemetryHttpClient client;
   private TelemetryManager telemetryManager;
@@ -202,7 +204,11 @@ class TelemetryManagerTests {
     assertThat(reloaded.lastUseDate()).isEqualTo(data.lastUseDate());
     assertThat(reloaded.numUseDays()).isEqualTo(data.numUseDays());
     assertThat(reloaded.lastUploadTime()).isEqualTo(data.lastUploadTime());
-    assertThat(reloaded.notifications().get(FOO_EVENT).getDevNotificationsCount()).isEqualTo(10);
+    assertThat(reloaded.notifications().get(FOO_EVENT).getDevNotificationsCount()).isEqualTo(data.notifications().get(FOO_EVENT).getDevNotificationsCount());
+    assertThat(reloaded.getHelpAndFeedbackLinkClickedCounter().get(SUGGEST_FEATURE).getHelpAndFeedbackLinkClickedCount())
+      .isEqualTo(data.getHelpAndFeedbackLinkClickedCounter().get(SUGGEST_FEATURE).getHelpAndFeedbackLinkClickedCount());
+    assertThat(reloaded.getAnalysisReportingCount().get(PRE_COMMIT_ANALYSIS).getAnalysisReportingCount())
+      .isEqualTo(data.getAnalysisReportingCount().get(PRE_COMMIT_ANALYSIS).getAnalysisReportingCount());
   }
 
   @Test
@@ -226,6 +232,7 @@ class TelemetryManagerTests {
       data.setNumUseDays(5);
       data.notifications().put(FOO_EVENT, new TelemetryNotificationsCounter(DEFAULT_NOTIF_COUNT, DEFAULT_NOTIF_CLICKED));
       data.getHelpAndFeedbackLinkClickedCounter().put(SUGGEST_FEATURE, new TelemetryHelpAndFeedbackCounter(DEFAULT_HELP_AND_FEEDBACK_COUNT));
+      data.getAnalysisReportingCount().put(PRE_COMMIT_ANALYSIS, new TelemetryAnalysisReportingCounter(DEFAULT_ANALYSIS_REPORTING_COUNT));
     });
 
     telemetryManager.uploadAndClearTelemetry(telemetryPayload);
@@ -243,6 +250,7 @@ class TelemetryManagerTests {
     assertThat(reloaded.getFixSuggestionResolved()).isEmpty();
     assertThat(reloaded.openHotspotInBrowserCount()).isZero();
     assertThat(reloaded.getHelpAndFeedbackLinkClickedCounter()).isEmpty();
+    assertThat(reloaded.getAnalysisReportingCount()).isEmpty();
   }
 
   private void createAndSaveSampleData(TelemetryLocalStorageManager storage) {
@@ -254,6 +262,7 @@ class TelemetryManagerTests {
       data.setNumUseDays(5);
       data.notifications().put(FOO_EVENT, new TelemetryNotificationsCounter(DEFAULT_NOTIF_COUNT, DEFAULT_NOTIF_CLICKED));
       data.getHelpAndFeedbackLinkClickedCounter().put(SUGGEST_FEATURE, new TelemetryHelpAndFeedbackCounter(DEFAULT_HELP_AND_FEEDBACK_COUNT));
+      data.getAnalysisReportingCount().put(PRE_COMMIT_ANALYSIS, new TelemetryAnalysisReportingCounter(DEFAULT_ANALYSIS_REPORTING_COUNT));
     });
   }
 

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryMeasuresPayloadTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryMeasuresPayloadTests.java
@@ -66,7 +66,8 @@ class TelemetryMeasuresPayloadTests {
       "{\"key\":\"bindings.server_count\",\"value\":\"2\",\"type\":\"integer\",\"granularity\":\"daily\"}," +
       "{\"key\":\"bindings.cloud_eu_count\",\"value\":\"0\",\"type\":\"integer\",\"granularity\":\"daily\"}," +
       "{\"key\":\"bindings.cloud_us_count\",\"value\":\"0\",\"type\":\"integer\",\"granularity\":\"daily\"}," +
-      "{\"key\":\"help_and_feedback.doc_link\",\"value\":\"5\",\"type\":\"integer\",\"granularity\":\"daily\"" +
+      "{\"key\":\"help_and_feedback.doc_link\",\"value\":\"5\",\"type\":\"integer\",\"granularity\":\"daily\"}," +
+      "{\"key\":\"analysis_reporting.trigger_count_vcs_changed_files\",\"value\":\"7\",\"type\":\"integer\",\"granularity\":\"daily\"" +
       "}]" +
       "}");
 
@@ -92,6 +93,8 @@ class TelemetryMeasuresPayloadTests {
 
     values.add(new TelemetryMeasuresValue("help_and_feedback.doc_link", String.valueOf(5), INTEGER, DAILY));
 
+    values.add(new TelemetryMeasuresValue("analysis_reporting.trigger_count_vcs_changed_files", String.valueOf(7), INTEGER, DAILY));
+
     return values;
   }
 
@@ -101,7 +104,8 @@ class TelemetryMeasuresPayloadTests {
       .contains(tuple("shared_connected_mode.imported", "2", INTEGER, DAILY))
       .contains(tuple("shared_connected_mode.auto", "3", INTEGER, DAILY))
       .contains(tuple("shared_connected_mode.exported", "4", INTEGER, DAILY))
-      .contains(tuple("help_and_feedback.doc_link", "5", INTEGER, DAILY));
+      .contains(tuple("help_and_feedback.doc_link", "5", INTEGER, DAILY))
+      .contains(tuple("analysis_reporting.trigger_count_vcs_changed_files", "7", INTEGER, DAILY));
   }
 
 }

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -43,6 +43,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddQuickFixA
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddReportedRulesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisDoneOnSingleLanguageParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingTriggeredParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingType;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.DevNotificationsClickedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionResolvedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionStatus;
@@ -355,9 +356,9 @@ class TelemetryMediumTests {
   void it_should_record_anaysisReportingTriggered(SonarLintTestHarness harness) {
     var backend = setupClientAndBackend(harness);
 
-    backend.getTelemetryService().analysisReportingTriggered(new AnalysisReportingTriggeredParams("analysisTypeId"));
+    backend.getTelemetryService().analysisReportingTriggered(new AnalysisReportingTriggeredParams(AnalysisReportingType.ALL_FILES_ANALYSIS_TYPE));
     await().untilAsserted(() -> assertThat(backend.telemetryFilePath()).content().asBase64Decoded().asString().contains(
-      "\"analysisReportingCount\":{\"analysisTypeId\":{\"analysisReportingCount\":1}}"));
+      "\"analysisReportingCountersByType\":{\"ALL_FILES_ANALYSIS_TYPE\":{\"analysisReportingCount\":1}}"));
   }
 
   @SonarLintTest

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -42,6 +42,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.log.LogParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddQuickFixAppliedForRuleParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddReportedRulesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisDoneOnSingleLanguageParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingTriggeredParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.DevNotificationsClickedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionResolvedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionStatus;
@@ -348,6 +349,15 @@ class TelemetryMediumTests {
     backend.getTelemetryService().helpAndFeedbackLinkClicked(new HelpAndFeedbackClickedParams("itemId"));
     await().untilAsserted(() -> assertThat(backend.telemetryFilePath()).content().asBase64Decoded().asString().contains(
       "\"helpAndFeedbackLinkClickedCount\":{\"itemId\":{\"helpAndFeedbackLinkClickedCount\":1}}"));
+  }
+
+  @SonarLintTest
+  void it_should_record_anaysisReportingTriggered(SonarLintTestHarness harness) {
+    var backend = setupClientAndBackend(harness);
+
+    backend.getTelemetryService().analysisReportingTriggered(new AnalysisReportingTriggeredParams("analysisTypeId"));
+    await().untilAsserted(() -> assertThat(backend.telemetryFilePath()).content().asBase64Decoded().asString().contains(
+      "\"analysisReportingCount\":{\"analysisTypeId\":{\"analysisReportingCount\":1}}"));
   }
 
   @SonarLintTest

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/TelemetryRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/TelemetryRpcService.java
@@ -27,6 +27,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFiles
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddQuickFixAppliedForRuleParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AddReportedRulesParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisDoneOnSingleLanguageParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingTriggeredParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.DevNotificationsClickedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.FixSuggestionResolvedParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.HelpAndFeedbackClickedParams;
@@ -81,6 +82,13 @@ public interface TelemetryRpcService {
 
   @JsonNotification
   void helpAndFeedbackLinkClicked(HelpAndFeedbackClickedParams params);
+
+  /**
+   * Should be used to track the usage of specific types of analysis
+   * This includes analysis of VCS changed files, pre-commit analysis or all project files analysis
+   */
+  @JsonNotification
+  void analysisReportingTriggered(AnalysisReportingTriggeredParams params);
 
   @JsonNotification
   void fixSuggestionResolved(FixSuggestionResolvedParams params);

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AnalysisReportingTriggeredParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AnalysisReportingTriggeredParams.java
@@ -1,0 +1,32 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry;
+
+public class AnalysisReportingTriggeredParams {
+  private final String analysisTypeId;
+
+  public AnalysisReportingTriggeredParams(String analysisTypeId) {
+    this.analysisTypeId = analysisTypeId;
+  }
+
+  public String getAnalysisTypeId() {
+    return analysisTypeId;
+  }
+}

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AnalysisReportingType.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/telemetry/AnalysisReportingType.java
@@ -19,14 +19,18 @@
  */
 package org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry;
 
-public class AnalysisReportingTriggeredParams {
-  private final AnalysisReportingType analysisType;
+public enum AnalysisReportingType {
+  VCS_CHANGED_ANALYSIS_TYPE("trigger_count_vcs_changed_files"),
+  ALL_FILES_ANALYSIS_TYPE("trigger_count_all_project_files"),
+  PRE_COMMIT_ANALYSIS_TYPE("trigger_count_pre_commit");
 
-  public AnalysisReportingTriggeredParams(AnalysisReportingType analysisType) {
-    this.analysisType = analysisType;
+  private final String id;
+
+  AnalysisReportingType(String id) {
+    this.id = id;
   }
 
-  public AnalysisReportingType getAnalysisType() {
-    return analysisType;
+  public String getId() {
+    return id;
   }
 }


### PR DESCRIPTION
[SLCORE-1276](https://sonarsource.atlassian.net/browse/SLCORE-1276)

The goal is to track the usage of specific types of analysis such as analysis VCS changed files, all project files, or the pre-commit analysis. Currently, these actions are purely triggered from the client side.

[SLCORE-1276]: https://sonarsource.atlassian.net/browse/SLCORE-1276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ