### PR TITLE
SLCORE-1406 Consider AnalyzerConfigurationStorage invalid if file doesn't exist

### DIFF
--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorage.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorage.java
@@ -19,6 +19,7 @@
  */
 package org.sonarsource.sonarlint.core.serverconnection;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -45,6 +46,10 @@ public class AnalyzerConfigurationStorage {
   }
 
   public boolean isValid() {
+    if (!Files.exists(storageFilePath)) {
+      LOG.debug("Analyzer configuration storage doesn't exist: {}", storageFilePath);
+      return false;
+    }
     return tryRead().isPresent();
   }
 

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorageTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/AnalyzerConfigurationStorageTests.java
@@ -1,0 +1,44 @@
+/*
+ * SonarLint Core - Server Connection
+ * Copyright (C) 2016-2025 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.serverconnection;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class AnalyzerConfigurationStorageTests {
+  @RegisterExtension
+  private static final SonarLintLogTester logTester = new SonarLintLogTester();
+
+  @Test
+  void should_consider_config_storage_invalid_if_not_readable_and_do_not_log_exception(@TempDir Path tempDir) {
+    var analyzerConfigurationStorage = new AnalyzerConfigurationStorage(tempDir);
+
+    var valid = analyzerConfigurationStorage.isValid();
+
+    assertFalse(valid);
+    assertThat(logTester.logs()).contains("Analyzer configuration storage doesn't exist: " + tempDir.toAbsolutePath().resolve("analyzer_config.pb"));
+  }
+}


### PR DESCRIPTION
[SLCORE-1312](https://sonarsource.atlassian.net/browse/SLCORE-1312)

Proposal is to not log full exception since it ends up being captured by sentry. To reduce the noise we keep logging the fact storage was not available, but without reporting to sentry.
For more generic exception we still report to sentry to be aware about other types of issues here.

[SLCORE-1312]: https://sonarsource.atlassian.net/browse/SLCORE-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ