### PR TITLE
SLCORE-1544 Split porcelain output of `git blame` more robustly

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParser.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParser.java
@@ -31,7 +31,7 @@ import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 
 public class BlameParser {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
-  private static final String FILENAME = "filename ";
+  private static final String FILENAME_PORCELAIN_REGEXP = "\nfilename ";
   private static final String AUTHOR_MAIL = "author-mail ";
   private static final String COMMITTER_TIME = "committer-time ";
   // if this text change between different git versions it will break the implementation
@@ -48,7 +48,7 @@ public class BlameParser {
     }
     var currentFileBlame = new BlameResult.FileBlame(currentFilePath, numberOfLines);
     blameResult.getFileBlameByPath().put(currentFilePath, currentFileBlame);
-    var lineBlameSnippets = blameOutput.split(FILENAME);
+    var lineBlameSnippets = blameOutput.split(FILENAME_PORCELAIN_REGEXP);
     var currentLineNumber = 0;
 
     // because of the way we split the blame output, the last snippet should be skipped
@@ -77,7 +77,7 @@ public class BlameParser {
   }
 
   public static int numberOfLinesInBlameOutput(String blameOutput) {
-    var pattern = Pattern.compile("^" + FILENAME, Pattern.MULTILINE);
+    var pattern = Pattern.compile(FILENAME_PORCELAIN_REGEXP, Pattern.MULTILINE);
     var matcher = pattern.matcher(blameOutput);
     var count = 0;
     while (matcher.find()) {

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParserTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/BlameParserTests.java
@@ -33,4 +33,39 @@ class BlameParserTests {
 
     assertThat(blameResult.getFileBlameByPath()).isEmpty();
   }
+
+  @Test
+  void shouldSplitBlameOutputCorrectlyWhenLinesContainSplitPattern() {
+    var blameResult = new BlameResult();
+    BlameParser.parseBlameOutput("""
+      5746f09bf53067450843eaddff52ea7b0f16cde3 1 1 2
+      author Some One
+      author-mail <some.one@sonarsource.com>
+      author-time 1553598120
+      author-tz +0100
+      committer Some One
+      committer-mail <some.one@sonarsource.com>
+      committer-time 1554191055
+      committer-tz +0200
+      summary Initial revision
+      previous 35c9ca0b1f41231508e706707d76ca0485b8a3ad file.txt
+      filename file.txt
+              First line with filename in it
+      5746f09bf53067450843eaddff52ea7b0f16cde3 2 2
+      author Some One
+      author-mail <some.one@sonarsource.com>
+      author-time 1553598120
+      author-tz +0100
+      committer Some One
+      committer-mail <some.one@sonarsource.com>
+      committer-time 1554191055
+      committer-tz +0200
+      summary Initial revision
+      previous 35c9ca0b1f41231508e706707d76ca0485b8a3ad file.txt
+      filename file.txt
+              Second line also with filename in it
+      """, "", blameResult);
+
+    assertThat(blameResult.getFileBlameByPath()).hasSize(1);
+  }
 }


### PR DESCRIPTION
[SLCORE-1544](https://sonarsource.atlassian.net/browse/SLCORE-1544)



[SLCORE-1544]: https://sonarsource.atlassian.net/browse/SLCORE-1544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ