### PR TITLE
SLCORE-1545 Update dependencies to fix CVEs

### DIFF
--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/MockWebServerExtension.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/MockWebServerExtension.java
@@ -27,7 +27,6 @@ import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
 import okio.Buffer;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -51,7 +50,6 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
     server = new MockWebServer();
     responsesByPath.clear();
     final Dispatcher dispatcher = new Dispatcher() {
-      @NotNull
       @Override
       public MockResponse dispatch(RecordedRequest request) {
         if (responsesByPath.containsKey(request.getPath())) {

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/MockWebServerExtension.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/testutils/MockWebServerExtension.java
@@ -27,6 +27,7 @@ import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
 import mockwebserver3.RecordedRequest;
 import okio.Buffer;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -50,12 +51,13 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
     server = new MockWebServer();
     responsesByPath.clear();
     final Dispatcher dispatcher = new Dispatcher() {
+      @NotNull
       @Override
       public MockResponse dispatch(RecordedRequest request) {
         if (responsesByPath.containsKey(request.getPath())) {
           return responsesByPath.get(request.getPath());
         }
-        return new MockResponse().setResponseCode(404);
+        return new MockResponse.Builder().code(404).build();
       }
     };
     server.setDispatcher(dispatcher);
@@ -80,7 +82,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
   }
 
   public void addStringResponse(String path, String body) {
-    responsesByPath.put(path, new MockResponse().setBody(body));
+    responsesByPath.put(path, new MockResponse.Builder().body(body).build());
   }
 
   public void removeResponse(String path) {
@@ -110,7 +112,7 @@ public class MockWebServerExtension implements BeforeEachCallback, AfterEachCall
 
   public void addResponseFromResource(String path, String responseResourcePath) {
     try (var b = new Buffer()) {
-      responsesByPath.put(path, new MockResponse().setBody(b.readFrom(requireNonNull(MockWebServerExtension.class.getResourceAsStream(responseResourcePath)))));
+      responsesByPath.put(path, new MockResponse.Builder().body(b.readFrom(requireNonNull(MockWebServerExtension.class.getResourceAsStream(responseResourcePath)))).build());
     } catch (IOException e) {
       fail(e);
     }

--- a/backend/core/pom.xml
+++ b/backend/core/pom.xml
@@ -83,6 +83,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/BindingClueProvider.java
@@ -42,8 +42,8 @@ import org.sonarsource.sonarlint.core.repository.connection.SonarQubeConnectionC
 import org.sonarsource.sonarlint.core.rpc.protocol.common.SonarCloudRegion;
 
 import static java.util.stream.Collectors.toSet;
-import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.apache.commons.lang.StringUtils.trimToNull;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
 import static org.sonarsource.sonarlint.core.commons.log.SonarLintLogger.singlePlural;
 
 public class BindingClueProvider {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConnectionSuggestionProvider.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConnectionSuggestionProvider.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.Strings;
 import org.jetbrains.annotations.NotNull;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.commons.progress.ExecutorServiceShutdownWatchable;
@@ -47,7 +48,6 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.SuggestConn
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Either;
 import org.springframework.context.event.EventListener;
 
-import static org.apache.commons.lang.StringUtils.removeEnd;
 import static org.sonarsource.sonarlint.core.BindingClueProvider.ALL_BINDING_CLUE_FILENAMES;
 
 public class ConnectionSuggestionProvider {
@@ -159,7 +159,7 @@ public class ConnectionSuggestionProvider {
       var serverUrl = sonarQubeBindingClue.getServerUrl();
       var connection = connectionRepository.findByUrl(serverUrl);
       if (connection.isEmpty()) {
-        return Optional.of(Either.forLeft(removeEnd(serverUrl, "/")));
+        return Optional.of(Either.forLeft(Strings.CS.removeEnd(serverUrl, "/")));
       }
     } else {
       LOG.debug("Found an invalid binding clue for connection suggestion");

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironment.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/SonarCloudActiveEnvironment.java
@@ -23,9 +23,9 @@ import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.Strings;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.SonarQubeCloudRegionDto;
 
-import static org.apache.commons.lang.StringUtils.removeEnd;
 
 public class SonarCloudActiveEnvironment {
   private final Map<SonarCloudRegion, SonarQubeCloudRegionDto> alternativeRegionUris;
@@ -75,18 +75,18 @@ public class SonarCloudActiveEnvironment {
     
     throw new IllegalArgumentException("URI should be a known SonarCloud URI");
   }
-  
+
   private Optional<SonarCloudRegion> getRegionByUri(String uri) {
-    var cleanedUri = removeEnd(uri, "/");
+    var cleanedUri = Strings.CS.removeEnd(uri, "/");
     for (var entry : alternativeRegionUris.entrySet()) {
-      var regionDto = entry.getValue();
-      if (regionDto.getUri() != null && removeEnd(regionDto.getUri().toString(), "/").equals(cleanedUri)) {
+      var regionUri = entry.getValue().getUri();
+      if (regionUri != null && Strings.CS.removeEnd(regionUri.toString(), "/").equals(cleanedUri)) {
         return Optional.of(entry.getKey());
       }
     }
 
     for (var region : SonarCloudRegion.values()) {
-      if (removeEnd(region.getProductionUri().toString(), "/").equals(cleanedUri)) {
+      if (Strings.CS.removeEnd(region.getProductionUri().toString(), "/").equals(cleanedUri)) {
         return Optional.of(region);
       }
     }

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/RequestHandlerBindingAssistant.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/RequestHandlerBindingAssistant.java
@@ -29,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.sonarsource.sonarlint.core.BindingCandidatesFinder;
 import org.sonarsource.sonarlint.core.BindingSuggestionProvider;
 import org.sonarsource.sonarlint.core.SonarQubeClientManager;
@@ -49,6 +48,8 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreat
 import org.sonarsource.sonarlint.core.rpc.protocol.client.connection.AssistCreatingConnectionResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.message.MessageType;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.message.ShowMessageParams;
+
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 
 public class RequestHandlerBindingAssistant {
 
@@ -220,7 +221,7 @@ public class RequestHandlerBindingAssistant {
     var configScopeCandidates = bindingCandidatesFinder.findConfigScopesToBind(connectionId, projectKey, cancelMonitor);
     // For now, we decided to only support automatic binding if there is only one clear candidate
     if (configScopeCandidates.size() != 1) {
-      client.noBindingSuggestionFound(new NoBindingSuggestionFoundParams(StringEscapeUtils.escapeHtml(projectKey), isSonarCloud));
+      client.noBindingSuggestionFound(new NoBindingSuggestionFoundParams(escapeHtml4(projectKey), isSonarCloud));
       return new NewBinding(connectionId, null);
     }
     var bindableConfig = configScopeCandidates.iterator().next();

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/RequestHandlerUtils.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/RequestHandlerUtils.java
@@ -19,10 +19,9 @@
  */
 package org.sonarsource.sonarlint.core.embedded.server;
 
+import org.apache.commons.lang3.Strings;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ProtocolException;
-
-import static org.apache.commons.lang3.StringUtils.removeEnd;
 
 public class RequestHandlerUtils {
 
@@ -33,6 +32,6 @@ public class RequestHandlerUtils {
   public static String getServerUrlForSonarCloud(ClassicHttpRequest request) throws ProtocolException {
     var originUrl = request.getHeader("Origin").getValue();
     // Since the 'isSonarCloud' check passed, we are sure that the region will be there
-    return removeEnd(originUrl, "/");
+    return Strings.CS.removeEnd(originUrl, "/");
   }
 }

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowFixSuggestionRequestHandler.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/embedded/server/ShowFixSuggestionRequestHandler.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpException;
@@ -65,6 +64,7 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 import static org.sonarsource.sonarlint.core.commons.util.StringUtils.sanitizeAgainstRTLO;
 import static org.sonarsource.sonarlint.core.embedded.server.RequestHandlerUtils.getServerUrlForSonarCloud;
 
@@ -303,7 +303,7 @@ public class ShowFixSuggestionRequestHandler implements HttpRequestHandler {
     public FixSuggestionPayload(FileEditPayload fileEdit, String suggestionId, String explanation) {
       this.fileEdit = fileEdit;
       this.suggestionId = suggestionId;
-      this.explanation = StringEscapeUtils.escapeHtml(explanation);
+      this.explanation = escapeHtml4(explanation);
     }
 
     public boolean isValid() {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/WindowsShortcutUtils.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/file/WindowsShortcutUtils.java
@@ -24,8 +24,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
-import org.apache.commons.lang.ArrayUtils;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+
+import static org.apache.commons.lang3.ArrayUtils.reverse;
 
 public class WindowsShortcutUtils {
   // Based on Windows specification the magic number is 0x0000004C that must be tested with both big and little endian
@@ -66,7 +67,7 @@ public class WindowsShortcutUtils {
       }
 
       // Check little endian
-      ArrayUtils.reverse(magicNumber);
+      reverse(magicNumber);
       return Arrays.equals(WINDOWS_SHORTCUT_MAGIC_NUMBER, magicNumber);
     } catch (IOException err) {
       SonarLintLogger.get().debug("Cannot check whether '" + uri + "' is a Windows shortcut, assuming it is not.");

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/AbstractConnectionConfiguration.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/AbstractConnectionConfiguration.java
@@ -22,10 +22,9 @@ package org.sonarsource.sonarlint.core.repository.connection;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
+import org.apache.commons.lang3.Strings;
 import org.sonarsource.sonarlint.core.commons.ConnectionKind;
 import org.sonarsource.sonarlint.core.serverapi.EndpointParams;
-
-import static org.apache.commons.lang.StringUtils.removeEnd;
 
 public abstract class AbstractConnectionConfiguration {
 
@@ -42,7 +41,7 @@ public abstract class AbstractConnectionConfiguration {
     this.connectionId = connectionId;
     this.kind = kind;
     this.disableNotifications = disableNotifications;
-    this.url = removeEnd(url, "/");
+    this.url = Strings.CS.removeEnd(url, "/");
   }
 
   public String getConnectionId() {
@@ -67,8 +66,8 @@ public abstract class AbstractConnectionConfiguration {
     URI myUri;
     URI otherUri;
     try {
-      myUri = new URI(removeEnd(url, "/"));
-      otherUri = new URI(removeEnd(otherUrl, "/"));
+      myUri = new URI(Strings.CS.removeEnd(url, "/"));
+      otherUri = new URI(Strings.CS.removeEnd(otherUrl, "/"));
     } catch (URISyntaxException e) {
       return false;
     }

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/SonarCloudConnectionConfiguration.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/repository/connection/SonarCloudConnectionConfiguration.java
@@ -22,11 +22,10 @@ package org.sonarsource.sonarlint.core.repository.connection;
 import java.net.URI;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.Strings;
 import org.sonarsource.sonarlint.core.SonarCloudRegion;
 import org.sonarsource.sonarlint.core.commons.ConnectionKind;
 import org.sonarsource.sonarlint.core.serverapi.EndpointParams;
-
-import static org.apache.commons.lang.StringUtils.removeEnd;
 
 public class SonarCloudConnectionConfiguration extends AbstractConnectionConfiguration {
 
@@ -47,7 +46,7 @@ public class SonarCloudConnectionConfiguration extends AbstractConnectionConfigu
 
   @Override
   public EndpointParams getEndpointParams() {
-    return new EndpointParams(getUrl(), removeEnd(apiUri.toString(), "/"), true, organization);
+    return new EndpointParams(getUrl(), Strings.CS.removeEnd(apiUri.toString(), "/"), true, organization);
   }
 
   public SonarCloudRegion getRegion() {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TextRangeUtils.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/TextRangeUtils.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.lang.StringUtils;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
 import org.sonarsource.sonarlint.core.commons.LineWithHash;
 import org.sonarsource.sonarlint.core.commons.api.TextRange;
@@ -32,6 +31,8 @@ import org.sonarsource.sonarlint.core.commons.api.TextRangeWithHash;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.LineWithHashDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TextRangeWithHashDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.TextRangeDto;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 public class TextRangeUtils {
 
@@ -83,7 +84,7 @@ public class TextRangeUtils {
 
   private static String getLineContent(ClientInputFile file, TextRange textRange) {
     var fileContent = getFileContentOrEmptyString(file);
-    if (StringUtils.isEmpty(fileContent)) return "";
+    if (isEmpty(fileContent)) return "";
     var lines = fileContent.lines().toList();
     if (lines.size() < textRange.getStartLine()) return "";
     var line = lines.get(textRange.getStartLine() - 1);

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/events/SmartNotificationEvent.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/events/SmartNotificationEvent.java
@@ -19,14 +19,15 @@
  */
 package org.sonarsource.sonarlint.core.websocket.events;
 
-import org.apache.commons.lang.StringEscapeUtils;
 import org.sonarsource.sonarlint.core.serverapi.push.SonarServerEvent;
+
+import static org.apache.commons.text.StringEscapeUtils.escapeHtml4;
 
 public record SmartNotificationEvent(String message, String link, String project, String date,
                                      String category) implements SonarServerEvent {
 
   public SmartNotificationEvent(String message, String link, String project, String date, String category) {
-    this.message = StringEscapeUtils.escapeHtml(message);
+    this.message = escapeHtml4(message);
     this.link = link;
     this.project = project;
     this.date = date;

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/MockWebServerExtensionWithProtobuf.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/MockWebServerExtensionWithProtobuf.java
@@ -37,7 +37,7 @@ public class MockWebServerExtensionWithProtobuf extends MockWebServerExtension {
   public void addProtobufResponse(String path, Message m) {
     try (var b = new Buffer()) {
       m.writeTo(b.outputStream());
-      responsesByPath.put(path, new MockResponse().setBody(b));
+      responsesByPath.put(path, new MockResponse.Builder().body(b).build());
     } catch (IOException e) {
       fail(e);
     }
@@ -46,7 +46,7 @@ public class MockWebServerExtensionWithProtobuf extends MockWebServerExtension {
   public void addProtobufResponseDelimited(String path, Message... m) {
     try (var b = new Buffer()) {
       writeMessages(b.outputStream(), Arrays.asList(m).iterator());
-      responsesByPath.put(path, new MockResponse().setBody(b));
+      responsesByPath.put(path, new MockResponse.Builder().body(b).build());
     }
   }
 

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/authentication/AuthenticationApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/authentication/AuthenticationApiTests.java
@@ -64,7 +64,7 @@ class AuthenticationApiTests {
 
   @Test
   void test_connection_issue() {
-    mockServer.addResponse("/api/authentication/validate?format=json", new MockResponse().setResponseCode(500).setBody("Foo"));
+    mockServer.addResponse("/api/authentication/validate?format=json", new MockResponse.Builder().code(500).body("Foo").build());
 
     var validationResult = underTest.validate(new SonarLintCancelMonitor());
 

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApiTests.java
@@ -75,7 +75,7 @@ class IssueApiTests {
 
   @Test
   void should_return_no_batch_issue_if_download_is_forbidden() {
-    mockServer.addResponse("/batch/issues?key=keyyy", new MockResponse().setResponseCode(403));
+    mockServer.addResponse("/batch/issues?key=keyyy", new MockResponse.Builder().code(403).build());
 
     var issues = underTest.downloadAllFromBatchIssues("keyyy", null, new SonarLintCancelMonitor());
 
@@ -84,7 +84,7 @@ class IssueApiTests {
 
   @Test
   void should_return_no_batch_issue_if_endpoint_is_not_found() {
-    mockServer.addResponse("/batch/issues?key=keyyy", new MockResponse().setResponseCode(404));
+    mockServer.addResponse("/batch/issues?key=keyyy", new MockResponse.Builder().code(404).build());
 
     var issues = underTest.downloadAllFromBatchIssues("keyyy", null, new SonarLintCancelMonitor());
 
@@ -93,7 +93,7 @@ class IssueApiTests {
 
   @Test
   void should_throw_an_error_if_batch_issue_download_fails() {
-    mockServer.addResponse("/batch/issues?key=keyyy", new MockResponse().setResponseCode(500));
+    mockServer.addResponse("/batch/issues?key=keyyy", new MockResponse.Builder().code(500).build());
 
     var throwable = catchThrowable(() -> underTest.downloadAllFromBatchIssues("keyyy", null, new SonarLintCancelMonitor()));
 

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/PushApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/PushApiTests.java
@@ -62,13 +62,14 @@ class PushApiTests {
   @Test
   @Disabled("Settings will be supported later")
   void should_notify_setting_changed_event_for_simple_setting() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("event: SettingChanged\n" +
-      "data: {" +
-      "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
-      "\"key\": \"key1\"," +
-      "\"value\": \"value1\"" +
-      "}\n\n");
+    var mockResponse = new MockResponse.Builder()
+      .body("event: SettingChanged\n" +
+        "data: {" +
+        "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
+        "\"key\": \"key1\"," +
+        "\"value\": \"value1\"" +
+        "}\n\n")
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -82,13 +83,14 @@ class PushApiTests {
   @Test
   @Disabled("Settings will be supported later")
   void should_notify_setting_changed_event_for_multi_values_setting() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("event: SettingChanged\n" +
-      "data: {" +
-      "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
-      "\"key\": \"key1\"," +
-      "\"values\": [\"value1\",\"value2\"]" +
-      "}\n\n");
+    var mockResponse = new MockResponse.Builder()
+      .body("event: SettingChanged\n" +
+        "data: {" +
+        "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
+        "\"key\": \"key1\"," +
+        "\"values\": [\"value1\",\"value2\"]" +
+        "}\n\n")
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -102,20 +104,21 @@ class PushApiTests {
   @Test
   @Disabled("Settings will be supported later")
   void should_notify_setting_changed_event_for_field_values_setting() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("event: SettingChanged\n" +
-      "data: {" +
-      "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
-      "\"key\": \"key1\"," +
-      "\"fieldValues\": [{" +
-      "\"key2\": \"value2\"," +
-      "\"key3\": \"value3\"" +
-      "}," +
-      "{" +
-      "\"key4\": \"value4\"," +
-      "\"key5\": \"value5\"" +
-      "}]" +
-      "}\n\n");
+    var mockResponse = new MockResponse.Builder()
+      .body("event: SettingChanged\n" +
+        "data: {" +
+        "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
+        "\"key\": \"key1\"," +
+        "\"fieldValues\": [{" +
+        "\"key2\": \"value2\"," +
+        "\"key3\": \"value3\"" +
+        "}," +
+        "{" +
+        "\"key4\": \"value4\"," +
+        "\"key5\": \"value5\"" +
+        "}]" +
+        "}\n\n")
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -130,23 +133,24 @@ class PushApiTests {
 
   @Test
   void should_notify_rule_set_changed_event_without_impacts() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: RuleSetChanged
-      data: {\
-        "projects": ["projectKey1", "projectKey2"],\
-        "activatedRules": [{\
-          "key": "java:S0000",\
-          "severity": "MAJOR",\
-          "params": [{\
-            "key": "key1",\
-            "value": "value1"\
-          }]\
-        }],\
-        "deactivatedRules": ["java:S4321"]\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: RuleSetChanged
+        data: {\
+          "projects": ["projectKey1", "projectKey2"],\
+          "activatedRules": [{\
+            "key": "java:S0000",\
+            "severity": "MAJOR",\
+            "params": [{\
+              "key": "key1",\
+              "value": "value1"\
+            }]\
+          }],\
+          "deactivatedRules": ["java:S4321"]\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -167,28 +171,29 @@ class PushApiTests {
 
   @Test
   void should_notify_rule_set_changed_event() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: RuleSetChanged
-      data: {\
-        "projects": ["projectKey1", "projectKey2"],\
-        "activatedRules": [{\
-          "key": "java:S0000",\
-          "severity": "MAJOR",\
-          "params": [{\
-            "key": "key1",\
-            "value": "value1"\
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: RuleSetChanged
+        data: {\
+          "projects": ["projectKey1", "projectKey2"],\
+          "activatedRules": [{\
+            "key": "java:S0000",\
+            "severity": "MAJOR",\
+            "params": [{\
+              "key": "key1",\
+              "value": "value1"\
+            }],\
+            "templateKey": "templateKey",\
+            "impacts": [{\
+              "softwareQuality": "SECURITY",\
+              "severity": "HIGH"\
+            }]\
           }],\
-          "templateKey": "templateKey",\
-          "impacts": [{\
-            "softwareQuality": "SECURITY",\
-            "severity": "HIGH"\
-          }]\
-        }],\
-        "deactivatedRules": ["java:S4321"]\
-      }
-      
-      """);
+          "deactivatedRules": ["java:S4321"]\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -209,13 +214,14 @@ class PushApiTests {
 
   @Test
   void should_not_notify_while_event_is_incomplete() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: RuleSetChanged
-      data: {\
-        "projects": ["projectKey1", "projectKey2"],\
-        "activatedRules":
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: RuleSetChanged
+        data: {\
+          "projects": ["projectKey1", "projectKey2"],\
+          "activatedRules":
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -226,22 +232,23 @@ class PushApiTests {
 
   @Test
   void should_ignore_events_without_project_keys() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: RuleSetChanged
-      data: {\
-        "activatedRules": ["java:S1234"],\
-        "deactivatedRules": ["java:S4321"],\
-        "changedRules": [{\
-          "key": "java:S0000",\
-          "overriddenSeverity": "MAJOR",\
-          "params": [{\
-            "key": "key1",\
-            "value": "value1"\
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: RuleSetChanged
+        data: {\
+          "activatedRules": ["java:S1234"],\
+          "deactivatedRules": ["java:S4321"],\
+          "changedRules": [{\
+            "key": "java:S0000",\
+            "overriddenSeverity": "MAJOR",\
+            "params": [{\
+              "key": "key1",\
+              "value": "value1"\
+            }]\
           }]\
-        }]\
-      }
-      """);
+        }
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -252,12 +259,13 @@ class PushApiTests {
 
   @Test
   void should_ignore_unknown_events() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: UnknownEvent
-      data: "plop"
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: UnknownEvent
+        data: "plop"
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -268,12 +276,13 @@ class PushApiTests {
 
   @Test
   void should_ignore_ruleset_changed_events_with_invalid_json() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: RuleSetChanged
-      data: {]
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: RuleSetChanged
+        data: {]
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -284,12 +293,13 @@ class PushApiTests {
 
   @Test
   void should_ignore_setting_changed_events_with_invalid_json() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: SettingChanged
-      data: {]
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: SettingChanged
+        data: {]
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -300,18 +310,19 @@ class PushApiTests {
 
   @Test
   void should_ignore_invalid_setting_changed_events() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: SettingChanged
-      data: {\
-        "projects": ["projectKey1", "projectKey2"],\
-        "key": "key1",\
-        "value": "",\
-        "values": [],\
-        "fieldValues": []\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: SettingChanged
+        data: {\
+          "projects": ["projectKey1", "projectKey2"],\
+          "key": "key1",\
+          "value": "",\
+          "values": [],\
+          "fieldValues": []\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -322,20 +333,21 @@ class PushApiTests {
 
   @Test
   void should_notify_issue_changed_event_when_resolved_status_changed() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: IssueChanged
-      data: {\
-        "projectKey": "projectKey1",\
-        "issues": [{\
-          "issueKey": "key1",\
-          "branchName": "master",\
-          "impacts": [ { "softwareQuality": "MAINTAINABILITY", "severity": "HIGH" } ]\
-        }],\
-        "resolved": true\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: IssueChanged
+        data: {\
+          "projectKey": "projectKey1",\
+          "issues": [{\
+            "issueKey": "key1",\
+            "branchName": "master",\
+            "impacts": [ { "softwareQuality": "MAINTAINABILITY", "severity": "HIGH" } ]\
+          }],\
+          "resolved": true\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -355,19 +367,20 @@ class PushApiTests {
 
   @Test
   void should_notify_issue_changed_event_when_severity_changed() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: IssueChanged
-      data: {\
-        "projectKey": "projectKey1",\
-        "issues": [{\
-          "issueKey": "key1",\
-          "branchName": "master"\
-        }],\
-        "userSeverity": "MAJOR"\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: IssueChanged
+        data: {\
+          "projectKey": "projectKey1",\
+          "issues": [{\
+            "issueKey": "key1",\
+            "branchName": "master"\
+          }],\
+          "userSeverity": "MAJOR"\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -387,19 +400,20 @@ class PushApiTests {
 
   @Test
   void should_notify_issue_changed_event_when_type_changed() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: IssueChanged
-      data: {\
-        "projectKey": "projectKey1",\
-        "issues": [{\
-          "issueKey": "key1",\
-          "branchName": "master"\
-        }],\
-        "userType": "BUG"\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: IssueChanged
+        data: {\
+          "projectKey": "projectKey1",\
+          "issues": [{\
+            "issueKey": "key1",\
+            "branchName": "master"\
+          }],\
+          "userType": "BUG"\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -419,18 +433,19 @@ class PushApiTests {
 
   @Test
   void should_not_notify_issue_changed_event_when_no_change_is_present() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: IssueChangedEvent
-      data: {\
-        "projectKey": "projectKey1",\
-        "issues": [{\
-          "issueKey": "key1",\
-          "branchName": "master"\
-        }]\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: IssueChangedEvent
+        data: {\
+          "projectKey": "projectKey1",\
+          "issues": [{\
+            "issueKey": "key1",\
+            "branchName": "master"\
+          }]\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -441,55 +456,56 @@ class PushApiTests {
 
   @Test
   void should_notify_taint_vulnerability_raised_event() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: TaintVulnerabilityRaised
-      data: {\
-        "key": "taintKey",\
-        "projectKey": "projectKey1",\
-        "branch": "branch",\
-        "creationDate": 123456789,\
-        "ruleKey": "javasecurity:S123",\
-        "severity": "MAJOR",\
-        "type": "VULNERABILITY",\
-        "mainLocation": {\
-          "filePath": "functions/taint.js",\
-          "message": "blah blah",\
-          "textRange": {\
-            "startLine": 17,\
-            "startLineOffset": 10,\
-            "endLine": 3,\
-            "endLineOffset": 2,\
-            "hash": "hash"\
-          }\
-        },\
-        "flows": [{\
-          "locations": [{\
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: TaintVulnerabilityRaised
+        data: {\
+          "key": "taintKey",\
+          "projectKey": "projectKey1",\
+          "branch": "branch",\
+          "creationDate": 123456789,\
+          "ruleKey": "javasecurity:S123",\
+          "severity": "MAJOR",\
+          "type": "VULNERABILITY",\
+          "mainLocation": {\
             "filePath": "functions/taint.js",\
-            "message": "sink: tainted value is used to perform a security-sensitive operation",\
+            "message": "blah blah",\
             "textRange": {\
               "startLine": 17,\
               "startLineOffset": 10,\
               "endLine": 3,\
               "endLineOffset": 2,\
-              "hash": "hash1"\
+              "hash": "hash"\
             }\
           },\
-          {\
-            "filePath": "functions/taint2.js",\
-            "message": "sink: tainted value is used to perform a security-sensitive operation",\
-            "textRange": {\
-              "startLine": 18,\
-              "startLineOffset": 11,\
-              "endLine": 4,\
-              "endLineOffset": 3,\
-              "hash": "hash2"\
-            }\
+          "flows": [{\
+            "locations": [{\
+              "filePath": "functions/taint.js",\
+              "message": "sink: tainted value is used to perform a security-sensitive operation",\
+              "textRange": {\
+                "startLine": 17,\
+                "startLineOffset": 10,\
+                "endLine": 3,\
+                "endLineOffset": 2,\
+                "hash": "hash1"\
+              }\
+            },\
+            {\
+              "filePath": "functions/taint2.js",\
+              "message": "sink: tainted value is used to perform a security-sensitive operation",\
+              "textRange": {\
+                "startLine": 18,\
+                "startLineOffset": 11,\
+                "endLine": 4,\
+                "endLineOffset": 3,\
+                "hash": "hash2"\
+              }\
+            }]\
           }]\
-        }]\
-      }
-      
-      """);
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -513,58 +529,59 @@ class PushApiTests {
 
   @Test
   void should_notify_taint_vulnerability_raised_event_with_cct() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: TaintVulnerabilityRaised
-      data: {\
-        "key": "taintKey",\
-        "projectKey": "projectKey1",\
-        "branch": "branch",\
-        "creationDate": 123456789,\
-        "ruleKey": "javasecurity:S123",\
-        "severity": "MAJOR",\
-        "type": "VULNERABILITY",\
-        "cleanCodeAttribute": "TRUSTWORTHY",\
-        "impacts": [ { "softwareQuality": "SECURITY", "severity": "HIGH" } ],\
-        "type": "VULNERABILITY",\
-        "mainLocation": {\
-          "filePath": "functions/taint.js",\
-          "message": "blah blah",\
-          "textRange": {\
-            "startLine": 17,\
-            "startLineOffset": 10,\
-            "endLine": 3,\
-            "endLineOffset": 2,\
-            "hash": "hash"\
-          }\
-        },\
-        "flows": [{\
-          "locations": [{\
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: TaintVulnerabilityRaised
+        data: {\
+          "key": "taintKey",\
+          "projectKey": "projectKey1",\
+          "branch": "branch",\
+          "creationDate": 123456789,\
+          "ruleKey": "javasecurity:S123",\
+          "severity": "MAJOR",\
+          "type": "VULNERABILITY",\
+          "cleanCodeAttribute": "TRUSTWORTHY",\
+          "impacts": [ { "softwareQuality": "SECURITY", "severity": "HIGH" } ],\
+          "type": "VULNERABILITY",\
+          "mainLocation": {\
             "filePath": "functions/taint.js",\
-            "message": "sink: tainted value is used to perform a security-sensitive operation",\
+            "message": "blah blah",\
             "textRange": {\
               "startLine": 17,\
               "startLineOffset": 10,\
               "endLine": 3,\
               "endLineOffset": 2,\
-              "hash": "hash1"\
+              "hash": "hash"\
             }\
           },\
-          {\
-            "filePath": "functions/taint2.js",\
-            "message": "sink: tainted value is used to perform a security-sensitive operation",\
-            "textRange": {\
-              "startLine": 18,\
-              "startLineOffset": 11,\
-              "endLine": 4,\
-              "endLineOffset": 3,\
-              "hash": "hash2"\
-            }\
+          "flows": [{\
+            "locations": [{\
+              "filePath": "functions/taint.js",\
+              "message": "sink: tainted value is used to perform a security-sensitive operation",\
+              "textRange": {\
+                "startLine": 17,\
+                "startLineOffset": 10,\
+                "endLine": 3,\
+                "endLineOffset": 2,\
+                "hash": "hash1"\
+              }\
+            },\
+            {\
+              "filePath": "functions/taint2.js",\
+              "message": "sink: tainted value is used to perform a security-sensitive operation",\
+              "textRange": {\
+                "startLine": 18,\
+                "startLineOffset": 11,\
+                "endLine": 4,\
+                "endLineOffset": 3,\
+                "hash": "hash2"\
+              }\
+            }]\
           }]\
-        }]\
-      }
-      
-      """);
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -577,15 +594,16 @@ class PushApiTests {
 
   @Test
   void should_notify_taint_vulnerability_closed_event() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: TaintVulnerabilityClosed
-      data: {\
-        "projectKey": "projectKey1",\
-        "key": "taintKey"\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: TaintVulnerabilityClosed
+        data: {\
+          "projectKey": "projectKey1",\
+          "key": "taintKey"\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();
@@ -598,20 +616,21 @@ class PushApiTests {
 
   @Test
   void should_notify_issue_changed_event_when_software_impacts_changed() {
-    var mockResponse = new MockResponse();
-    mockResponse.setBody("""
-      event: IssueChanged
-      data: {\
-        "projectKey": "projectKey1",\
-        "issues": [{\
-          "issueKey": "key1",\
-          "branchName": "master",\
-          "impacts": [ { "softwareQuality": "MAINTAINABILITY", "severity": "HIGH" } ]\
-        }],\
-        "resolved": true\
-      }
-      
-      """);
+    var mockResponse = new MockResponse.Builder()
+      .body("""
+        event: IssueChanged
+        data: {\
+          "projectKey": "projectKey1",\
+          "issues": [{\
+            "issueKey": "key1",\
+            "branchName": "master",\
+            "impacts": [ { "softwareQuality": "MAINTAINABILITY", "severity": "HIGH" } ]\
+          }],\
+          "resolved": true\
+        }
+        
+        """)
+      .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1&languages=java,py", mockResponse);
 
     List<SonarServerEvent> receivedEvents = new CopyOnWriteArrayList<>();

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/PushApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/push/PushApiTests.java
@@ -63,12 +63,15 @@ class PushApiTests {
   @Disabled("Settings will be supported later")
   void should_notify_setting_changed_event_for_simple_setting() {
     var mockResponse = new MockResponse.Builder()
-      .body("event: SettingChanged\n" +
-        "data: {" +
-        "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
-        "\"key\": \"key1\"," +
-        "\"value\": \"value1\"" +
-        "}\n\n")
+      .body("""
+        event: SettingChanged
+        data: {
+          "projects": ["projectKey1", "projectKey2"],
+          "key": "key1",
+          "value": "value1"
+        }
+    
+        """)
       .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
@@ -84,12 +87,15 @@ class PushApiTests {
   @Disabled("Settings will be supported later")
   void should_notify_setting_changed_event_for_multi_values_setting() {
     var mockResponse = new MockResponse.Builder()
-      .body("event: SettingChanged\n" +
-        "data: {" +
-        "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
-        "\"key\": \"key1\"," +
-        "\"values\": [\"value1\",\"value2\"]" +
-        "}\n\n")
+      .body("""
+        event: SettingChanged
+        data: {
+          "projects": ["projectKey1", "projectKey2"],
+          "key": "key1",
+          "values": ["value1","value2"]
+        }
+    
+        """)
       .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 
@@ -105,19 +111,24 @@ class PushApiTests {
   @Disabled("Settings will be supported later")
   void should_notify_setting_changed_event_for_field_values_setting() {
     var mockResponse = new MockResponse.Builder()
-      .body("event: SettingChanged\n" +
-        "data: {" +
-        "\"projects\": [\"projectKey1\", \"projectKey2\"]," +
-        "\"key\": \"key1\"," +
-        "\"fieldValues\": [{" +
-        "\"key2\": \"value2\"," +
-        "\"key3\": \"value3\"" +
-        "}," +
-        "{" +
-        "\"key4\": \"value4\"," +
-        "\"key5\": \"value5\"" +
-        "}]" +
-        "}\n\n")
+      .body("""
+        event: SettingChanged
+        data: {
+          "projects": ["projectKey1", "projectKey2"],
+          "key": "key1",
+          "fieldValues": [
+            {
+              "key2": "value2",
+              "key3": "value3"
+            },
+            {
+              "key4": "value4",
+              "key5": "value5"
+            }
+          ]
+        }
+    
+        """)
       .build();
     mockServer.addResponse("/api/push/sonarlint_events?projectKeys=projectKey1,projectKey2&languages=java,py", mockResponse);
 

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfileApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/qualityprofile/QualityProfileApiTests.java
@@ -20,6 +20,7 @@
 package org.sonarsource.sonarlint.core.serverapi.qualityprofile;
 
 import mockwebserver3.MockResponse;
+import okhttp3.Headers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
@@ -44,7 +45,7 @@ class QualityProfileApiTests {
   void should_throw_when_the_endpoint_is_not_found() {
     var underTest = new QualityProfileApi(mockServer.serverApiHelper());
 
-    mockServer.addResponse("/api/qualityprofiles/search.protobuf?project=projectKey", new MockResponse().setResponseCode(404));
+    mockServer.addResponse("/api/qualityprofiles/search.protobuf?project=projectKey", new MockResponse(404, Headers.EMPTY, ""));
 
     var cancelMonitor = new SonarLintCancelMonitor();
     assertThrows(ProjectNotFoundException.class, () -> underTest.getQualityProfiles("projectKey", cancelMonitor));
@@ -54,7 +55,7 @@ class QualityProfileApiTests {
   void should_throw_when_a_server_error_occurs() {
     var underTest = new QualityProfileApi(mockServer.serverApiHelper());
 
-    mockServer.addResponse("/api/qualityprofiles/search.protobuf?project=projectKey", new MockResponse().setResponseCode(503));
+    mockServer.addResponse("/api/qualityprofiles/search.protobuf?project=projectKey", new MockResponse(503, Headers.EMPTY, ""));
 
     var cancelMonitor = new SonarLintCancelMonitor();
     assertThrows(ServerErrorException.class, () -> underTest.getQualityProfiles("projectKey", cancelMonitor));

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloaderTests.java
@@ -356,7 +356,7 @@ class IssueDownloaderTests {
 
   @Test
   void test_fail_other_codes() {
-    mockServer.addResponse("/batch/issues?key=" + DUMMY_KEY, new MockResponse().setResponseCode(503));
+    mockServer.addResponse("/batch/issues?key=" + DUMMY_KEY, new MockResponse.Builder().code(503).build());
 
     var cancelMonitor = new SonarLintCancelMonitor();
     var thrown = assertThrows(ServerErrorException.class,
@@ -366,7 +366,7 @@ class IssueDownloaderTests {
 
   @Test
   void test_return_empty_if_404() {
-    mockServer.addResponse("/batch/issues?key=" + DUMMY_KEY, new MockResponse().setResponseCode(404));
+    mockServer.addResponse("/batch/issues?key=" + DUMMY_KEY, new MockResponse.Builder().code(404).build());
 
     var issues = underTest.downloadFromBatch(serverApi, DUMMY_KEY, null, new SonarLintCancelMonitor());
     assertThat(issues).isEmpty();

--- a/backend/server-connection/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
+++ b/backend/server-connection/src/test/java/testutils/MockWebServerExtensionWithProtobuf.java
@@ -39,7 +39,7 @@ public class MockWebServerExtensionWithProtobuf extends MockWebServerExtension {
   public void addProtobufResponse(String path, Message m) {
     try (var b = new Buffer()) {
       m.writeTo(b.outputStream());
-      responsesByPath.put(path, new MockResponse().setBody(b));
+      responsesByPath.put(path, new MockResponse.Builder().body(b).build());
     } catch (IOException e) {
       fail(e);
     }
@@ -48,7 +48,7 @@ public class MockWebServerExtensionWithProtobuf extends MockWebServerExtension {
   public void addProtobufResponseDelimited(String path, Message... m) {
     try (var b = new Buffer()) {
       writeMessages(b.outputStream(), Arrays.asList(m).iterator());
-      responsesByPath.put(path, new MockResponse().setBody(b));
+      responsesByPath.put(path, new MockResponse.Builder().body(b).build());
     }
   }
 

--- a/its/plugins/custom-sensor-plugin/pom.xml
+++ b/its/plugins/custom-sensor-plugin/pom.xml
@@ -19,22 +19,23 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sonar.apiVersion>5.6</sonar.apiVersion>
+    <sonar.apiVersion>9.14.0.375</sonar.apiVersion>
+    <sonar.testing-harness>9.9.0.65466</sonar.testing-harness>
     <jdk.min.version>11</jdk.min.version>
   </properties>
 
   <dependencies>
     <dependency>
-      <groupId>org.sonarsource.sonarqube</groupId>
+      <groupId>org.sonarsource.api.plugin</groupId>
       <artifactId>sonar-plugin-api</artifactId>
       <version>${sonar.apiVersion}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <!-- packaged with the plugin -->
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.18.0</version>
     </dependency>
 
 
@@ -42,13 +43,13 @@
     <dependency>
       <groupId>org.sonarsource.sonarqube</groupId>
       <artifactId>sonar-testing-harness</artifactId>
-      <version>${sonar.apiVersion}</version>
+      <version>${sonar.testing-harness}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/its/plugins/global-extension-plugin/pom.xml
+++ b/its/plugins/global-extension-plugin/pom.xml
@@ -36,9 +36,9 @@
     </dependency>
     <dependency>
       <!-- packaged with the plugin -->
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.6</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.18.0</version>
     </dependency>
   </dependencies>
 
@@ -64,6 +64,10 @@
         <configuration>
           <source>${jdk.min.version}</source>
           <target>${jdk.min.version}</target>
+          <basedir/>
+          <buildDirectory/>
+          <outputDirectory/>
+          <projectArtifact/>
         </configuration>
       </plugin>
     </plugins>

--- a/its/plugins/java-custom-rules/pom.xml
+++ b/its/plugins/java-custom-rules/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <sonarjava.version>7.16.0.30901</sonarjava.version>
-    <analyzer.commons.version>2.11.0.2861</analyzer.commons.version>
+    <analyzer.commons.version>2.1.0.1111</analyzer.commons.version>
     <sonar.apiVersion>9.14.0.375</sonar.apiVersion>
   </properties>
 
@@ -90,6 +90,10 @@
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
+          <basedir/>
+          <buildDirectory/>
+          <outputDirectory/>
+          <projectArtifact/>
         </configuration>
       </plugin>
     </plugins>

--- a/its/tests/pom.xml
+++ b/its/tests/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>11.0.20</version>
+      <version>11.0.25</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -143,6 +143,12 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp-jvm</artifactId>
+      <version>${okhttp.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/medium-tests/src/test/java/mediumtest/EmbeddedServerMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/EmbeddedServerMediumTests.java
@@ -25,11 +25,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.List;
-import org.apache.commons.lang.RandomStringUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
 
+import static com.github.tomakehurst.wiremock.common.Strings.randomAlphabetic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.when;
@@ -154,7 +154,7 @@ class EmbeddedServerMediumTests {
     var embeddedServerPort = backend.getEmbeddedServerPort();
     var request = HttpRequest.newBuilder()
       .uri(URI.create("http://localhost:" + embeddedServerPort + "/sonarlint/api/status"))
-      .header("Origin", RandomStringUtils.randomAlphabetic(10))
+      .header("Origin", randomAlphabetic(10))
       .GET().build();
     for (int i = 0; i < 15; i++) {
       java.net.http.HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
@@ -190,7 +190,7 @@ class EmbeddedServerMediumTests {
     var embeddedServerPort = backend.getEmbeddedServerPort();
     var request = HttpRequest.newBuilder()
       .uri(URI.create("http://localhost:" + embeddedServerPort + "/sonarlint/api/status"))
-      .header("Origin", RandomStringUtils.randomAlphabetic(10))
+      .header("Origin", randomAlphabetic(10))
       .GET().build();
     for (int i = 0; i < 15; i++) {
       java.net.http.HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());

--- a/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/SharedConnectedModeSettingsMediumTests.java
@@ -22,13 +22,13 @@ package mediumtest;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.Strings;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.binding.GetSharedConnectedModeConfigFileParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.binding.GetSharedConnectedModeConfigFileResponse;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
 
-import static org.apache.commons.lang.StringUtils.removeEnd;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SharedConnectedModeSettingsMediumTests {
@@ -116,7 +116,7 @@ class SharedConnectedModeSettingsMediumTests {
       {
           "sonarQubeUri": "%s",
           "projectKey": "%s"
-      }""", removeEnd(server.baseUrl(), "/"), projectKey);
+      }""", Strings.CS.removeEnd(server.baseUrl(), "/"), projectKey);
 
     var backend = harness.newBackend()
       .withSonarQubeConnection(connectionId, server)

--- a/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/CheckResolutionStatusChangePermittedMediumTests.java
@@ -461,7 +461,7 @@ class CheckResolutionStatusChangePermittedMediumTests {
   }
 
   private void fakeServerWithWrongBody(String issueKey) {
-    mockWebServerExtension.addResponse(apiIssueSearchPath(issueKey, null), new MockResponse().setBody("wrong body"));
+    mockWebServerExtension.addResponse(apiIssueSearchPath(issueKey, null), new MockResponse.Builder().code(200).body("wrong body").build());
   }
 
   private static String apiIssueSearchPath(String issueKey, @Nullable String orgKey) {

--- a/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
@@ -116,7 +116,7 @@ class SmartNotificationsMediumTests {
   @SonarLintTest
   void it_should_send_notification_for_two_config_scope_with_same_binding(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
@@ -139,7 +139,7 @@ class SmartNotificationsMediumTests {
   @SonarLintTest
   void it_should_send_notification_for_two_config_scope_with_inherited_binding(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
@@ -162,8 +162,8 @@ class SmartNotificationsMediumTests {
   @SonarLintTest
   void it_should_send_notification_for_different_bindings(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
-    mockWebServerExtension2.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
+    mockWebServerExtension2.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     var timestamp = UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER));
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "," + PROJECT_KEY_3 + "," + PROJECT_KEY_4 + "&from=" +
       timestamp + "," + timestamp + "," + timestamp, THREE_EVENTS_P1_P3_P4);
@@ -206,7 +206,7 @@ class SmartNotificationsMediumTests {
   @SonarLintTest
   void it_should_not_send_notification_with_unbound_config_scope(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
@@ -228,7 +228,7 @@ class SmartNotificationsMediumTests {
   @SonarLintTest
   void it_should_send_notification_after_adding_removing_binding(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
@@ -257,7 +257,7 @@ class SmartNotificationsMediumTests {
   @SonarLintTest
   void it_should_send_notification_handled_by_sonarcloud_websocket_as_fallback(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
@@ -281,7 +281,7 @@ class SmartNotificationsMediumTests {
     webSocketServer.start();
     var fakeClient = harness.newFakeClient().withToken(CONNECTION_ID, "token")
       .build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 
@@ -310,7 +310,7 @@ class SmartNotificationsMediumTests {
   @SonarLintTest
   void it_should_send_sonarqube_notification(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
-    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse().setResponseCode(200));
+    mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
       UrlUtils.urlEncode(STORED_DATE.format(TIME_FORMATTER)), EVENT_PROJECT_1);
 

--- a/medium-tests/src/test/java/utils/MockWebServerExtensionWithProtobuf.java
+++ b/medium-tests/src/test/java/utils/MockWebServerExtensionWithProtobuf.java
@@ -39,7 +39,7 @@ public class MockWebServerExtensionWithProtobuf extends MockWebServerExtension {
   public void addProtobufResponse(String path, Message m) {
     try (var b = new Buffer()) {
       m.writeTo(b.outputStream());
-      responsesByPath.put(path, new MockResponse().setBody(b));
+      responsesByPath.put(path, new MockResponse.Builder().body(b).build());
     } catch (IOException e) {
       fail(e);
     }
@@ -48,7 +48,7 @@ public class MockWebServerExtensionWithProtobuf extends MockWebServerExtension {
   public void addProtobufResponseDelimited(String path, Message... m) {
     try (var b = new Buffer()) {
       writeMessages(b.outputStream(), Arrays.asList(m).iterator());
-      responsesByPath.put(path, new MockResponse().setBody(b));
+      responsesByPath.put(path, new MockResponse.Builder().body(b).build());
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,17 +58,17 @@
     <maven.compiler.release>17</maven.compiler.release>
 
     <sonar-plugin-api.version>12.0.0.2960</sonar-plugin-api.version>
-    <sonar-markdown.version>9.4.0.54424</sonar-markdown.version>
+    <sonar-markdown.version>25.3.0.104237</sonar-markdown.version>
     <sonar-scanner-protocol.version>9.9.0.65466</sonar-scanner-protocol.version>
     <protobuf.version>4.28.2</protobuf.version>
     <gitRepositoryName>sonarlint-core</gitRepositoryName>
-    <okhttp.version>5.0.0-alpha.10</okhttp.version>
+    <okhttp.version>5.0.0-alpha.16</okhttp.version>
     <junit.jupiter.version>5.13.1</junit.jupiter.version>
     <artifactsToPublish>${project.groupId}:sonarlint-core:jar</artifactsToPublish>
     <jdk.min.version>11</jdk.min.version>
     <gson.version>2.10</gson.version>
     <mockito.version>5.8.0</mockito.version>
-    <kotlin.version>1.6.21</kotlin.version>
+    <kotlin.version>1.9.21</kotlin.version>
     <lsp4j.version>0.22.0</lsp4j.version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.17</logback.version>
@@ -130,7 +130,12 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.17.0</version>
+        <version>3.18.0</version>
+      </dependency>
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-text</artifactId>
+          <version>1.13.1</version>
       </dependency>
       <!-- This dependency is imported by the SLLS, ping them when it is modified -->
       <dependency>
@@ -229,7 +234,7 @@
       <dependency>
         <groupId>org.wiremock</groupId>
         <artifactId>wiremock-jetty12</artifactId>
-        <version>3.12.1</version>
+        <version>3.13.1</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -65,13 +65,13 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-websocket</artifactId>
-      <version>11.0.6</version>
+      <version>11.0.8</version>
     </dependency>
     <!-- For Plugins testing -->
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.16.1</version>
+      <version>1.17.6</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
[SLCORE-1545](https://sonarsource.atlassian.net/browse/SLCORE-1545)

Fixing following dependencies:
- okio-jvm
- commons-fileupload
- commons-lang3
- commons-lang
- tomcat-embed-core

Changes implied:
- `MockResponse()` constructor is not supported anymore -> Builder
- `isBlank`, `trimToNull`, `StringEscapeUtils`, etc. removed from `commons-lang3` -> Add dependency on `commons-text`
- `removeEnd` deprecated -> `Strings.CS.removeEnd` as a replacement
- Old ITs projects depending on old dependencies for `analyzer-commons`, `sonar-plugin-api` and `org.sonarsource.sonarqube` -> Modified to fit the versions used by LTA SQ:S (9.9)
- Kotlin version updated to fit the new `okhttp` version

[SLCORE-1545]: https://sonarsource.atlassian.net/browse/SLCORE-1545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ