### PR TITLE
SLCORE-1602 Fix CVE on tomcat 11.0.8

### DIFF
--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-websocket</artifactId>
-      <version>11.0.8</version>
+      <version>11.0.10</version>
     </dependency>
     <!-- For Plugins testing -->
     <dependency>


### PR DESCRIPTION
[SLCORE-1602](https://sonarsource.atlassian.net/browse/SLCORE-1602)

This is not critical, it is only used in test

[SLCORE-1602]: https://sonarsource.atlassian.net/browse/SLCORE-1602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ