### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/backend/http/pom.xml
+++ b/backend/http/pom.xml
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>io.github.hakky54</groupId>
-      <artifactId>sslcontext-kickstart</artifactId>
+      <artifactId>ayza</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -228,8 +228,8 @@
       </dependency>
       <dependency>
         <groupId>io.github.hakky54</groupId>
-        <artifactId>sslcontext-kickstart</artifactId>
-        <version>9.0.0</version>
+        <artifactId>ayza</artifactId>
+        <version>10.0.0</version>
       </dependency>
       <!-- Use the Jetty 12 variant that supports Servlet 6, to not conflict with Tomcat -->
       <dependency>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience