### PR TITLE
SLCORE-1655 Telemetry for MCP integration

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -13,6 +13,8 @@
   * It is sent by the backend to notify the client that the embedded server has started
   * It contains the embedded server port
   * Example usage is by the MCP Server to establish the bridge connection
+* Add a new `org.sonarsource.sonarlint.core.rpc.protocol.backend.telemetry.TelemetryRpcService.mcpIntegrationEnabled` method.
+  * Should only be used by SonarQube MCP Server when integration with SQ:IDE is enabled and valid
 
 # 10.31
 

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryService.java
@@ -269,6 +269,9 @@ public class TelemetryService {
     updateTelemetry(TelemetryLocalStorage::incrementSuggestedRemoteBindingsCount);
   }
 
+  public void mcpIntegrationEnabled() {
+    updateTelemetry(storage -> storage.setMcpIntegrationEnabled(true));
+  }
 
   public void toolCalled(ToolCalledParams params) {
     updateTelemetry(storage -> storage.incrementToolCalledCount(params.getToolName(), params.isSucceeded()));

--- a/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TelemetryRpcServiceDelegate.java
+++ b/backend/rpc-impl/src/main/java/org/sonarsource/sonarlint/core/rpc/impl/TelemetryRpcServiceDelegate.java
@@ -95,6 +95,11 @@ class TelemetryRpcServiceDelegate extends AbstractRpcServiceDelegate implements 
   }
 
   @Override
+  public void mcpIntegrationEnabled() {
+    notify(() -> getBean(TelemetryService.class).mcpIntegrationEnabled());
+  }
+
+  @Override
   public void toolCalled(ToolCalledParams params) {
     notify(() -> getBean(TelemetryService.class).toolCalled(params));
   }

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
@@ -97,6 +97,7 @@ public class TelemetryLocalStorage {
   private int automaticAnalysisToggledCount;
   private int flightRecorderSessionsCount;
   private int mcpServerConfigurationRequestedCount;
+  private boolean isMcpIntegrationEnabled;
 
   TelemetryLocalStorage() {
     enabled = true;
@@ -263,6 +264,7 @@ public class TelemetryLocalStorage {
     automaticAnalysisToggledCount = 0;
     flightRecorderSessionsCount = 0;
     mcpServerConfigurationRequestedCount = 0;
+    isMcpIntegrationEnabled = false;
   }
 
   public long numUseDays() {
@@ -576,6 +578,14 @@ public class TelemetryLocalStorage {
 
   public long getIssuesFixedCount() {
     return issuesFixedCount;
+  }
+
+  public void setMcpIntegrationEnabled(boolean isMcpIntegrationEnabled) {
+    this.isMcpIntegrationEnabled = isMcpIntegrationEnabled;
+  }
+
+  public boolean isMcpIntegrationEnabled() {
+    return isMcpIntegrationEnabled;
   }
 
   public void incrementToolCalledCount(String toolName, boolean succeeded) {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
@@ -75,8 +75,6 @@ public class TelemetryMeasuresBuilder {
 
     addMCPMeasures(values);
 
-    addMcpIntegrationMeasures(values);
-
     return new TelemetryMeasuresPayload(UUID.randomUUID().toString(), platform, storage.installTime(), product, TelemetryMeasuresDimension.INSTALLATION, values);
   }
 
@@ -210,11 +208,7 @@ public class TelemetryMeasuresBuilder {
 
   private void addMCPMeasures(List<TelemetryMeasuresValue> values) {
     values.add(new TelemetryMeasuresValue("mcp.configuration_requested", String.valueOf(storage.getMcpServerConfigurationRequestedCount()), INTEGER, DAILY));
-  }
-
-  private void addMcpIntegrationMeasures(List<TelemetryMeasuresValue> values) {
-    var isMcpIntegrationEnabled = storage.isMcpIntegrationEnabled();
-    values.add(new TelemetryMeasuresValue("mcp.integration_enabled", Boolean.toString(isMcpIntegrationEnabled), BOOLEAN, DAILY));
+    values.add(new TelemetryMeasuresValue("mcp.integration_enabled", Boolean.toString(storage.isMcpIntegrationEnabled()), BOOLEAN, DAILY));
   }
 
 }

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
@@ -75,6 +75,8 @@ public class TelemetryMeasuresBuilder {
 
     addMCPMeasures(values);
 
+    addMcpIntegrationMeasures(values);
+
     return new TelemetryMeasuresPayload(UUID.randomUUID().toString(), platform, storage.installTime(), product, TelemetryMeasuresDimension.INSTALLATION, values);
   }
 
@@ -209,4 +211,10 @@ public class TelemetryMeasuresBuilder {
   private void addMCPMeasures(List<TelemetryMeasuresValue> values) {
     values.add(new TelemetryMeasuresValue("mcp.configuration_requested", String.valueOf(storage.getMcpServerConfigurationRequestedCount()), INTEGER, DAILY));
   }
+
+  private void addMcpIntegrationMeasures(List<TelemetryMeasuresValue> values) {
+    var isMcpIntegrationEnabled = storage.isMcpIntegrationEnabled();
+    values.add(new TelemetryMeasuresValue("mcp.integration_enabled", Boolean.toString(isMcpIntegrationEnabled), BOOLEAN, DAILY));
+  }
+
 }

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
@@ -119,6 +119,7 @@ class TelemetryHttpClientTests {
     telemetryLocalStorage.addFixedIssues(2);
     telemetryLocalStorage.findingsFiltered("severity");
     telemetryLocalStorage.incrementFlightRecorderSessionsCount();
+    telemetryLocalStorage.setMcpIntegrationEnabled(true);
     spy.upload(telemetryLocalStorage, getTelemetryLiveAttributesDto());
 
     telemetryMock.verify(postRequestedFor(urlEqualTo("/"))
@@ -141,7 +142,8 @@ class TelemetryHttpClientTests {
             {"key":"tools.tool_name_success_count","value":"1","type":"integer","granularity":"daily"},
             {"key":"tools.tool_name_error_count","value":"1","type":"integer","granularity":"daily"},
             {"key":"findings_filtered.severity","value":"1","type":"integer","granularity":"daily"},
-            {"key":"flight_recorder.sessions_count","value":"1","type":"integer","granularity":"daily"}
+            {"key":"flight_recorder.sessions_count","value":"1","type":"integer","granularity":"daily"},
+            {"key":"mcp.integration_enabled","value":"true","type":"boolean","granularity":"daily"}
           ]}
           """, PLATFORM),
           true, true)));

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
@@ -350,4 +350,12 @@ class TelemetryLocalStorageTests {
     data.incrementMcpServerConfigurationRequestedCount();
     assertThat(data.getMcpServerConfigurationRequestedCount()).isEqualTo(2);
   }
+
+  @Test
+  void should_find_mcp_integration_enabled() {
+    var data = new TelemetryLocalStorage();
+    assertThat(data.isMcpIntegrationEnabled()).isFalse();
+    data.setMcpIntegrationEnabled(true);
+    assertThat(data.isMcpIntegrationEnabled()).isTrue();
+  }
 }

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
@@ -235,6 +235,7 @@ class TelemetryManagerTests {
       data.getAnalysisReportingCountersByType().put(PRE_COMMIT_ANALYSIS_TYPE, new TelemetryAnalysisReportingCounter(DEFAULT_ANALYSIS_REPORTING_COUNT));
       data.findingsFiltered("severity");
       data.incrementFlightRecorderSessionsCount();
+      data.setMcpIntegrationEnabled(true);
     });
 
     telemetryManager.uploadAndClearTelemetry(telemetryPayload);
@@ -255,6 +256,7 @@ class TelemetryManagerTests {
     assertThat(reloaded.getAnalysisReportingCountersByType()).isEmpty();
     assertThat(reloaded.getFindingsFilteredCountersByType()).isEmpty();
     assertThat(reloaded.getFlightRecorderSessionsCount()).isZero();
+    assertThat(reloaded.isMcpIntegrationEnabled()).isFalse();
   }
 
   private void createAndSaveSampleData(TelemetryLocalStorageManager storage) {

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryMeasuresPayloadTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryMeasuresPayloadTests.java
@@ -79,7 +79,8 @@ class TelemetryMeasuresPayloadTests {
       "{\"key\":\"performance.biggest_size_config_scope_files\",\"value\":\"12345\",\"type\":\"integer\",\"granularity\":\"daily\"}," +
       "{\"key\":\"automatic_analysis.enabled\",\"value\":\"true\",\"type\":\"boolean\",\"granularity\":\"daily\"}," +
       "{\"key\":\"automatic_analysis.toggled_count\",\"value\":\"1\",\"type\":\"integer\",\"granularity\":\"daily\"}," +
-      "{\"key\":\"mcp.configuration_requested\",\"value\":\"3\",\"type\":\"integer\",\"granularity\":\"daily\"}" +
+      "{\"key\":\"mcp.configuration_requested\",\"value\":\"3\",\"type\":\"integer\",\"granularity\":\"daily\"}," +
+      "{\"key\":\"mcp.integration_enabled\",\"value\":\"true\",\"type\":\"boolean\",\"granularity\":\"daily\"}" +
       "]}");
 
     assertThat(m.messageUuid()).isEqualTo(messageUuid);
@@ -121,6 +122,7 @@ class TelemetryMeasuresPayloadTests {
     values.add(new TelemetryMeasuresValue("automatic_analysis.toggled_count", String.valueOf(1), INTEGER, DAILY));
 
     values.add(new TelemetryMeasuresValue("mcp.configuration_requested", String.valueOf(3), INTEGER, DAILY));
+    values.add(new TelemetryMeasuresValue("mcp.integration_enabled", String.valueOf(true), BOOLEAN, DAILY));
 
     return values;
   }
@@ -140,7 +142,8 @@ class TelemetryMeasuresPayloadTests {
       .contains(tuple("help_and_feedback.doc_link", "5", INTEGER, DAILY))
       .contains(tuple("analysis_reporting.trigger_count_vcs_changed_files", "7", INTEGER, DAILY))
       .contains(tuple("automatic_analysis.enabled", "true", BOOLEAN, DAILY))
-      .contains(tuple("automatic_analysis.toggled_count", "1", INTEGER, DAILY));
+      .contains(tuple("automatic_analysis.toggled_count", "1", INTEGER, DAILY))
+      .contains(tuple("mcp.integration_enabled", "true", BOOLEAN, DAILY));
   }
 
 }

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -435,6 +435,15 @@ class TelemetryMediumTests {
   }
 
   @SonarLintTest
+  void it_should_record_mcpIntegrationEnabled(SonarLintTestHarness harness) {
+    var backend = setupClientAndBackend(harness);
+
+    backend.getTelemetryService().mcpIntegrationEnabled();
+
+    await().untilAsserted(() -> assertThat(backend.telemetryFileContent().isMcpIntegrationEnabled()).isTrue());
+  }
+
+  @SonarLintTest
   void it_should_record_toolCalled(SonarLintTestHarness harness) {
     var backend = setupClientAndBackend(harness);
 

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/TelemetryRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/telemetry/TelemetryRpcService.java
@@ -86,6 +86,13 @@ public interface TelemetryRpcService {
   @JsonNotification
   void helpAndFeedbackLinkClicked(HelpAndFeedbackClickedParams params);
 
+  /**
+   * To be called from SonarQube MCP Server when SQ:IDE integration is enabled and valid
+   * This is tracking if SQ:IDE integration was enabled at least once during the day
+   */
+  @JsonNotification
+  void mcpIntegrationEnabled();
+
   @JsonNotification
   void toolCalled(ToolCalledParams params);
 


### PR DESCRIPTION
[SLCORE-1655](https://sonarsource.atlassian.net/browse/SLCORE-1655)

We should track if SQ:IDE integration was enabled at least once during the day, when SonarQube MCP Server is starting.

Measure: mcp.integration_enabled → false/true

It resets to false every day

[SLCORE-1655]: https://sonarsource.atlassian.net/browse/SLCORE-1655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ