### PR TITLE
SLCORE-1705 Bump logback dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <kotlin.version>1.9.21</kotlin.version>
     <lsp4j.version>0.22.0</lsp4j.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <logback.version>1.5.17</logback.version>
+    <logback.version>1.5.19</logback.version>
     <version.surefire.plugin>3.1.2</version.surefire.plugin>
     <system.stubs.version>2.1.7</system.stubs.version>
 


### PR DESCRIPTION
[SLCORE-1705](https://sonarsource.atlassian.net/browse/SLCORE-1705)



[SLCORE-1705]: https://sonarsource.atlassian.net/browse/SLCORE-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Bumping the version as recommended way of dealing with dependency risk: https://next.sonarqube.com/sonarqube/dependency-risks/4e5e8024-f33f-4cee-8c0d-e7fbbd06b571/what?id=org.sonarsource.sonarlint.core%3Asonarlint-core-parent