### PR TITLE
SLCORE-1432 Introduce a cache for file contents

### DIFF
--- a/API_CHANGES.md
+++ b/API_CHANGES.md
@@ -4,6 +4,12 @@
 
 * Remove the `org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.DependencyRiskRpcService.getDependencyRiskDetails` method and associated DTOs.
 
+## New features
+
+* Added caching for file contents during analysis. Following environment variables are used to control it: 
+  * `CACHE_STATS_ENABLED_PROPERTY` - when `true`, it enables cache stats gathering (like amount of cache hits/misses and evictions caused by overflow).
+  * `SONARLINT_CACHE_SIZE` - to set another cap to total length of strings in the cache, 1.000.000 by default.
+
 # 10.38
 
 ## New features

--- a/backend/core/pom.xml
+++ b/backend/core/pom.xml
@@ -110,6 +110,14 @@
       <version>5.3.2</version>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>okhttp</artifactId>
       <scope>test</scope>

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/BackendInputFile.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/BackendInputFile.java
@@ -19,10 +19,10 @@
  */
 package org.sonarsource.sonarlint.core.analysis;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.commons.util.FileUtils;
@@ -56,8 +56,8 @@ public class BackendInputFile implements ClientInputFile {
   }
 
   @Override
-  public InputStream inputStream() throws IOException {
-    return clientFile.inputStream();
+  public InputStream inputStream() {
+    return IOUtils.toInputStream(contents(), getCharset());
   }
 
   @Override

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ReadThroughFileCache.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ReadThroughFileCache.java
@@ -1,0 +1,81 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.fs;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.function.Supplier;
+import org.apache.commons.io.ByteOrderMark;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+import org.sonarsource.sonarlint.core.analysis.AnalysisFinishedEvent;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.event.EventListener;
+
+import static org.sonarsource.sonarlint.core.spring.CacheConfig.CACHE_STATS_ENABLED_PROPERTY;
+
+public class ReadThroughFileCache {
+
+  private static final SonarLintLogger LOG = SonarLintLogger.get();
+
+  private final Supplier<CacheStats> cacheStatsProvider;
+
+  public ReadThroughFileCache(Supplier<CacheStats> cacheStatsProvider) {
+    this.cacheStatsProvider = cacheStatsProvider;
+  }
+
+  @Cacheable(cacheNames = "fileContentsCache")
+  public String content(Path fsPath, Charset charset) throws IOException {
+    var inputStream = BOMInputStream.builder()
+      .setPath(fsPath)
+      .setByteOrderMarks(ByteOrderMark.UTF_32LE, ByteOrderMark.UTF_32BE, ByteOrderMark.UTF_8, ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_16BE)
+      .get();
+
+    return IOUtils.toString(inputStream, charset);
+  }
+
+  @CacheEvict(cacheNames = "fileContentsCache", beforeInvocation = true)
+  public void remove(Path fsPath, Charset charset) {
+    LOG.debug("Evicted {} ({}) from file cache.", fsPath, charset);
+  }
+
+  @EventListener
+  @CacheEvict(cacheNames = "fileContentsCache", allEntries = true)
+  public void onAnalysisFinished(AnalysisFinishedEvent event) {
+    if ("true".equals(System.getenv(CACHE_STATS_ENABLED_PROPERTY))) {
+      var cacheStats = cacheStatsProvider.get();
+      LOG.debug("Clearing up cache after the analysis {}, cache summary: {}",
+        event.getAnalysisId(), cacheSummary(cacheStats));
+    }
+  }
+
+  private static String cacheSummary(CacheStats stats) {
+    return "{"
+      + "hitCount:" + stats.hitCount() + ", "
+      + "missCount:" + stats.missCount() + ", "
+      + "evictionCount:" + stats.evictionCount() + ", "
+      + "evictionWeight:" + stats.evictionWeight()
+      + "}";
+  }
+}

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/CacheConfig.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/CacheConfig.java
@@ -1,0 +1,73 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) 2016-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.spring;
+
+import com.github.benmanes.caffeine.cache.AsyncCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.sonarsource.sonarlint.core.fs.ReadThroughFileCache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cache.interceptor.SimpleKey;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@EnableCaching
+@Import({
+  ReadThroughFileCache.class
+})
+public class CacheConfig {
+
+  public static final String CACHE_STATS_ENABLED_PROPERTY = "SONARLINT_CACHE_STATS_ENABLED";
+  private static final String SONARLINT_CACHE_SIZE = "SONARLINT_CACHE_SIZE";
+  // Total string length in the cache. Each symbol is 2-4 bytes, so it should be a cap slightly above 2MB.
+  private static final int DEFAULT_MAXIMUM_WEIGHT = 1_000_000;
+
+  @Bean
+  public CacheManager cacheManager(AsyncCache<Object, Object> fileContentsCache) {
+    var caffeineCacheManager = new CaffeineCacheManager();
+    caffeineCacheManager.registerCustomCache("fileContentsCache",
+      fileContentsCache);
+    return caffeineCacheManager;
+  }
+
+  @Bean
+  public AsyncCache<Object, Object> fileContentsCache() {
+    var caffeine = Caffeine.newBuilder();
+    caffeine.<SimpleKey, String>weigher((k, v) -> StringUtils.length(v));
+    caffeine.maximumWeight(NumberUtils.toInt(
+      System.getenv(SONARLINT_CACHE_SIZE), DEFAULT_MAXIMUM_WEIGHT));
+    if ("true".equals(System.getenv(CACHE_STATS_ENABLED_PROPERTY))) {
+      caffeine.recordStats();
+    }
+    return caffeine.buildAsync();
+  }
+
+  @Bean
+  public Supplier<CacheStats> cacheStatsProvider(AsyncCache<Object, Object> fileContentsCache) {
+    return () -> fileContentsCache.synchronous().stats();
+  }
+}

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SpringApplicationContextInitializer.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SpringApplicationContextInitializer.java
@@ -39,6 +39,7 @@ public class SpringApplicationContextInitializer implements AutoCloseable {
     applicationContext.register(TelemetrySpringConfig.class);
     applicationContext.register(GessieSpringConfig.class);
     applicationContext.register(IdeLabsSpringConfig.class);
+    applicationContext.register(CacheConfig.class);
     applicationContext.registerBean("sonarlintClient", SonarLintRpcClient.class, () -> requireNonNull(client));
     applicationContext.registerBean("initializeParams", InitializeParams.class, () -> params);
     applicationContext.refresh();

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/analysis/BackendInputFileTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/analysis/BackendInputFileTests.java
@@ -23,17 +23,21 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.sonarsource.sonarlint.core.fs.ReadThroughFileCache;
 import org.sonarsource.sonarlint.core.fs.ClientFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class BackendInputFileTests {
+
+  private final ReadThroughFileCache cache = mock(ReadThroughFileCache.class);
 
   @Test
   void ascii_path_should_be_the_same() {
     var path = Path.of("/test/file.php");
     var pathAsString = path.toString().replace(File.separatorChar, '/');
-    var clientFile = new ClientFile(URI.create("file://" + pathAsString), "configScopeId", path, false, null, null, null, true);
+    var clientFile = new ClientFile(URI.create("file://" + pathAsString), "configScopeId", path, false, null, null, null, true, cache);
 
     var inputFile = new BackendInputFile(clientFile);
 
@@ -44,7 +48,7 @@ class BackendInputFileTests {
   void non_ascii_path_should_be_the_same() {
     var path = Path.of("/中文字符/file.php");
     var pathAsString = path.toString().replace(File.separatorChar, '/');
-    var clientFile = new ClientFile(URI.create("file://" + pathAsString), "configScopeId", path, false, null, null, null, true);
+    var clientFile = new ClientFile(URI.create("file://" + pathAsString), "configScopeId", path, false, null, null, null, true, cache);
 
     var inputFile = new BackendInputFile(clientFile);
 

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/file/PathTranslationServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/file/PathTranslationServiceTests.java
@@ -31,6 +31,7 @@ import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
 import org.sonarsource.sonarlint.core.event.BindingConfigChangedEvent;
 import org.sonarsource.sonarlint.core.fs.ClientFile;
 import org.sonarsource.sonarlint.core.fs.ClientFileSystemService;
+import org.sonarsource.sonarlint.core.fs.ReadThroughFileCache;
 import org.sonarsource.sonarlint.core.repository.config.ConfigurationRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +52,7 @@ class PathTranslationServiceTests {
   private final ClientFileSystemService clientFs = mock(ClientFileSystemService.class);
   private final ConfigurationRepository configurationRepository = mock(ConfigurationRepository.class);
   private final ServerFilePathsProvider serverFilePathsProvider = mock(ServerFilePathsProvider.class);
+  private final ReadThroughFileCache cache = mock(ReadThroughFileCache.class);
   private final PathTranslationService underTest = new PathTranslationService(clientFs, configurationRepository, serverFilePathsProvider);
 
   @BeforeEach
@@ -126,7 +128,7 @@ class PathTranslationServiceTests {
 
   private void mockClientFilePaths(String... paths) {
     doReturn(Arrays.stream(paths)
-      .map(path -> new ClientFile(null, null, Paths.get(path), null, null, null, null, true))
+      .map(path -> new ClientFile(null, null, Paths.get(path), null, null, null, null, true, cache))
       .toList())
       .when(clientFs)
       .getFiles(CONFIG_SCOPE);

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/fs/ClientFileTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/fs/ClientFileTests.java
@@ -26,13 +26,16 @@ import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class ClientFileTests {
+
+  private final ReadThroughFileCache cache = mock(ReadThroughFileCache.class);
 
   @Test
   void dirty_file_larger_than_threshold_returns_true() throws Exception {
     var uri = URI.create("file:///dirty.js");
-    var clientFile = new ClientFile(uri, "scope", Paths.get("dirty.js"), null, StandardCharsets.UTF_8, null, null, true);
+    var clientFile = new ClientFile(uri, "scope", Paths.get("dirty.js"), null, StandardCharsets.UTF_8, null, null, true, cache);
 
     var content = "x".repeat(2048);
     clientFile.setDirty(content);
@@ -47,11 +50,11 @@ class ClientFileTests {
     Files.write(tempFile, new byte[4096]);
 
     var localUri = tempFile.toUri();
-    var localClientFile = new ClientFile(localUri, "scope", Paths.get("local.txt"), null, StandardCharsets.UTF_8, tempFile, null, true);
+    var localClientFile = new ClientFile(localUri, "scope", Paths.get("local.txt"), null, StandardCharsets.UTF_8, tempFile, null, true, cache);
 
     var missingPath = tempFile.getParent().resolve("missing.txt");
     var nonLocalUri = missingPath.toUri();
-    var nonLocalClientFile = new ClientFile(nonLocalUri, "scope", Paths.get("missing.txt"), null, StandardCharsets.UTF_8, null, null, true);
+    var nonLocalClientFile = new ClientFile(nonLocalUri, "scope", Paths.get("missing.txt"), null, StandardCharsets.UTF_8, null, null, true, cache);
 
     assertThat(localClientFile.isLargerThan(1024)).isTrue();
     assertThat(localClientFile.isLargerThan(8192)).isFalse();

--- a/medium-tests/src/test/java/mediumtest/cache/CachingMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/cache/CachingMediumTests.java
@@ -1,0 +1,87 @@
+/*
+ * SonarLint Core - Medium Tests
+ * Copyright (C) 2016-2025 SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package mediumtest.cache;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFilesAndTrackParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.log.LogParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
+import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
+import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import utils.TestPlugin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static utils.AnalysisUtils.createFile;
+
+@ExtendWith(SystemStubsExtension.class)
+class CachingMediumTests {
+
+  @SystemStub
+  private EnvironmentVariables environmentVariables;
+
+  @BeforeEach
+  void setUp() {
+    environmentVariables.set("SONARLINT_CACHE_STATS_ENABLED", "true");
+  }
+
+  private static final String CONFIG_SCOPE_ID = "CONFIG_SCOPE_ID";
+
+  @SonarLintTest
+  void should_invalidate_cache_after_analysis(SonarLintTestHarness harness, @TempDir Path baseDir) {
+    var filePath = createFile(baseDir, "pom.xml",
+      """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <project>
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>com.foo</groupId>
+          <artifactId>bar</artifactId>
+          <version>${pom.version}</version>
+        </project>""");
+    var fileUri = filePath.toUri();
+    var client = harness.newFakeClient()
+      .withInitialFs(CONFIG_SCOPE_ID, baseDir, List.of(
+        new ClientFileDto(fileUri, baseDir.relativize(filePath), CONFIG_SCOPE_ID, false, null, filePath, null, null, true)))
+      .build();
+    var backend = harness.newBackend()
+      .withUnboundConfigScope(CONFIG_SCOPE_ID)
+      .withStandaloneEmbeddedPluginAndEnabledLanguage(TestPlugin.XML)
+      .start(client);
+
+    backend.getAnalysisService()
+      .analyzeFilesAndTrack(new AnalyzeFilesAndTrackParams(CONFIG_SCOPE_ID,  UUID.randomUUID(), List.of(fileUri), Map.of(), false)).join();
+    backend.getAnalysisService()
+      .analyzeFilesAndTrack(new AnalyzeFilesAndTrackParams(CONFIG_SCOPE_ID,  UUID.randomUUID(), List.of(fileUri), Map.of(), false)).join();
+    backend.getAnalysisService()
+      .analyzeFilesAndTrack(new AnalyzeFilesAndTrackParams(CONFIG_SCOPE_ID,  UUID.randomUUID(), List.of(fileUri), Map.of(), false)).join();
+
+    assertThat(client.getLogs()).extracting(LogParams::getMessage)
+      .anyMatch(message -> message.contains("missCount:3"),
+        "We should have each analysis miss at first");
+  }
+}

--- a/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/tracking/IssueTrackingMediumTests.java
@@ -138,13 +138,14 @@ class IssueTrackingMediumTests {
     var firstAnalysisPublishedIssues = analyzeFileAndGetAllIssuesOfRule(backend, client, fileUri, ruleKey);
 
     assertThat(firstAnalysisPublishedIssues).hasSize(1);
-    changeFileContent(baseDir, ideFilePath,
-      """
-        package sonar;
-        // FIXME foo bar
-        public interface Foo {
-        // FIXME bar baz
-        }""");
+    var newContent = """
+      package sonar;
+      // FIXME foo bar
+      public interface Foo {
+      // FIXME bar baz
+      }""";
+    backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(List.of(),
+      List.of(new ClientFileDto(fileUri, baseDir.relativize(filePath), CONFIG_SCOPE_ID, false, null, filePath, newContent, null, true)), List.of()));
     var secondAnalysisPublishedIssues = analyzeFileAndGetAllIssuesOfRule(backend, client, fileUri, ruleKey);
     assertThat(secondAnalysisPublishedIssues).hasSize(2);
 
@@ -996,6 +997,8 @@ class IssueTrackingMediumTests {
     changeFileContent(baseDir, filePath.getFileName().toString(), """
         # TODO try that
       """);
+    backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(List.of(),
+      List.of(new ClientFileDto(fileUri, baseDir.relativize(filePath), CONFIG_SCOPE_ID, false, null, filePath, null, null, true)), List.of()));
     raisedIssueDtos = analyzeFileAndGetAllIssues(backend, client, fileUri);
     assertThat(raisedIssueDtos).hasSize(1);
 
@@ -1003,6 +1006,8 @@ class IssueTrackingMediumTests {
         # TODO try this
         # TODO try that
       """);
+    backend.getFileService().didUpdateFileSystem(new DidUpdateFileSystemParams(List.of(),
+      List.of(new ClientFileDto(fileUri, baseDir.relativize(filePath), CONFIG_SCOPE_ID, false, null, filePath, null, null, true)), List.of()));
     raisedIssueDtos = analyzeFileAndGetAllIssues(backend, client, fileUri);
     assertThat(raisedIssueDtos)
       .hasSize(2);

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,16 @@
         <artifactId>sonar-classloader</artifactId>
         <version>1.2.1.2095</version>
       </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>3.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-cache</artifactId>
+        <version>4.0.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
I didn't notice any performance boosts, but it should help us with making sure that files are not staying open as `inputStream()` implementation now relies on in-memory copy instead of going straight to the file.

Feel free to discuss default cache size as it did lead to almost a 50/50 between hits and misses in my test run. But even after increasing the size I didn't notice performance boost.