### PR TITLE
BUILD-10699: test fallback-to-default-branch cache behaviour

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
             development/kv/data/next token | NEXT_TOKEN;
       - name: Cache Sonar Scanner artifacts
         id: sonar-scanner-cache
-        uses: SonarSource/ci-github-actions/cache@94416c84682255b8f6e189d54d323d5d41195278 # 1.3.26
+        uses: SonarSource/gh-action_cache@2cffd56e21f9dafc74ff1df34d77ae5f5ae46e6f # BUILD-10699 test: fallback-to-default-branch
         with:
           path: ~/.sonar/cache
           key: sonar-scanner-${{ runner.os }}
@@ -227,7 +227,7 @@ jobs:
           echo "ORCHESTRATOR_HOME=${ORCHESTRATOR_HOME}" >> "$GITHUB_ENV"
           echo "Create dir ${ORCHESTRATOR_HOME} if needed"
           mkdir -p "${ORCHESTRATOR_HOME}"
-      - uses: SonarSource/ci-github-actions/cache@94416c84682255b8f6e189d54d323d5d41195278 # 1.3.26
+      - uses: SonarSource/gh-action_cache@2cffd56e21f9dafc74ff1df34d77ae5f5ae46e6f # BUILD-10699 test: fallback-to-default-branch
         if: ${{ matrix.sc != true && matrix.sq_version != 'DEV' }}
         with:
           path: ${{ github.workspace }}/orchestrator/${{ steps.month.outputs.month }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
             development/kv/data/next token | NEXT_TOKEN;
       - name: Cache Sonar Scanner artifacts
         id: sonar-scanner-cache
-        uses: SonarSource/gh-action_cache@2cffd56e21f9dafc74ff1df34d77ae5f5ae46e6f # BUILD-10699 test: fallback-to-default-branch
+        uses: SonarSource/gh-action_cache@3c1a97360f54d1b67430b36a5ccce12ea3f472f8 # BUILD-10699 test: fallback-to-default-branch
         with:
           path: ~/.sonar/cache
           key: sonar-scanner-${{ runner.os }}
@@ -227,7 +227,7 @@ jobs:
           echo "ORCHESTRATOR_HOME=${ORCHESTRATOR_HOME}" >> "$GITHUB_ENV"
           echo "Create dir ${ORCHESTRATOR_HOME} if needed"
           mkdir -p "${ORCHESTRATOR_HOME}"
-      - uses: SonarSource/gh-action_cache@2cffd56e21f9dafc74ff1df34d77ae5f5ae46e6f # BUILD-10699 test: fallback-to-default-branch
+      - uses: SonarSource/gh-action_cache@3c1a97360f54d1b67430b36a5ccce12ea3f472f8 # BUILD-10699 test: fallback-to-default-branch
         if: ${{ matrix.sc != true && matrix.sq_version != 'DEV' }}
         with:
           path: ${{ github.workspace }}/orchestrator/${{ steps.month.outputs.month }}


### PR DESCRIPTION
## Purpose

Test PR for [BUILD-10699](https://sonarsource.atlassian.net/browse/BUILD-10699) — validating the new `fallback-to-default-branch` behaviour in [gh-action_cache#42](https://github.com/SonarSource/gh-action_cache/pull/42).

Both cache steps have been migrated from the deprecated `ci-github-actions/cache` wrapper to `gh-action_cache` directly, pinned to the feature branch SHA `2cffd56` which adds `fallback-to-default-branch: true` as a default.

**Do not merge.** This PR exists only for CI testing.

---

## What changed

Both cache usages in `build.yml` now point at the `gh-action_cache` feature branch:

1. **Sonar Scanner cache** (`test-linux` job) — `key: sonar-scanner-Linux`, no `restore-keys`
2. **Orchestrator cache** (`qa` job) — `key: cache-Linux-{month}-{matrix.name}`, no `restore-keys`

With the new default behaviour, both will automatically get a fallback restore key pointing to the `master` branch cache, even though no `restore-keys` are explicitly set.

---

## Test Plan

### Test 1 — Sonar Scanner cache (`test-linux` job)

**Cache step:** `Cache Sonar Scanner artifacts`
**Key:** `sonar-scanner-Linux`
**restore-keys:** none (relying on new default)

| Scenario | Expected log output | Success criteria |
|---|---|---|
| **First run on this branch** (cold cache) | `prepare-keys` step outputs `branch-restore-keys` containing `refs/heads/master/sonar-scanner-Linux` | The output variable is set and visible in the step's debug output |
| **Cache restore** | `runs-on/cache` step logs show it attempted restore with key `BUILD-10699-test-fallback-to-default-branch/sonar-scanner-Linux` and fallback `refs/heads/master/sonar-scanner-Linux` | Either a hit on the fallback key (partial restore) or a miss — but the fallback key must have been **attempted** |
| **Subsequent run on this branch** (warm cache) | Exact hit on `BUILD-10699-test-fallback-to-default-branch/sonar-scanner-Linux` | `cache-hit: true` output, restore time is fast |

### Test 2 — Orchestrator cache (`qa` job, matrix: SQLatest, SQLts99)

**Cache step:** unnamed orchestrator cache step
**Key:** `cache-Linux-{YYYY-MM}-{matrix.name}` (e.g. `cache-Linux-2026-03-SQLatest`)
**restore-keys:** none (relying on new default)

| Scenario | Expected log output | Success criteria |
|---|---|---|
| **First run on this branch** (cold cache) | `prepare-keys` outputs `branch-restore-keys = refs/heads/master/cache-Linux-2026-03-SQLatest` | Output variable set; fallback key attempted during restore |
| **Cache restore with master hit** | `runs-on/cache` logs show fallback key `refs/heads/master/cache-Linux-2026-03-SQLatest` was found | Cache restored from master; orchestrator download skipped or faster than cold |
| **Subsequent run on this branch** | Exact hit on `BUILD-10699-test-fallback-to-default-branch/cache-Linux-2026-03-SQLatest` | `cache-hit: true` |

### Test 3 — `fallback-to-default-branch: false` (opt-out)

Not tested in this PR (no opt-out case here). Covered by unit testing of `prepare-keys.sh` directly.

### Test 4 — On `master` branch (no fallback expected)

When this same workflow runs on `master`, the `prepare-keys` step should detect it's already on the default branch and **not** add any fallback restore keys. Verify by inspecting a master build's `prepare-keys` step output — `branch-restore-keys` should be empty.

---

## How to verify

For each CI run triggered by this PR, inspect the **"Prepare cache keys"** step output in the Actions log. You should see:

```
branch-key=refs/pull/{N}/merge/sonar-scanner-Linux
branch-restore-keys=refs/heads/master/sonar-scanner-Linux
```

The presence of `branch-restore-keys` pointing to `master` — even without any `restore-keys` input — is the primary success signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUILD-10699]: https://sonarsource.atlassian.net/browse/BUILD-10699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ