### PR TITLE
BUILD-10699: test fallback-to-default-branch cache behaviour (v2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
             development/kv/data/next token | NEXT_TOKEN;
       - name: Cache Sonar Scanner artifacts
         id: sonar-scanner-cache
-        uses: SonarSource/ci-github-actions/cache@94416c84682255b8f6e189d54d323d5d41195278 # 1.3.26
+        uses: SonarSource/gh-action_cache@5f49da54a5f21fe9cc2e461d3a63c215613496ca # BUILD-10699 test: fallback-to-default-branch v2
         with:
           path: ~/.sonar/cache
           key: sonar-scanner-${{ runner.os }}
@@ -227,7 +227,7 @@ jobs:
           echo "ORCHESTRATOR_HOME=${ORCHESTRATOR_HOME}" >> "$GITHUB_ENV"
           echo "Create dir ${ORCHESTRATOR_HOME} if needed"
           mkdir -p "${ORCHESTRATOR_HOME}"
-      - uses: SonarSource/ci-github-actions/cache@94416c84682255b8f6e189d54d323d5d41195278 # 1.3.26
+      - uses: SonarSource/gh-action_cache@5f49da54a5f21fe9cc2e461d3a63c215613496ca # BUILD-10699 test: fallback-to-default-branch v2
         if: ${{ matrix.sc != true && matrix.sq_version != 'DEV' }}
         with:
           path: ${{ github.workspace }}/orchestrator/${{ steps.month.outputs.month }}


### PR DESCRIPTION
## Purpose

Test PR for [BUILD-10699](https://sonarsource.atlassian.net/browse/BUILD-10699) — validating the latest changes in [gh-action_cache#42](https://github.com/SonarSource/gh-action_cache/pull/42), specifically the fix for explicit `fallback-branch` handling when `fallback-to-default-branch: false`.

Both cache steps have been migrated from the deprecated `ci-github-actions/cache` wrapper to `gh-action_cache` directly, pinned to the feature branch SHA `5f49da5` which includes:
- `fallback-to-default-branch: true` as a default
- Fix: explicit `fallback-branch` is now always honoured, regardless of `fallback-to-default-branch`

**Do not merge.** This PR exists only for CI testing.

---

## What changed

Both cache usages in `build.yml` now point at the `gh-action_cache` feature branch:

1. **Sonar Scanner cache** (`test-linux` job) — `key: sonar-scanner-Linux`, no `restore-keys`
2. **Orchestrator cache** (`qa` job) — `key: cache-Linux-{month}-{matrix.name}`, no `restore-keys`

With the new default behaviour, both will automatically get a fallback restore key pointing to the `master` branch cache, even though no `restore-keys` are explicitly set.

---

## Test Plan

### Test 1 — Cold cache (first run)

| Step | Expected | Success criteria |
|---|---|---|
| `Prepare cache keys` | `branch-restore-keys` contains `refs/heads/master/sonar-scanner-Linux` | Output variable is set and visible in step logs |
| `Cache on S3` | Attempts restore with fallback key pointing to master | Fallback key was **attempted** (hit or miss) |

### Test 2 — Warm cache (second run)

| Step | Expected | Success criteria |
|---|---|---|
| `Cache on S3` | Exact hit on branch-specific key | `cache-hit: true`, fast restore |

### Test 3 — Comparison with PR #1918

This PR is identical in intent to [sonarlint-core#1918](https://github.com/SonarSource/sonarlint-core/pull/1918) but uses the latest commit from gh-action_cache PR #42, which includes the fix for the `fallback-branch` / `fallback-to-default-branch` interaction.

---

## How to verify

Inspect the **"Prepare cache keys"** step output in Actions logs. You should see:

```
branch-key=refs/pull/{N}/merge/sonar-scanner-Linux
branch-restore-keys=refs/heads/master/sonar-scanner-Linux
```

The presence of `branch-restore-keys` pointing to `master` — even without any `restore-keys` input — is the primary success signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BUILD-10699]: https://sonarsource.atlassian.net/browse/BUILD-10699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ