### PR TITLE
SLCORE-670 Add parameter 'components' in addition to 'componentKeys'

### DIFF
--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApi.java
@@ -123,8 +123,9 @@ public class IssueApi {
   }
 
   private static String getVulnerabilitiesUrl(String key, Set<String> ruleKeys) {
+    var encodedKey = urlEncode(key);
     return "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys="
-      + urlEncode(key) + "&rules=" + urlEncode(String.join(",", ruleKeys));
+      + encodedKey + "&components=" + encodedKey + "&rules=" + urlEncode(String.join(",", ruleKeys));
   }
 
   private static String getUrlBranchParameter(@Nullable String branchName) {
@@ -254,7 +255,7 @@ public class IssueApi {
   }
 
   public Optional<ServerIssueDetails> fetchServerIssue(String issueKey, String projectKey, String branch, @Nullable String pullRequest, SonarLintCancelMonitor cancelMonitor) {
-    String searchUrl = "/api/issues/search.protobuf?issues=" + urlEncode(issueKey) + "&componentKeys=" + projectKey + "&ps=1&p=1";
+    String searchUrl = "/api/issues/search.protobuf?issues=" + urlEncode(issueKey) + "&componentKeys=" + projectKey + "&components=" + projectKey + "&ps=1&p=1";
     if (pullRequest != null && !pullRequest.isEmpty()) {
       searchUrl = searchUrl.concat("&pullRequest=").concat(urlEncode(pullRequest));
     } else if (!branch.isEmpty()) {

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/issue/IssueApiTests.java
@@ -111,9 +111,9 @@ class IssueApiTests {
 
   @Test
   void should_download_all_vulnerabilities() {
-    mockServer.addProtobufResponse("/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=keyyy&rules=ruleKey&ps=500&p=1",
+    mockServer.addProtobufResponse("/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=keyyy&components=keyyy&rules=ruleKey&ps=500&p=1",
       Issues.SearchWsResponse.newBuilder().addIssues(Issues.Issue.newBuilder().setKey("issueKey").build()).build());
-    mockServer.addProtobufResponse("/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=keyyy&rules=ruleKey&ps=500&p=2",
+    mockServer.addProtobufResponse("/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=keyyy&components=keyyy&rules=ruleKey&ps=500&p=2",
       Issues.SearchWsResponse.newBuilder().addComponents(Issues.Component.newBuilder().setKey("componentKey").setPath("componentPath").build()).build());
 
     var result = underTest.downloadVulnerabilitiesForRules("keyyy", Set.of("ruleKey"), null, new SonarLintCancelMonitor());
@@ -130,7 +130,7 @@ class IssueApiTests {
     var issueKey = "issueKey";
     var path = "/home/file.java";
     var projectKey = "projectKey";
-    mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode(issueKey)).concat("&componentKeys=").concat(projectKey).concat("&ps=1&p=1"),
+    mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode(issueKey)).concat("&componentKeys=").concat(projectKey).concat("&components=").concat(projectKey).concat("&ps=1&p=1"),
       Issues.SearchWsResponse.newBuilder()
         .addIssues(Issues.Issue.newBuilder().setKey(issueKey).build())
         .addComponents(Issues.Component.newBuilder().setPath(path).build())
@@ -144,7 +144,7 @@ class IssueApiTests {
 
   @Test
   void should_not_fail_when_no_issue_found_by_key() {
-    mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode("qwert")).concat("&componentKeys=myProject").concat("&ps=1&p=1"),
+    mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode("qwert")).concat("&componentKeys=myProject").concat("&components=myProject").concat("&ps=1&p=1"),
       Issues.SearchWsResponse.newBuilder().addIssues(Issues.Issue.newBuilder().build()).build());
     var serverIssueDetails = underTest.fetchServerIssue("non-existent", "myProject", "", "", new SonarLintCancelMonitor());
     assertThat(serverIssueDetails).isEmpty();
@@ -155,7 +155,7 @@ class IssueApiTests {
   void should_not_fetch_server_issue_by_key_with_no_matching_component() {
     var issueKey = "issueKey";
     var path = "/home/file.java";
-    mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode(issueKey)).concat("&componentKeys=differentIssueComponent").concat("&ps=1&p=1"),
+    mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode(issueKey)).concat("&componentKeys=differentIssueComponent").concat("&components=differentIssueComponent").concat("&ps=1&p=1"),
       Issues.SearchWsResponse.newBuilder()
         .addIssues(Issues.Issue.newBuilder().setKey(issueKey).setComponent("issueComponent").build())
         .addComponents(Issues.Component.newBuilder().setPath(path).setKey("differentIssueComponent").build())
@@ -174,6 +174,7 @@ class IssueApiTests {
     var branch = "branch";
     mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode(issueKey))
         .concat("&componentKeys=").concat(projectKey)
+        .concat("&components=").concat(projectKey)
         .concat("&ps=1&p=1")
         .concat("&branch=").concat(branch),
       Issues.SearchWsResponse.newBuilder()
@@ -195,6 +196,7 @@ class IssueApiTests {
     var pullRequest = "1234";
     mockServer.addProtobufResponse("/api/issues/search.protobuf?issues=".concat(urlEncode(issueKey))
         .concat("&componentKeys=").concat(projectKey)
+        .concat("&components=").concat(projectKey)
         .concat("&ps=1&p=1")
         .concat("&pullRequest=").concat(pullRequest),
       Issues.SearchWsResponse.newBuilder()

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloaderTests.java
@@ -158,7 +158,7 @@ class TaintIssueDownloaderTests {
       "/api/rules/search.protobuf?repositories=roslyn.sonaranalyzer.security.cs,javasecurity,jssecurity,kotlinsecurity,phpsecurity,pythonsecurity,tssecurity,vbnetsecurity,gosecurity&f=repo&s=key&ps=500&p=1",
       ruleSearchResponse);
     mockServer.addProtobufResponse(
-      "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=" + DUMMY_KEY + "&rules=javasecurity%3AS789&ps=500&p=1",
+      "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=" + DUMMY_KEY + "&components=" + DUMMY_KEY + "&rules=javasecurity%3AS789&ps=500&p=1",
       issueSearchResponse);
     mockServer.addStringResponse("/api/sources/raw?key=" + URLEncoder.encode(FILE_1_KEY, StandardCharsets.UTF_8), "Even\nBefore My\n\tCode\n  Snippet And\n After");
 
@@ -224,7 +224,7 @@ class TaintIssueDownloaderTests {
       "/api/rules/search.protobuf?repositories=roslyn.sonaranalyzer.security.cs,javasecurity,jssecurity,kotlinsecurity,phpsecurity,pythonsecurity,tssecurity,vbnetsecurity,gosecurity&f=repo&s=key&ps=500&p=1",
       ruleSearchResponse);
     mockServer.addProtobufResponse(
-      "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=dummyKey&rules=javasecurity%3AS789&branch=branchName&ps=500&p=1", response);
+      "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=dummyKey&components=dummyKey&rules=javasecurity%3AS789&branch=branchName&ps=500&p=1", response);
 
     var issues = underTest.downloadTaintFromIssueSearch(serverApi, DUMMY_KEY, "branchName", new SonarLintCancelMonitor());
 

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/ServerFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/ServerFixture.java
@@ -1087,6 +1087,10 @@ public class ServerFixture {
       }));
     }
 
+    private static String componentKeyParams(String projectKey) {
+      return "&componentKeys=" + projectKey + "&components=" + projectKey;
+    }
+
     private void registerSearchIssueApiResponses() {
       projectsByProjectKey.forEach((projectKey, project) -> {
         project.pullRequestsByName.forEach((pullRequestName, pullRequest) -> {
@@ -1096,7 +1100,7 @@ public class ServerFixture {
 
           allIssues.forEach(issue -> {
             var searchUrl = "/api/issues/search.protobuf?issues=".concat(urlEncode(issue.getKey()))
-              .concat("&componentKeys=").concat(projectKey)
+              .concat(componentKeyParams(projectKey))
               .concat("&ps=1&p=1")
               .concat("&pullRequest=").concat(pullRequestName);
             mockServer.stubFor(get(searchUrl)
@@ -1124,7 +1128,7 @@ public class ServerFixture {
 
           allIssues.forEach(issue -> {
             var searchUrl = "/api/issues/search.protobuf?issues=".concat(urlEncode(issue.getKey()))
-              .concat("&componentKeys=").concat(projectKey)
+              .concat(componentKeyParams(projectKey))
               .concat("&ps=1&p=1")
               .concat("&branch=").concat(branchName);
             mockServer.stubFor(get(searchUrl)
@@ -1141,7 +1145,8 @@ public class ServerFixture {
           });
 
           var vulnerabilities = allIssues.stream().filter(issue -> issue.getType() == Common.RuleType.VULNERABILITY).toList();
-          var searchUrl = "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=" + projectKey + "&rules=&branch=" + branchName
+          var searchUrl = "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY"
+            + componentKeyParams(projectKey) + "&rules=&branch=" + branchName
             + "&ps=500&p=1";
           mockServer.stubFor(get(searchUrl)
             .willReturn(aResponse().withResponseBody(protobufBody(Issues.SearchWsResponse.newBuilder()


### PR DESCRIPTION
We still apparently need the old parameter name for the SQ Cloud. So using both parameters for now.