### PR TITLE
BUILD-10765 Important: Update SonarSource/gh-action_release to v6 and gh-action_releasability to v3

### DIFF
--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -17,7 +17,7 @@ jobs:
             contents: read
         if: github.event.workflow_run.conclusion == 'success'
         steps:
-            -   uses: SonarSource/gh-action_releasability/releasability-status@683b9a1ffd08c3a23af1d1bffb67a9d7bcfb1b08 # 3.0.4
+            -   uses: SonarSource/gh-action_releasability/releasability-status@v3
                 with:
                     optional_checks: "Jira"
                 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@c52861bb0e5dd564187f3fd74e048f20aef0f761 # 6.5.0
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
     with:
       version: ${{ inputs.version }}
       releaseId: ${{ inputs.releaseId }}


### PR DESCRIPTION
**Important:** Update GitHub Actions to compliant versions.

- `.github/workflows/release.yml`: `release` `c52861bb0e5dd564187f3fd74e048f20aef0f761` → `v6`
- `.github/workflows/releasability.yml`: `releasability` `683b9a1ffd08c3a23af1d1bffb67a9d7bcfb1b08` → `v3`

See: https://discuss.sonarsource.com/t/action-required-update-your-github-actions-cache-release-and-releasability-before-31-04-2026/23899