### PR TITLE
SLCORE-2235 Revert major dependency bumps from #1914

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisSchedulerCache.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisSchedulerCache.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-import jakarta.annotation.PreDestroy;
+import javax.annotation.PreDestroy;
 import org.sonarsource.sonarlint.core.UserPaths;
 import org.sonarsource.sonarlint.core.analysis.api.AnalysisSchedulerConfiguration;
 import org.sonarsource.sonarlint.core.analysis.api.ClientModuleFileSystem;

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ClientFileSystemService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/ClientFileSystemService.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
-import jakarta.annotation.PreDestroy;
+import javax.annotation.PreDestroy;
 import org.sonarsource.sonarlint.core.commons.SmartCancelableLoadingCache;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/promotion/campaign/CampaignService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/promotion/campaign/CampaignService.java
@@ -34,7 +34,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
-import jakarta.annotation.PostConstruct;
+import javax.annotation.PostConstruct;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/XodusKnownFindingsStorageService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/tracking/XodusKnownFindingsStorageService.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicReference;
-import jakarta.annotation.PreDestroy;
+import javax.annotation.PreDestroy;
 import org.apache.commons.io.FileUtils;
 import org.sonarsource.sonarlint.core.UserPaths;
 

--- a/backend/server-connection/pom.xml
+++ b/backend/server-connection/pom.xml
@@ -78,11 +78,6 @@
       <artifactId>xodus-vfs</artifactId>
       <version>${xodus.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-
     <!-- unit tests -->
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>

--- a/its/plugins/custom-sensor-plugin/pom.xml
+++ b/its/plugins/custom-sensor-plugin/pom.xml
@@ -72,11 +72,11 @@
         <!-- UTF-8 bundles are not supported by Java, so they must be converted during build -->
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>native2ascii-maven-plugin</artifactId>
-        <version>2.1.1</version>
+        <version>1.0-beta-1</version>
         <executions>
           <execution>
             <goals>
-              <goal>resources</goal>
+              <goal>native2ascii</goal>
             </goals>
           </execution>
         </executions>

--- a/its/plugins/global-extension-plugin/pom.xml
+++ b/its/plugins/global-extension-plugin/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.17</version>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <!-- packaged with the plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -50,13 +50,13 @@
     <protobuf.version>4.28.2</protobuf.version>
     <gitRepositoryName>sonarlint-core</gitRepositoryName>
     <okhttp.version>5.0.0-alpha.16</okhttp.version>
-    <junit.jupiter.version>6.0.3</junit.jupiter.version>
+    <junit.jupiter.version>5.14.3</junit.jupiter.version>
     <artifactsToPublish>${project.groupId}:sonarlint-core:jar</artifactsToPublish>
     <jdk.min.version>11</jdk.min.version>
     <gson.version>2.13.2</gson.version>
     <mockito.version>5.22.0</mockito.version>
-    <kotlin.version>2.3.20</kotlin.version>
-    <lsp4j.version>1.0.0</lsp4j.version>
+    <kotlin.version>1.9.25</kotlin.version>
+    <lsp4j.version>0.24.0</lsp4j.version>
     <slf4j.version>2.0.17</slf4j.version>
     <logback.version>1.5.32</logback.version>
     <version.surefire.plugin>3.1.2</version.surefire.plugin>
@@ -64,7 +64,7 @@
 
     <!-- JGit 7 rely on Java 17 and only used by the backend, JGit 6 relying on Java 11 for the Java clients -->
     <jgit6.version>6.10.1.202505221210-r</jgit6.version>
-    <jgit7.version>7.6.0.202603022253-r</jgit7.version>
+    <jgit7.version>7.5.0.202512021534-r</jgit7.version>
     <sentry.version>8.34.0</sentry.version>
 
     <!-- Not only used as a plug-in but also as a dependency for 'maven-shade-ext-bnd-transformer' -->
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.springframework</groupId>
          <artifactId>spring-framework-bom</artifactId>
-         <version>7.0.6</version>
+         <version>6.2.16</version>
          <type>pom</type>
          <scope>import</scope>
       </dependency>
@@ -278,21 +278,6 @@
         <artifactId>sonar-classloader</artifactId>
         <version>1.2.1.2095</version>
       </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>2.21</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>2.21.0</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.21.0</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -302,7 +287,7 @@
         <plugin>
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-maven-plugin</artifactId>
-          <version>7.2.1</version>
+          <version>6.4.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Reverts the following to pre-PR versions:
- junit.jupiter: 6.0.3 -> 5.14.3
- kotlin: 2.3.20 -> 1.9.25
- lsp4j: 1.0.0 -> 0.24.0
- jgit7: 7.6.0.202603022253-r -> 7.5.0.202512021534-r
- flyway: 12.1.0 -> 11.20.3
- spring-framework-bom: 7.0.6 -> 6.2.16
- bnd-maven-plugin: 7.2.1 -> 6.4.0
- native2ascii-maven-plugin: 2.1.1 -> 1.0-beta-1
- slf4j-api in ITs global-extension-plugin: 2.0.17 -> 1.7.36
- Remove explicit jackson-annotations/core/databind pins
- Remove jackson-databind from server-connection dependencies
- Revert jakarta.annotation imports back to javax.annotation
