### PR TITLE
SLCORE-2317 Replace deprecated public runners (sonar-xs-public, sonar-m-public)

### DIFF
--- a/.github/workflows/PullRequestClosed.yml
+++ b/.github/workflows/PullRequestClosed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestClosed_job:
     name: Pull Request Closed
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
       pull-requests: read

--- a/.github/workflows/PullRequestCreated.yml
+++ b/.github/workflows/PullRequestCreated.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   PullRequestCreated_job:
     name: Pull Request Created
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be created manually

--- a/.github/workflows/RequestReview.yml
+++ b/.github/workflows/RequestReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   RequestReview_job:
     name: Request review
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/SubmitReview.yml
+++ b/.github/workflows/SubmitReview.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   SubmitReview_job:
     name: Submit Review
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     permissions:
       id-token: write
     # For external PR, ticket should be moved manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   build-number:
     outputs:
       BUILD_NUMBER: ${{ steps.build-number.outputs.BUILD_NUMBER }}
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Get build number
     permissions:
       id-token: write
@@ -32,7 +32,7 @@ jobs:
         id: build-number
 
   build:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     needs: build-number
     name: Build
     permissions:
@@ -61,7 +61,7 @@ jobs:
 
   test-linux:
     needs: [ build-number, build ]
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: Test (Linux, Sonar Next)
     permissions:
       id-token: write
@@ -177,7 +177,7 @@ jobs:
 
   qa:
     needs: [ build-number, build ]
-    runs-on: sonar-m-public
+    runs-on: sonar-m
     name: QA (${{ matrix.name }})
     permissions:
       id-token: write
@@ -310,7 +310,7 @@ jobs:
 
   promote:
     needs: [ build-number, build, qa, test-linux, test-windows ]
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Promote
     permissions:
       id-token: write

--- a/.github/workflows/full-release.yml
+++ b/.github/workflows/full-release.yml
@@ -32,7 +32,7 @@ jobs:
 
   bump-version:
     name: Create a PR to bump version
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     needs:
       - release
     permissions:

--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   notify:
-    runs-on: sonar-xs-public
+    runs-on: sonar-xs
     name: Send Slack Notification
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     steps:

--- a/.github/workflows/releasability.yml
+++ b/.github/workflows/releasability.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     releasability-status:
         name: Releasability status
-        runs-on: sonar-xs-public
+        runs-on: sonar-xs
         permissions:
             id-token: write
             statuses: write


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD Configuration:**
  - Replaced deprecated `sonar-xs-public` and `sonar-m-public` runners with `sonar-xs` and `sonar-m` in multiple GitHub workflow files.
  - Updated runners across build, test, release, and PR management workflows to ensure continued compatibility with infrastructure updates.

<sub>This will update automatically on new commits.</sub>