### PR TITLE
SLCORE-2392 Skip malformed items during server synchronization

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/ScaSynchronizationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sync/ScaSynchronizationService.java
@@ -80,17 +80,25 @@ public class ScaSynchronizationService {
         }
         return true;
       })
-      .map(issueRelease -> new ServerDependencyRisk(
-        issueRelease.key(),
-        ServerDependencyRisk.Type.valueOf(issueRelease.type().name()),
-        ServerDependencyRisk.Severity.valueOf(issueRelease.severity().name()),
-        ServerDependencyRisk.SoftwareQuality.valueOf(issueRelease.quality().name()),
-        ServerDependencyRisk.Status.valueOf(issueRelease.status().name()),
-        issueRelease.release().packageName(),
-        issueRelease.release().version(),
-        issueRelease.vulnerabilityId(),
-        issueRelease.cvssScore(),
-        issueRelease.transitions().stream().map(Enum::name).map(ServerDependencyRisk.Transition::valueOf).toList()))
+      .map(issueRelease -> {
+        try {
+          return new ServerDependencyRisk(
+            issueRelease.key(),
+            ServerDependencyRisk.Type.valueOf(issueRelease.type().name()),
+            ServerDependencyRisk.Severity.valueOf(issueRelease.severity().name()),
+            ServerDependencyRisk.SoftwareQuality.valueOf(issueRelease.quality().name()),
+            ServerDependencyRisk.Status.valueOf(issueRelease.status().name()),
+            issueRelease.release().packageName(),
+            issueRelease.release().version(),
+            issueRelease.vulnerabilityId(),
+            issueRelease.cvssScore(),
+            issueRelease.transitions().stream().map(Enum::name).map(ServerDependencyRisk.Transition::valueOf).toList());
+        } catch (Exception e) {
+          LOG.warn("[SYNC] Skipping dependency risk '{}': {}", issueRelease.key(), e.getMessage());
+          return null;
+        }
+      })
+      .filter(Objects::nonNull)
       .toList();
 
     findingsStore.replaceAllDependencyRisksOfBranch(branchName, serverDependencyRisks);

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApi.java
@@ -116,17 +116,20 @@ public class RulesApi {
       },
       activeEntry -> {
         var ruleKey = activeEntry.getKey();
-        // Since we are querying rules for a given profile, we know there will be only one active rule per rule
-        Rules.Active ar = activeEntry.getValue().getActiveListList().get(0);
-        activeRulesByKey.put(ruleKey, new ServerActiveRule(
-          ruleKey,
-          IssueSeverity.valueOf(ar.getSeverity()),
-          ar.getParamsList().stream().collect(toMap(Rules.Active.Param::getKey, Rules.Active.Param::getValue)),
-          ruleTemplatesByRuleKey.get(ruleKey),
-          ar.getImpacts().getImpactsList().stream()
-            .map(impact -> new ImpactPayload(impact.getSoftwareQuality().toString(), ImpactSeverity.mapSeverity(impact.getSeverity().name()).name()))
-            .toList()));
-
+        try {
+          // Since we are querying rules for a given profile, we know there will be only one active rule per rule
+          Rules.Active ar = activeEntry.getValue().getActiveListList().get(0);
+          activeRulesByKey.put(ruleKey, new ServerActiveRule(
+            ruleKey,
+            IssueSeverity.valueOf(ar.getSeverity()),
+            ar.getParamsList().stream().collect(toMap(Rules.Active.Param::getKey, Rules.Active.Param::getValue)),
+            ruleTemplatesByRuleKey.get(ruleKey),
+            ar.getImpacts().getImpactsList().stream()
+              .map(impact -> new ImpactPayload(impact.getSoftwareQuality().toString(), ImpactSeverity.mapSeverity(impact.getSeverity().name()).name()))
+              .toList()));
+        } catch (Exception e) {
+          LOG.warn("[SYNC] Skipping active rule '{}': {}", ruleKey, e.getMessage());
+        }
       },
       false,
       cancelMonitor);

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/rules/RulesApiTests.java
@@ -190,6 +190,31 @@ class RulesApiTests {
   }
 
   @Test
+  void should_skip_active_rule_with_unknown_severity_and_continue() {
+    mockServer.addProtobufResponse(
+      "/api/rules/search.protobuf?qprofile=QPKEY&activation=true&f=templateKey,actives&types=CODE_SMELL,BUG,VULNERABILITY,SECURITY_HOTSPOT&s=key&ps=500&p=1",
+      Rules.SearchResponse.newBuilder()
+        .setPaging(Common.Paging.newBuilder().setTotal(2).build())
+        .addRules(Rules.Rule.newBuilder().setKey("repo:bad_rule").build())
+        .addRules(Rules.Rule.newBuilder().setKey("repo:good_rule").build())
+        .setActives(Rules.Actives.newBuilder()
+          .putActives("repo:bad_rule", Rules.ActiveList.newBuilder().addActiveList(
+            Rules.Active.newBuilder().setSeverity("BRAND_NEW_SEVERITY").build()).build())
+          .putActives("repo:good_rule", Rules.ActiveList.newBuilder().addActiveList(
+            Rules.Active.newBuilder().setSeverity("MINOR").build()).build())
+          .build())
+        .build());
+
+    var rulesApi = new RulesApi(mockServer.serverApiHelper());
+
+    var activeRules = rulesApi.getAllActiveRules("QPKEY", new SonarLintCancelMonitor());
+
+    assertThat(activeRules).hasSize(1);
+    assertThat(activeRules.iterator().next().getRuleKey()).isEqualTo("repo:good_rule");
+    assertThat(logTester.logs()).anyMatch(log -> log.contains("Skipping active rule") && log.contains("repo:bad_rule"));
+  }
+
+  @Test
   void should_fallback_on_deprecated_pagination_for_sonarqube_older_than_9_8() {
     mockServer.addProtobufResponse(
       "/api/rules/search.protobuf?qprofile=QPKEY%2B&organization=orgKey&activation=true&f=templateKey,actives&types=CODE_SMELL,BUG,VULNERABILITY,SECURITY_HOTSPOT&s=key&ps=500&p=1",

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloader.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloader.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,6 +38,7 @@ import org.sonarsource.sonarlint.core.commons.RuleType;
 import org.sonarsource.sonarlint.core.commons.SoftwareQuality;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.commons.api.TextRangeWithHash;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
 import org.sonarsource.sonarlint.core.serverapi.ServerApi;
 import org.sonarsource.sonarlint.core.serverapi.proto.sonarqube.ws.Issues;
@@ -52,6 +54,8 @@ import static org.sonarsource.sonarlint.core.serverconnection.DownloaderUtils.pa
 import static org.sonarsource.sonarlint.core.serverconnection.DownloaderUtils.parseProtoSoftwareQuality;
 
 public class IssueDownloader {
+
+  private static final SonarLintLogger LOG = SonarLintLogger.get();
 
   private final Set<SonarLanguage> enabledLanguages;
 
@@ -82,7 +86,11 @@ public class IssueDownloader {
     for (ScannerInput.ServerIssue batchIssue : batchIssues) {
       // We ignore project level issues
       if (!RulesApi.TAINT_REPOS.contains(batchIssue.getRuleRepository()) && batchIssue.hasPath()) {
-        result.add(convertBatchIssue(batchIssue));
+        try {
+          result.add(convertBatchIssue(batchIssue));
+        } catch (Exception e) {
+          LOG.warn("[SYNC] Skipping issue '{}': {}", batchIssue.getKey(), e.getMessage());
+        }
       }
     }
 
@@ -106,7 +114,15 @@ public class IssueDownloader {
       // Ignore project level issues
       .filter(i -> i.getMainLocation().hasFilePath())
       .filter(not(IssueLite::getClosed))
-      .<ServerIssue<?>>map(IssueDownloader::convertLiteIssue)
+      .<ServerIssue<?>>map(i -> {
+        try {
+          return convertLiteIssue(i);
+        } catch (Exception e) {
+          LOG.warn("[SYNC] Skipping issue '{}': {}", i.getKey(), e.getMessage());
+          return null;
+        }
+      })
+      .filter(Objects::nonNull)
       .toList();
     var closedIssueKeys = apiResult.getIssues()
       .stream()

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloader.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloader.java
@@ -81,7 +81,14 @@ public class TaintIssueDownloader {
     var downloadVulnerabilitiesForRules = issueApi.downloadVulnerabilitiesForRules(key, taintRuleKeys, branchName, cancelMonitor);
     downloadVulnerabilitiesForRules.getIssues()
       .stream()
-      .map(i -> convertTaintVulnerability(serverApi.source(), i, downloadVulnerabilitiesForRules.getComponentPathsByKey(), sourceCodeByKey, cancelMonitor))
+      .map(i -> {
+        try {
+          return convertTaintVulnerability(serverApi.source(), i, downloadVulnerabilitiesForRules.getComponentPathsByKey(), sourceCodeByKey, cancelMonitor);
+        } catch (Exception e) {
+          LOG.warn("[SYNC] Skipping taint issue '{}': {}", i.getKey(), e.getMessage());
+          return null;
+        }
+      })
       .filter(Objects::nonNull)
       .forEach(result::add);
 
@@ -104,7 +111,15 @@ public class TaintIssueDownloader {
       // Ignore project level issues
       .filter(i -> i.getMainLocation().hasFilePath())
       .filter(not(TaintVulnerabilityLite::getClosed))
-      .map(TaintIssueDownloader::convertLiteTaintIssue)
+      .<ServerTaintIssue>map(i -> {
+        try {
+          return convertLiteTaintIssue(i);
+        } catch (Exception e) {
+          LOG.warn("[SYNC] Skipping taint issue '{}': {}", i.getKey(), e.getMessage());
+          return null;
+        }
+      })
+      .filter(Objects::nonNull)
       .toList();
     var closedIssueKeys = apiResult.getTaintIssues()
       .stream()

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/IssueDownloaderTests.java
@@ -387,4 +387,57 @@ class IssueDownloaderTests {
     assertThat(issues).hasSize(1);
   }
 
+  @Test
+  void should_skip_batch_issue_with_unknown_type_and_continue() {
+    var badIssue = ScannerInput.ServerIssue.newBuilder()
+      .setKey("bad-uuid")
+      .setRuleRepository("sonarjava")
+      .setRuleKey("S999")
+      .setPath("foo/bar/Bad.java")
+      .setType("BRAND_NEW_TYPE")
+      .build();
+    var goodIssue = ScannerInput.ServerIssue.newBuilder()
+      .setKey("good-uuid")
+      .setRuleRepository("sonarjava")
+      .setRuleKey("S123")
+      .setPath("foo/bar/Hello.java")
+      .setType("BUG")
+      .build();
+
+    mockServer.addProtobufResponseDelimited("/batch/issues?key=" + DUMMY_KEY, badIssue, goodIssue);
+
+    var issues = underTest.downloadFromBatch(serverApi, DUMMY_KEY, null, new SonarLintCancelMonitor());
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).getKey()).isEqualTo("good-uuid");
+    assertThat(logTester.logs()).anyMatch(log -> log.contains("Skipping issue") && log.contains("bad-uuid"));
+  }
+
+  @Test
+  void should_skip_pull_issue_with_unknown_type_and_continue() {
+    var timestamp = Issues.IssuesPullQueryTimestamp.newBuilder().setQueryTimestamp(123L).build();
+    var badIssue = IssueLite.newBuilder()
+      .setKey("bad-uuid")
+      .setRuleKey("sonarjava:S999")
+      // type not set -> UNSPECIFIED_RULE_TYPE -> RuleType.valueOf throws
+      .setMainLocation(Location.newBuilder().setFilePath("foo/bar/Bad.java").setMessage("Bad"))
+      .setCreationDate(123456789L)
+      .build();
+    var goodIssue = IssueLite.newBuilder()
+      .setKey("good-uuid")
+      .setRuleKey("sonarjava:S123")
+      .setType(Common.RuleType.BUG)
+      .setMainLocation(Location.newBuilder().setFilePath("foo/bar/Hello.java").setMessage("Good"))
+      .setCreationDate(123456789L)
+      .build();
+
+    mockServer.addProtobufResponseDelimited("/api/issues/pull?projectKey=" + DUMMY_KEY + "&branchName=myBranch&languages=java", timestamp, badIssue, goodIssue);
+
+    var result = underTest.downloadFromPull(serverApi, DUMMY_KEY, "myBranch", Optional.empty(), new SonarLintCancelMonitor());
+
+    assertThat(result.getChangedIssues()).hasSize(1);
+    assertThat(result.getChangedIssues().get(0).getKey()).isEqualTo("good-uuid");
+    assertThat(logTester.logs()).anyMatch(log -> log.contains("Skipping issue") && log.contains("bad-uuid"));
+  }
+
 }

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloaderTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/TaintIssueDownloaderTests.java
@@ -393,6 +393,78 @@ class TaintIssueDownloaderTests {
       .hasMessage("Unknown or missing impact severity");
   }
 
+  @Test
+  void should_skip_taint_from_pull_with_unknown_type_and_continue() {
+    var timestamp = Issues.IssuesPullQueryTimestamp.newBuilder().setQueryTimestamp(123L).build();
+    var badTaint = TaintVulnerabilityLite.newBuilder()
+      .setKey("bad-uuid")
+      .setRuleKey("javasecurity:S999")
+      .setSeverity(Severity.MAJOR)
+      // type not set -> UNSPECIFIED_RULE_TYPE -> RuleType.valueOf throws
+      .setMainLocation(Location.newBuilder().setFilePath("foo/bar/Bad.java").setMessage("Bad"))
+      .setCreationDate(123456789L)
+      .build();
+    var goodTaint = TaintVulnerabilityLite.newBuilder()
+      .setKey("good-uuid")
+      .setRuleKey("javasecurity:S789")
+      .setType(Common.RuleType.VULNERABILITY)
+      .setSeverity(Severity.MAJOR)
+      .setMainLocation(Location.newBuilder().setFilePath("foo/bar/Hello.java").setMessage("Good"))
+      .setCreationDate(123456789L)
+      .build();
+
+    mockServer.addProtobufResponseDelimited("/api/issues/pull_taint?projectKey=" + DUMMY_KEY + "&branchName=myBranch&languages=java", timestamp, badTaint, goodTaint);
+
+    var result = underTest.downloadTaintFromPull(serverApi, DUMMY_KEY, "myBranch", Optional.empty(), new SonarLintCancelMonitor());
+
+    assertThat(result.getChangedTaintIssues()).hasSize(1);
+    assertThat(result.getChangedTaintIssues().get(0).getSonarServerKey()).isEqualTo("good-uuid");
+    assertThat(logTester.logs()).anyMatch(log -> log.contains("Skipping taint issue") && log.contains("bad-uuid"));
+  }
+
+  @Test
+  void should_skip_taint_from_issue_search_with_unknown_type_and_continue() {
+    var ruleSearchResponse = Rules.SearchResponse.newBuilder()
+      .setTotal(1)
+      .addRules(Rules.Rule.newBuilder().setKey("javasecurity:S789"))
+      .build();
+    var issueSearchResponse = Issues.SearchWsResponse.newBuilder()
+      .addIssues(Issues.Issue.newBuilder()
+        .setKey("bad-uuid")
+        .setRule("javasecurity:S789")
+        .setMessage("Bad issue")
+        .setCreationDate("2021-01-11T18:17:31+0000")
+        .setComponent(FILE_1_KEY)
+        .setSeverity(Severity.INFO)
+        // type not set -> UNSPECIFIED_RULE_TYPE -> RuleType.valueOf throws
+      )
+      .addIssues(Issues.Issue.newBuilder()
+        .setKey("good-uuid")
+        .setRule("javasecurity:S789")
+        .setMessage("Good issue")
+        .setCreationDate("2021-01-11T18:17:31+0000")
+        .setComponent(FILE_1_KEY)
+        .setType(Common.RuleType.VULNERABILITY)
+        .setSeverity(Severity.INFO)
+      )
+      .addComponents(Issues.Component.newBuilder().setKey(FILE_1_KEY).setPath("foo/bar/Hello.java"))
+      .setPaging(Paging.newBuilder().setPageIndex(1).setPageSize(500).setTotal(2))
+      .build();
+
+    mockServer.addProtobufResponse(
+      "/api/rules/search.protobuf?repositories=roslyn.sonaranalyzer.security.cs,javasecurity,jssecurity,kotlinsecurity,phpsecurity,pythonsecurity,tssecurity,vbnetsecurity,gosecurity&f=repo&s=key&ps=500&p=1",
+      ruleSearchResponse);
+    mockServer.addProtobufResponse(
+      "/api/issues/search.protobuf?statuses=OPEN,CONFIRMED,REOPENED,RESOLVED&types=VULNERABILITY&componentKeys=" + DUMMY_KEY + "&components=" + DUMMY_KEY + "&rules=javasecurity%3AS789&ps=500&p=1",
+      issueSearchResponse);
+
+    var issues = underTest.downloadTaintFromIssueSearch(serverApi, DUMMY_KEY, null, new SonarLintCancelMonitor());
+
+    assertThat(issues).hasSize(1);
+    assertThat(issues.get(0).getSonarServerKey()).isEqualTo("good-uuid");
+    assertThat(logTester.logs()).anyMatch(log -> log.contains("Skipping taint issue") && log.contains("bad-uuid"));
+  }
+
   private static void assertTextRange(@Nullable TextRangeWithHash textRangeWithHash, int startLine, int startLineOffset,
     int endLine, int endLineOffset, String hash) {
     assertThat(textRangeWithHash).isNotNull();


### PR DESCRIPTION
----
## Summary by Gitar

- **Improved synchronization robustness:**
  - Added error handling to skip malformed items during server synchronization instead of failing the entire process.
  - Implemented `try-catch` blocks and logging in `ScaSynchronizationService`, `RulesApi`, `IssueDownloader`, and `TaintIssueDownloader`.
- **Enhanced resilience testing:**
  - Added unit tests in `RulesApiTests`, `IssueDownloaderTests`, and `TaintIssueDownloaderTests` to verify that invalid issues, rules, or taint vulnerabilities do not interrupt data processing.


<sub>This will update automatically on new commits.</sub>