### PR TITLE
SLVS-2943 SLI-2661 SLI-2631 11.4 analyzer updates

### DIFF
--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
@@ -59,7 +59,7 @@ class BinariesArtifactTest {
   void should_return_version_from_properties() {
     var actual = BinariesArtifact.CFAMILY_PLUGIN.version();
 
-    assertThat(actual).isEqualTo("6.80.0.98490");
+    assertThat(actual).isEqualTo("6.81.0.99236");
   }
 
   @Test

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
@@ -59,7 +59,7 @@ class BinariesArtifactTest {
   void should_return_version_from_properties() {
     var actual = BinariesArtifact.CFAMILY_PLUGIN.version();
 
-    assertThat(actual).isEqualTo("6.81.0.99236");
+    assertThat(actual).isEqualTo("6.81.1.99296");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <bouncycastle.version>1.84</bouncycastle.version>
     <!-- On-demand plugin versions -->
     <cfamily.version>6.81.1.99296</cfamily.version>
-    <csharp.version>10.24.0.138807</csharp.version>
+    <csharp.version>10.25.0.139117</csharp.version>
     <omnisharp.version>1.39.15</omnisharp.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <flyway.version>11.20.3</flyway.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <!-- On-demand plugin versions -->
-    <cfamily.version>6.81.0.99236</cfamily.version>
+    <cfamily.version>6.81.1.99296</cfamily.version>
     <csharp.version>10.24.0.138807</csharp.version>
     <omnisharp.version>1.39.15</omnisharp.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <flyway.version>11.20.3</flyway.version>
     <bouncycastle.version>1.84</bouncycastle.version>
     <!-- On-demand plugin versions -->
-    <cfamily.version>6.80.0.98490</cfamily.version>
+    <cfamily.version>6.81.0.99236</cfamily.version>
     <csharp.version>10.24.0.138807</csharp.version>
     <omnisharp.version>1.39.15</omnisharp.version>
   </properties>


### PR DESCRIPTION
Analyzer updates for the 11.4 release.

- SLVS-2943 Update CFamily analyzer to 6.81.0.99236
- SLI-2661 Update CFamily analyzer to 6.81.1.99296
- SLI-2631 Update embedded C# analyzer to 10.25.0.139117

Updates `cfamily.version` and `csharp.version` in the root `pom.xml`, and the hardcoded CFamily literal in `BinariesArtifactTest.java`.

Test:

```
[11:16 AM] [2026-05-27T11:13:36.744] [sonarlint-plugin-download-0] INFO sonarlint - Downloading cpp plugin version 6.81.1.99296 from https://binaries.sonarsource.com/CommercialDistribution/sonar-cfamily-plugin/sonar-cfamily-plugin-6.81.1.99296.jar
 [2026-05-27T11:13:44.268] [sonarlint-plugin-download-0] DEBUG sonarlint - Artifact file signature verified successfully
 [2026-05-27T11:13:44.269] [sonarlint-plugin-download-0] INFO sonarlint - Successfully downloaded cpp plugin version 6.81.1.99296
 [2026-05-27T11:14:58.681] [sonarlint-analysis-scheduler] DEBUG sonarlint -   * CFamily Code Quality and Security 6.81.1.99296 (cpp)
```