### PR TITLE
SLCORE-2407 Temporarily disable SQS Dev ITs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,9 +200,9 @@ jobs:
             sc: true
             sc_token_path: sonarcloud-it-US
             region: US
-          - name: SQDogfood
-            sq_version: DEV
-            category: "-DexcludedGroups=SonarCloud"
+#          - name: SQDogfood
+#            sq_version: DEV
+#            category: "-DexcludedGroups=SonarCloud"
           - name: SQLatest
             sq_version: LATEST_RELEASE
             category: "-DexcludedGroups=SonarCloud"


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Commented out the `SQDogfood` integration test job in `.github/workflows/build.yml` to temporarily disable SQS Dev ITs.

<sub>This will update automatically on new commits.</sub>