### PR TITLE
SLCORE-2408 Do not use the system clock in tests

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/storage/local/FileStorageManager.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/storage/local/FileStorageManager.java
@@ -35,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.commons.storage.adapter.LocalDateAdapter;
 import org.sonarsource.sonarlint.core.commons.storage.adapter.LocalDateTimeAdapter;
@@ -48,10 +49,16 @@ public class FileStorageManager<T extends LocalStorage> {
   private final Gson gson;
   private final Class<T> localStorageType;
   private final Supplier<T> defaultSupplier;
+  @Nullable
+  private final Consumer<T> postDeserialize;
   private T inMemoryStorage;
   private FileTime lastModified;
 
   public FileStorageManager(Path path, Supplier<T> defaultSupplier, Class<T> localStorageType) {
+    this(path, defaultSupplier, localStorageType, null);
+  }
+
+  public FileStorageManager(Path path, Supplier<T> defaultSupplier, Class<T> localStorageType, @Nullable Consumer<T> postDeserialize) {
     this.path = path;
     this.gson = new GsonBuilder()
       .registerTypeAdapter(OffsetDateTime.class, new OffsetDateTimeAdapter().nullSafe())
@@ -60,6 +67,7 @@ public class FileStorageManager<T extends LocalStorage> {
       .create();
     this.localStorageType = localStorageType;
     this.defaultSupplier = defaultSupplier;
+    this.postDeserialize = postDeserialize;
     this.inMemoryStorage = defaultSupplier.get();
   }
 
@@ -139,6 +147,9 @@ public class FileStorageManager<T extends LocalStorage> {
       var decoded = Base64.getDecoder().decode(buf.array());
       var oldJson = new String(decoded, StandardCharsets.UTF_8);
       var localStorage = gson.fromJson(oldJson, localStorageType);
+      if (postDeserialize != null) {
+        postDeserialize.accept(localStorage);
+      }
       localStorage.validateAndMigrate();
 
       return localStorage;

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/promotion/campaign/CampaignService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/promotion/campaign/CampaignService.java
@@ -23,10 +23,10 @@ package org.sonarsource.sonarlint.core.promotion.campaign;
 import com.google.common.util.concurrent.MoreExecutors;
 import jakarta.annotation.PreDestroy;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.Period;
-import java.time.ZoneId;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -80,15 +80,17 @@ public class CampaignService {
   private final FileStorageManager<CampaignsLocalStorage> fileStorageManager;
   private final ScheduledExecutorService scheduledExecutor;
   private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
   private final boolean isEnabled;
 
   public CampaignService(@Qualifier("campaignsPath") Path campaignsPath, SonarLintRpcClient client, InitializeParams initializeParams, TelemetryService telemetryService,
-    ApplicationEventPublisher eventPublisher) {
+    ApplicationEventPublisher eventPublisher, Clock clock) {
     this.productKey = initializeParams.getTelemetryConstantAttributes().getProductKey();
     this.client = client;
     this.telemetryService = telemetryService;
     this.fileStorageManager = new FileStorageManager<>(campaignsPath, CampaignsLocalStorage::new, CampaignsLocalStorage.class);
     this.eventPublisher = eventPublisher;
+    this.clock = clock;
     this.scheduledExecutor = FailSafeExecutors.newSingleThreadScheduledExecutor("SonarLint Telemetry");
     this.isEnabled = initializeParams.getBackendCapabilities().contains(BackendCapability.PROMOTIONAL_CAMPAIGNS);
   }
@@ -119,13 +121,13 @@ public class CampaignService {
   }
 
   private boolean isInstalledLongEnough() {
-    return OffsetDateTime.now(ZoneId.systemDefault()).minusDays(TWO_WEEKS).isAfter(telemetryService.installTime());
+    return OffsetDateTime.now(clock).minusDays(TWO_WEEKS).isAfter(telemetryService.installTime());
   }
 
-  private static boolean postponeTimePassed(String lastResponse, Campaign feedbackCampaign) {
+  private boolean postponeTimePassed(String lastResponse, Campaign feedbackCampaign) {
     var postpone = POSTPONE_PERIODS.get(lastResponse);
     var lastShown = feedbackCampaign.lastNotificationShownOn();
-    return lastShown.plus(postpone).isBefore(LocalDate.now(ZoneId.systemDefault()));
+    return lastShown.plus(postpone).isBefore(LocalDate.now(clock));
   }
 
   private void showFeedbackMessage() {
@@ -152,7 +154,7 @@ public class CampaignService {
 
       if (existingCampaign == null || !wasShownRecently(existingCampaign.lastNotificationShownOn())) {
         campaigns.put(CampaignConstants.FEEDBACK_2026_01_CAMPAIGN,
-          new Campaign(CampaignConstants.FEEDBACK_2026_01_CAMPAIGN, LocalDate.now(ZoneId.systemDefault()), "IGNORE"));
+          new Campaign(CampaignConstants.FEEDBACK_2026_01_CAMPAIGN, LocalDate.now(clock), "IGNORE"));
         shouldShow.set(true);
       }
     });
@@ -160,8 +162,8 @@ public class CampaignService {
     return shouldShow.get();
   }
 
-  private static boolean wasShownRecently(LocalDate lastShown) {
-    var today = LocalDate.now(ZoneId.systemDefault());
+  private boolean wasShownRecently(LocalDate lastShown) {
+    var today = LocalDate.now(clock);
     var yesterday = today.minusDays(1);
     // Consider "recently shown" if shown today or yesterday, this prevents midnight edge case where notification fires just after midnight
     return lastShown.equals(today) || lastShown.equals(yesterday);
@@ -182,7 +184,7 @@ public class CampaignService {
   private void handleFeedbackResponse(String responseOption) {
     fileStorageManager.tryUpdateAtomically(storage -> storage.campaigns().put(
       CampaignConstants.FEEDBACK_2026_01_CAMPAIGN,
-      new Campaign(CampaignConstants.FEEDBACK_2026_01_CAMPAIGN, LocalDate.now(ZoneId.systemDefault()), responseOption)));
+      new Campaign(CampaignConstants.FEEDBACK_2026_01_CAMPAIGN, LocalDate.now(clock), responseOption)));
     eventPublisher.publishEvent(new CampaignResolvedEvent(CampaignConstants.FEEDBACK_2026_01_CAMPAIGN,
       responseOption));
 

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/LastEventPolling.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/LastEventPolling.java
@@ -19,6 +19,7 @@
  */
 package org.sonarsource.sonarlint.core.smartnotifications;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -27,15 +28,21 @@ import org.sonarsource.sonarlint.core.storage.StorageService;
 public class LastEventPolling {
 
   private final StorageService storage;
+  private final Clock clock;
 
   public LastEventPolling(StorageService storage) {
+    this(storage, Clock.systemDefaultZone());
+  }
+
+  public LastEventPolling(StorageService storage, Clock clock) {
     this.storage = storage;
+    this.clock = clock;
   }
 
   public ZonedDateTime getLastEventPolling(String connectionId, String projectKey) {
     var lastEventPollingEpoch = storage.connection(connectionId).project(projectKey).smartNotifications().readLastEventPolling();
     return lastEventPollingEpoch.map(aLong -> ZonedDateTime.ofInstant(Instant.ofEpochMilli(aLong), ZoneId.systemDefault()))
-      .orElseGet(ZonedDateTime::now);
+      .orElseGet(() -> ZonedDateTime.now(clock));
   }
 
   public void setLastEventPolling(ZonedDateTime dateTime, String connectionId, String projectKey) {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/SmartNotifications.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/SmartNotifications.java
@@ -22,7 +22,7 @@ package org.sonarsource.sonarlint.core.smartnotifications;
 import com.google.common.util.concurrent.MoreExecutors;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import java.time.ZoneId;
+import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
@@ -68,10 +68,11 @@ public class SmartNotifications {
   private final WebSocketService webSocketService;
   private final InitializeParams params;
   private final LastEventPolling lastEventPollingService;
+  private final Clock clock;
   private ExecutorServiceShutdownWatchable<ScheduledExecutorService> smartNotificationsPolling;
 
   public SmartNotifications(ConfigurationRepository configurationRepository, ConnectionConfigurationRepository connectionRepository, SonarQubeClientManager sonarQubeClientManager,
-    SonarLintRpcClient client, StorageService storageService, TelemetryService telemetryService, WebSocketService webSocketService, InitializeParams params) {
+    SonarLintRpcClient client, StorageService storageService, TelemetryService telemetryService, WebSocketService webSocketService, InitializeParams params, Clock clock) {
     this.configurationRepository = configurationRepository;
     this.connectionRepository = connectionRepository;
     this.sonarQubeClientManager = sonarQubeClientManager;
@@ -79,7 +80,8 @@ public class SmartNotifications {
     this.telemetryService = telemetryService;
     this.webSocketService = webSocketService;
     this.params = params;
-    lastEventPollingService = new LastEventPolling(storageService);
+    this.clock = clock;
+    lastEventPollingService = new LastEventPolling(storageService, clock);
   }
 
   @PostConstruct
@@ -129,7 +131,7 @@ public class SmartNotifications {
     }
 
     projectKeysByLastEventPolling.keySet()
-      .forEach(projectKey -> lastEventPollingService.setLastEventPolling(ZonedDateTime.now(ZoneId.systemDefault()), connectionId, projectKey));
+      .forEach(projectKey -> lastEventPollingService.setLastEventPolling(ZonedDateTime.now(clock), connectionId, projectKey));
   }
 
   private boolean shouldSkipPolling(AbstractConnectionConfiguration connection) {
@@ -147,8 +149,8 @@ public class SmartNotifications {
     }
   }
 
-  private static ZonedDateTime getLastNotificationTime(ZonedDateTime lastTime) {
-    var oneDayAgo = ZonedDateTime.now(ZoneId.systemDefault()).minusDays(1);
+  private ZonedDateTime getLastNotificationTime(ZonedDateTime lastTime) {
+    var oneDayAgo = ZonedDateTime.now(clock).minusDays(1);
     return lastTime.isAfter(oneDayAgo) ? lastTime : oneDayAgo;
   }
 

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/spring/SonarLintSpringAppConfig.java
@@ -21,6 +21,7 @@ package org.sonarsource.sonarlint.core.spring;
 
 import java.net.ProxySelector;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.CheckForNull;
@@ -244,6 +245,11 @@ import static org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.Bac
   ServerPluginDownloader.class
 })
 public class SonarLintSpringAppConfig {
+
+  @Bean
+  Clock provideClock() {
+    return Clock.systemDefaultZone();
+  }
 
   @Bean(name = "applicationEventMulticaster")
   public ApplicationEventMulticaster simpleApplicationEventMulticaster() {

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/smartnotifications/LastEventPollingTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/smartnotifications/LastEventPollingTests.java
@@ -20,6 +20,8 @@
 package org.sonarsource.sonarlint.core.smartnotifications;
 
 import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -43,7 +45,8 @@ class LastEventPollingTests {
   @RegisterExtension
   private static final SonarLintLogTester logTester = new SonarLintLogTester();
 
-  private static final ZonedDateTime STORED_DATE = ZonedDateTime.now(ZoneId.systemDefault()).minusDays(5);
+  private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-07T10:00:00Z"), ZoneId.systemDefault());
+  private static final ZonedDateTime STORED_DATE = ZonedDateTime.now(FIXED_CLOCK).minusDays(5);
   private static final String PROJECT_KEY = "projectKey";
   private static final String CONNECTION_ID = "connectionId";
   private static final String FILE_NAME = "last_event_polling.pb";
@@ -80,12 +83,11 @@ class LastEventPollingTests {
   void should_not_retrieve_stored_last_event_polling(@TempDir Path tmpDir) {
     var databaseService = mock(SonarLintDatabaseService.class);
     var storage = new StorageService(userPathsFrom(tmpDir), databaseService);
-    var lastEventPolling = new LastEventPolling(storage);
+    var lastEventPolling = new LastEventPolling(storage, FIXED_CLOCK);
 
     var result = lastEventPolling.getLastEventPolling(CONNECTION_ID, PROJECT_KEY);
 
-    var now = ZonedDateTime.now(ZoneId.systemDefault());
-    assertThat(result).isBeforeOrEqualTo(now).isAfter(now.minusSeconds(3));
+    assertThat(result).isEqualTo(ZonedDateTime.now(FIXED_CLOCK));
   }
 
   private static UserPaths userPathsFrom(Path tmpDir) {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
@@ -111,7 +111,8 @@ public class TelemetryLocalStorage implements LocalStorage {
   private final Map<String, String> campaignsResolutions;
   private int supportedLanguagesPanelOpenedCount;
   private int supportedLanguagesPanelCtaClickedCount;
-  // transient: not serialized; on Gson read, set explicitly via setClock after deserialization.
+  // transient tells Gson to skip this field on serialization/deserialization; setClock re-injects it after a read.
+  @SuppressWarnings("java:S2065")
   private transient Clock clock;
 
   TelemetryLocalStorage() {
@@ -357,17 +358,17 @@ public class TelemetryLocalStorage implements LocalStorage {
 
   @Override
   public void validateAndMigrate() {
-    var clock = clockOrDefault();
-    var today = LocalDate.now(clock);
+    var effectiveClock = clockOrDefault();
+    var today = LocalDate.now(effectiveClock);
 
     // migrate deprecated installDate
     if (installDate != null && (installTime == null || installTime.toLocalDate().isAfter(installDate))) {
-      setInstallTime(installDate.atTime(OffsetTime.now(clock)));
+      setInstallTime(installDate.atTime(OffsetTime.now(effectiveClock)));
     }
 
     // fix install time if necessary
-    if (installTime == null || installTime.isAfter(OffsetDateTime.now(clock))) {
-      setInstallTime(OffsetDateTime.now(clock));
+    if (installTime == null || installTime.isAfter(OffsetDateTime.now(effectiveClock))) {
+      setInstallTime(OffsetDateTime.now(effectiveClock));
     }
 
     // calculate use days

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
@@ -19,11 +19,11 @@
  */
 package org.sonarsource.sonarlint.core.telemetry;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
-import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -111,10 +111,17 @@ public class TelemetryLocalStorage implements LocalStorage {
   private final Map<String, String> campaignsResolutions;
   private int supportedLanguagesPanelOpenedCount;
   private int supportedLanguagesPanelCtaClickedCount;
+  // transient: not serialized; on Gson read, set explicitly via setClock after deserialization.
+  private transient Clock clock;
 
   TelemetryLocalStorage() {
+    this(null);
+  }
+
+  TelemetryLocalStorage(@Nullable Clock clock) {
+    this.clock = clock;
     enabled = true;
-    installTime = OffsetDateTime.now(ZoneId.systemDefault());
+    installTime = OffsetDateTime.now(clockOrDefault());
     analyzers = new LinkedHashMap<>();
     notificationsCountersByEventType = new LinkedHashMap<>();
     issueStatusChangedRuleKeys = new HashSet<>();
@@ -133,6 +140,14 @@ public class TelemetryLocalStorage implements LocalStorage {
     aiHooksInstalledCount = new EnumMap<>(AiAgent.class);
     campaignsShown = new HashMap<>();
     campaignsResolutions = new HashMap<>();
+  }
+
+  public void setClock(Clock clock) {
+    this.clock = clock;
+  }
+
+  private Clock clockOrDefault() {
+    return clock != null ? clock : Clock.systemDefaultZone();
   }
 
   public Collection<String> getRaisedIssuesRules() {
@@ -226,7 +241,7 @@ public class TelemetryLocalStorage implements LocalStorage {
   }
 
   void setLastUploadTime() {
-    setLastUploadTime(LocalDateTime.now(ZoneId.systemDefault()));
+    setLastUploadTime(LocalDateTime.now(clockOrDefault()));
   }
 
   void setLastUploadTime(@Nullable LocalDateTime dateTime) {
@@ -315,7 +330,7 @@ public class TelemetryLocalStorage implements LocalStorage {
   }
 
   private void markSonarLintAsUsedToday() {
-    var now = LocalDate.now(ZoneId.systemDefault());
+    var now = LocalDate.now(clockOrDefault());
     if (lastUseDate == null || !lastUseDate.equals(now)) {
       numUseDays++;
     }
@@ -342,16 +357,17 @@ public class TelemetryLocalStorage implements LocalStorage {
 
   @Override
   public void validateAndMigrate() {
-    var today = LocalDate.now(ZoneId.systemDefault());
+    var clock = clockOrDefault();
+    var today = LocalDate.now(clock);
 
     // migrate deprecated installDate
     if (installDate != null && (installTime == null || installTime.toLocalDate().isAfter(installDate))) {
-      setInstallTime(installDate.atTime(OffsetTime.now(ZoneId.systemDefault())));
+      setInstallTime(installDate.atTime(OffsetTime.now(clock)));
     }
 
     // fix install time if necessary
-    if (installTime == null || installTime.isAfter(OffsetDateTime.now(ZoneId.systemDefault()))) {
-      setInstallTime(OffsetDateTime.now(ZoneId.systemDefault()));
+    if (installTime == null || installTime.isAfter(OffsetDateTime.now(clock))) {
+      setInstallTime(OffsetDateTime.now(clock));
     }
 
     // calculate use days

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
@@ -21,10 +21,10 @@ package org.sonarsource.sonarlint.core.telemetry;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.commons.storage.local.FileStorageManager;
@@ -40,10 +40,16 @@ public class TelemetryLocalStorageManager {
   private final FileStorageManager<TelemetryLocalStorage> fileStorageManager;
   @Nullable
   private final TelemetryMigrationDto telemetryMigration;
+  private final Clock clock;
 
-  public TelemetryLocalStorageManager(@Qualifier("telemetryPath") Path telemetryPath, InitializeParams initializeParams) {
-    fileStorageManager = new FileStorageManager<>(telemetryPath, TelemetryLocalStorage::new, TelemetryLocalStorage.class);
+  public TelemetryLocalStorageManager(@Qualifier("telemetryPath") Path telemetryPath, InitializeParams initializeParams, Clock clock) {
+    this.clock = clock;
+    fileStorageManager = new FileStorageManager<>(telemetryPath, this::newStorage, TelemetryLocalStorage.class);
     this.telemetryMigration = initializeParams.getTelemetryMigration();
+  }
+
+  private TelemetryLocalStorage newStorage() {
+    return new TelemetryLocalStorage(clock);
   }
 
   @VisibleForTesting
@@ -53,6 +59,7 @@ public class TelemetryLocalStorageManager {
 
   private TelemetryLocalStorage getStorage() {
     var inMemoryStorage = fileStorageManager.getStorage();
+    inMemoryStorage.setClock(clock);
     applyTelemetryMigration(inMemoryStorage);
     return inMemoryStorage;
   }
@@ -69,12 +76,15 @@ public class TelemetryLocalStorageManager {
     if (telemetryMigration == null) {
       return false;
     }
-    var duration = Duration.between(inMemoryStorage.installTime(), OffsetDateTime.now(ZoneId.systemDefault()));
+    var duration = Duration.between(inMemoryStorage.installTime(), OffsetDateTime.now(clock));
     return duration.getSeconds() < 10 && inMemoryStorage.numUseDays() == 0;
   }
 
   public void tryUpdateAtomically(Consumer<TelemetryLocalStorage> updater) {
-    fileStorageManager.tryUpdateAtomically(updater);
+    fileStorageManager.tryUpdateAtomically(storage -> {
+      storage.setClock(clock);
+      updater.accept(storage);
+    });
   }
 
   public LocalDateTime lastUploadTime() {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
@@ -44,12 +44,16 @@ public class TelemetryLocalStorageManager {
 
   public TelemetryLocalStorageManager(@Qualifier("telemetryPath") Path telemetryPath, InitializeParams initializeParams, Clock clock) {
     this.clock = clock;
-    fileStorageManager = new FileStorageManager<>(telemetryPath, this::newStorage, TelemetryLocalStorage.class);
+    fileStorageManager = new FileStorageManager<>(telemetryPath, this::newStorage, TelemetryLocalStorage.class, this::injectClock);
     this.telemetryMigration = initializeParams.getTelemetryMigration();
   }
 
   private TelemetryLocalStorage newStorage() {
     return new TelemetryLocalStorage(clock);
+  }
+
+  private void injectClock(TelemetryLocalStorage storage) {
+    storage.setClock(clock);
   }
 
   @VisibleForTesting
@@ -59,7 +63,6 @@ public class TelemetryLocalStorageManager {
 
   private TelemetryLocalStorage getStorage() {
     var inMemoryStorage = fileStorageManager.getStorage();
-    inMemoryStorage.setClock(clock);
     applyTelemetryMigration(inMemoryStorage);
     return inMemoryStorage;
   }
@@ -81,10 +84,7 @@ public class TelemetryLocalStorageManager {
   }
 
   public void tryUpdateAtomically(Consumer<TelemetryLocalStorage> updater) {
-    fileStorageManager.tryUpdateAtomically(storage -> {
-      storage.setClock(clock);
-      updater.accept(storage);
-    });
+    fileStorageManager.tryUpdateAtomically(updater);
   }
 
   public LocalDateTime lastUploadTime() {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManager.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManager.java
@@ -19,6 +19,7 @@
  */
 package org.sonarsource.sonarlint.core.telemetry;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.function.Consumer;
@@ -35,10 +36,12 @@ public class TelemetryManager implements TelemetryUserSetting {
 
   private final TelemetryLocalStorageManager storageManager;
   private final TelemetryHttpClient client;
+  private final Clock clock;
 
-  TelemetryManager(TelemetryLocalStorageManager storageManager, TelemetryHttpClient client) {
+  TelemetryManager(TelemetryLocalStorageManager storageManager, TelemetryHttpClient client, Clock clock) {
     this.storageManager = storageManager;
     this.client = client;
+    this.clock = clock;
   }
 
   void enable(TelemetryLiveAttributes telemetryLiveAttributes) {
@@ -50,8 +53,8 @@ public class TelemetryManager implements TelemetryUserSetting {
     });
   }
 
-  private static boolean isGracePeriodElapsedAndDayChanged(@Nullable LocalDateTime lastUploadTime) {
-    return TelemetryUtils.isGracePeriodElapsedAndDayChanged(lastUploadTime, MIN_HOURS_BETWEEN_UPLOAD);
+  private boolean isGracePeriodElapsedAndDayChanged(@Nullable LocalDateTime lastUploadTime) {
+    return TelemetryUtils.isGracePeriodElapsedAndDayChanged(lastUploadTime, MIN_HOURS_BETWEEN_UPLOAD, clock);
   }
 
   private void uploadAndClearTelemetry(TelemetryLiveAttributes telemetryLiveAttributes, TelemetryLocalStorage localStorage) {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtils.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtils.java
@@ -21,9 +21,9 @@ package org.sonarsource.sonarlint.core.telemetry;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -50,7 +50,11 @@ class TelemetryUtils {
    * @return true if it's a different day than the reference
    */
   static boolean isGracePeriodElapsedAndDayChanged(@Nullable LocalDate date) {
-    return date == null || !date.equals(LocalDate.now(ZoneId.systemDefault()));
+    return isGracePeriodElapsedAndDayChanged(date, Clock.systemDefaultZone());
+  }
+
+  static boolean isGracePeriodElapsedAndDayChanged(@Nullable LocalDate date, Clock clock) {
+    return date == null || !date.equals(LocalDate.now(clock));
   }
 
   /**
@@ -115,9 +119,13 @@ class TelemetryUtils {
    * @return true if it's a different day than the reference and at least hours have elapsed
    */
   static boolean isGracePeriodElapsedAndDayChanged(@Nullable LocalDateTime dateTime, long hours) {
+    return isGracePeriodElapsedAndDayChanged(dateTime, hours, Clock.systemDefaultZone());
+  }
+
+  static boolean isGracePeriodElapsedAndDayChanged(@Nullable LocalDateTime dateTime, long hours, Clock clock) {
     return dateTime == null ||
-      (!LocalDate.now(ZoneId.systemDefault()).equals(dateTime.toLocalDate())
-        && (dateTime.until(LocalDateTime.now(ZoneId.systemDefault()), ChronoUnit.HOURS) >= hours));
+      (!LocalDate.now(clock).equals(dateTime.toLocalDate())
+        && (dateTime.until(LocalDateTime.now(clock), ChronoUnit.HOURS) >= hours));
   }
 
   private static <T> BinaryOperator<T> throwingMerger() {

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
@@ -20,9 +20,9 @@
 package org.sonarsource.sonarlint.core.telemetry;
 
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.UUID;
@@ -44,8 +44,9 @@ class TelemetryLocalStorageManagerTests {
 
   @RegisterExtension
   private static final SonarLintLogTester logTester = new SonarLintLogTester();
+  private static final Clock CLOCK = Clock.systemDefaultZone();
 
-  private final LocalDate today = LocalDate.now(ZoneId.systemDefault());
+  private final LocalDate today = LocalDate.now(CLOCK);
   private Path filePath;
 
   @BeforeEach
@@ -67,7 +68,7 @@ class TelemetryLocalStorageManagerTests {
   }
 
   private final Condition<OffsetDateTime> within3SecOfNow = new Condition<>(p -> {
-    var now = OffsetDateTime.now(ZoneId.systemDefault());
+    var now = OffsetDateTime.now(CLOCK);
     return Math.abs(p.until(now, ChronoUnit.SECONDS)) < 3;
   }, "within3Sec");
 
@@ -106,7 +107,7 @@ class TelemetryLocalStorageManagerTests {
   void should_fix_invalid_numDays() {
     var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
 
-    var tenDaysAgo = OffsetDateTime.now(ZoneId.systemDefault()).minusDays(10);
+    var tenDaysAgo = OffsetDateTime.now(CLOCK).minusDays(10);
 
     storage.tryUpdateAtomically(data -> {
       data.setInstallTime(tenDaysAgo);
@@ -125,7 +126,7 @@ class TelemetryLocalStorageManagerTests {
     var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
 
     storage.tryUpdateAtomically(data -> {
-      data.setInstallTime(OffsetDateTime.now(ZoneId.systemDefault()).plusDays(5));
+      data.setInstallTime(OffsetDateTime.now(CLOCK).plusDays(5));
       data.setLastUseDate(today.plusDays(7));
       data.setNumUseDays(100);
     });
@@ -202,7 +203,7 @@ class TelemetryLocalStorageManagerTests {
   @Test
   void should_migrate_telemetry() {
     var initializeParams = mock(InitializeParams.class);
-    var expectedInstallTime = OffsetDateTime.now(ZoneId.systemDefault());
+    var expectedInstallTime = OffsetDateTime.now(CLOCK);
     when(initializeParams.getTelemetryMigration()).thenReturn(new TelemetryMigrationDto(expectedInstallTime, 42, false));
 
     var storageManager = new TelemetryLocalStorageManager(filePath, initializeParams);

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
@@ -21,8 +21,10 @@ package org.sonarsource.sonarlint.core.telemetry;
 
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 import java.util.UUID;
@@ -44,7 +46,7 @@ class TelemetryLocalStorageManagerTests {
 
   @RegisterExtension
   private static final SonarLintLogTester logTester = new SonarLintLogTester();
-  private static final Clock CLOCK = Clock.systemDefaultZone();
+  private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-05-07T10:00:00Z"), ZoneId.systemDefault());
 
   private final LocalDate today = LocalDate.now(CLOCK);
   private Path filePath;
@@ -56,7 +58,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void test_default_data() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     var data = storage.tryRead();
     assertThat(filePath).doesNotExist();
@@ -74,7 +76,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void should_update_data() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     storage.tryRead();
     assertThat(filePath).doesNotExist();
@@ -90,7 +92,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void should_fix_invalid_installTime() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     storage.tryUpdateAtomically(data -> {
       data.setInstallTime(null);
@@ -105,7 +107,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void should_fix_invalid_numDays() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     var tenDaysAgo = OffsetDateTime.now(CLOCK).minusDays(10);
 
@@ -123,7 +125,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void should_fix_dates_in_future() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     storage.tryUpdateAtomically(data -> {
       data.setInstallTime(OffsetDateTime.now(CLOCK).plusDays(5));
@@ -140,7 +142,7 @@ class TelemetryLocalStorageManagerTests {
   @Test
   void should_not_crash_when_cannot_read_storage(@TempDir Path temp) {
     InternalDebug.setEnabled(false);
-    assertThatCode(() -> new TelemetryLocalStorageManager(temp, mock(InitializeParams.class)).tryRead())
+    assertThatCode(() -> new TelemetryLocalStorageManager(temp, mock(InitializeParams.class), CLOCK).tryRead())
       .doesNotThrowAnyException();
 
   }
@@ -148,13 +150,13 @@ class TelemetryLocalStorageManagerTests {
   @Test
   void should_not_crash_when_cannot_write_storage(@TempDir Path temp) {
     InternalDebug.setEnabled(false);
-    assertThatCode(() -> new TelemetryLocalStorageManager(temp, mock(InitializeParams.class)).tryUpdateAtomically(d -> {}))
+    assertThatCode(() -> new TelemetryLocalStorageManager(temp, mock(InitializeParams.class), CLOCK).tryUpdateAtomically(d -> {}))
       .doesNotThrowAnyException();
   }
 
   @Test
   void should_increment_open_hotspot_in_browser() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     storage.tryUpdateAtomically(TelemetryLocalStorage::incrementOpenHotspotInBrowserCount);
     storage.tryUpdateAtomically(TelemetryLocalStorage::incrementOpenHotspotInBrowserCount);
@@ -165,7 +167,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void should_increment_hotspot_status_changed() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     storage.tryUpdateAtomically(TelemetryLocalStorage::incrementHotspotStatusChangedCount);
     storage.tryUpdateAtomically(TelemetryLocalStorage::incrementHotspotStatusChangedCount);
@@ -177,7 +179,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void should_increment_issue_status_changed() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
 
     storage.tryUpdateAtomically(telemetryLocalStorage -> telemetryLocalStorage.addIssueStatusChanged("ruleKey1"));
     storage.tryUpdateAtomically(telemetryLocalStorage -> telemetryLocalStorage.addIssueStatusChanged("ruleKey2"));
@@ -189,7 +191,7 @@ class TelemetryLocalStorageManagerTests {
 
   @Test
   void should_increment_issue_ai_fixable() {
-    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class), CLOCK);
     var uuid1 = UUID.randomUUID();
     var uuid2 = UUID.randomUUID();
     var uuid3 = UUID.randomUUID();
@@ -206,7 +208,7 @@ class TelemetryLocalStorageManagerTests {
     var expectedInstallTime = OffsetDateTime.now(CLOCK);
     when(initializeParams.getTelemetryMigration()).thenReturn(new TelemetryMigrationDto(expectedInstallTime, 42, false));
 
-    var storageManager = new TelemetryLocalStorageManager(filePath, initializeParams);
+    var storageManager = new TelemetryLocalStorageManager(filePath, initializeParams, CLOCK);
 
     var localStorage = storageManager.tryRead();
     var actualInstallTime = localStorage.installTime();

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
@@ -19,10 +19,10 @@
  */
 package org.sonarsource.sonarlint.core.telemetry;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
@@ -37,6 +37,8 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.sonarsource.sonarlint.core.telemetry.TelemetryLocalStorage.isOlder;
 
 class TelemetryLocalStorageTests {
+  private static final Clock CLOCK = Clock.systemDefaultZone();
+
   @Test
   void usedAnalysis_should_increment_num_days_on_first_run() {
     var data = new TelemetryLocalStorage();
@@ -103,14 +105,14 @@ class TelemetryLocalStorageTests {
     data.setUsedAnalysis();
     assertThat(data.numUseDays()).isEqualTo(1);
 
-    data.setLastUseDate(LocalDate.now(ZoneId.systemDefault()).minusDays(1));
+    data.setLastUseDate(LocalDate.now(CLOCK).minusDays(1));
     data.setUsedAnalysis();
     assertThat(data.numUseDays()).isEqualTo(2);
   }
 
   @Test
   void test_isOlder_LocalDate() {
-    var date = LocalDate.now(ZoneId.systemDefault());
+    var date = LocalDate.now(CLOCK);
 
     assertThat(isOlder((LocalDate) null, null)).isTrue();
     assertThat(isOlder(null, date)).isTrue();
@@ -121,7 +123,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void test_isOlder_LocalDateTime() {
-    var date = LocalDateTime.now(ZoneId.systemDefault());
+    var date = LocalDateTime.now(CLOCK);
 
     assertThat(isOlder((LocalDateTime) null, null)).isTrue();
     assertThat(isOlder(null, date)).isTrue();
@@ -133,7 +135,7 @@ class TelemetryLocalStorageTests {
   @Test
   void validate_should_reset_installTime_if_in_future() {
     var data = new TelemetryLocalStorage();
-    var now = OffsetDateTime.now(ZoneId.systemDefault());
+    var now = OffsetDateTime.now(CLOCK);
 
     data.validateAndMigrate();
     assertThat(data.installTime()).is(within3SecOfNow);
@@ -144,19 +146,19 @@ class TelemetryLocalStorageTests {
   }
 
   private final Condition<OffsetDateTime> within3SecOfNow = new Condition<>(p -> {
-    var now = OffsetDateTime.now(ZoneId.systemDefault());
+    var now = OffsetDateTime.now(CLOCK);
     return Math.abs(p.until(now, ChronoUnit.SECONDS)) < 3;
   }, "within3Sec");
 
   private final Condition<OffsetDateTime> about5DaysAgo = new Condition<>(p -> {
-    var fiveDaysAgo = OffsetDateTime.now(ZoneId.systemDefault()).minusDays(5);
+    var fiveDaysAgo = OffsetDateTime.now(CLOCK).minusDays(5);
     return Math.abs(p.until(fiveDaysAgo, ChronoUnit.SECONDS)) < 3;
   }, "about5DaysAgo");
 
   @Test
   void validate_should_reset_lastUseDate_if_in_future() {
     var data = new TelemetryLocalStorage();
-    var today = LocalDate.now(ZoneId.systemDefault());
+    var today = LocalDate.now(CLOCK);
 
     data.setLastUseDate(today.plusDays(1));
     data.validateAndMigrate();
@@ -166,7 +168,7 @@ class TelemetryLocalStorageTests {
   @Test
   void should_migrate_installDate() {
     var data = new TelemetryLocalStorage();
-    data.setInstallDate(LocalDate.now(ZoneId.systemDefault()).minusDays(5));
+    data.setInstallDate(LocalDate.now(CLOCK).minusDays(5));
     data.validateAndMigrate();
     assertThat(data.installTime()).is(about5DaysAgo);
   }
@@ -174,12 +176,12 @@ class TelemetryLocalStorageTests {
   @Test
   void validate_should_reset_lastUseDate_if_before_installTime() {
     var data = new TelemetryLocalStorage();
-    var now = OffsetDateTime.now(ZoneId.systemDefault());
+    var now = OffsetDateTime.now(CLOCK);
 
     data.setInstallTime(now);
     data.setLastUseDate(now.minusDays(1).toLocalDate());
     data.validateAndMigrate();
-    assertThat(data.lastUseDate()).isEqualTo(LocalDate.now(ZoneId.systemDefault()));
+    assertThat(data.lastUseDate()).isEqualTo(LocalDate.now(CLOCK));
   }
 
   @Test
@@ -195,7 +197,7 @@ class TelemetryLocalStorageTests {
   @Test
   void validate_should_fix_numDays_if_incorrect() {
     var data = new TelemetryLocalStorage();
-    var installTime = OffsetDateTime.now(ZoneId.systemDefault()).minusDays(10);
+    var installTime = OffsetDateTime.now(CLOCK).minusDays(10);
     var lastUseDate = installTime.plusDays(3).toLocalDate();
     data.setInstallTime(installTime);
     data.setLastUseDate(lastUseDate);

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
@@ -20,9 +20,11 @@
 package org.sonarsource.sonarlint.core.telemetry;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
@@ -37,11 +39,15 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.sonarsource.sonarlint.core.telemetry.TelemetryLocalStorage.isOlder;
 
 class TelemetryLocalStorageTests {
-  private static final Clock CLOCK = Clock.systemDefaultZone();
+  private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-05-07T10:00:00Z"), ZoneId.systemDefault());
+
+  private static TelemetryLocalStorage newStorage() {
+    return new TelemetryLocalStorage(CLOCK);
+  }
 
   @Test
   void usedAnalysis_should_increment_num_days_on_first_run() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.numUseDays()).isZero();
 
     data.setUsedAnalysis();
@@ -50,7 +56,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void usedAnalysis_should_not_increment_num_days_on_same_day() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.numUseDays()).isZero();
 
     data.setUsedAnalysis();
@@ -62,7 +68,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void usedAnalysis_with_duration_should_register_analyzer_performance() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.numUseDays()).isZero();
     assertThat(data.analyzers()).isEmpty();
 
@@ -96,7 +102,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void usedAnalysis_should_increment_num_days_when_day_changed() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.numUseDays()).isZero();
 
     data.setUsedAnalysis();
@@ -134,7 +140,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void validate_should_reset_installTime_if_in_future() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     var now = OffsetDateTime.now(CLOCK);
 
     data.validateAndMigrate();
@@ -157,7 +163,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void validate_should_reset_lastUseDate_if_in_future() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     var today = LocalDate.now(CLOCK);
 
     data.setLastUseDate(today.plusDays(1));
@@ -167,7 +173,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_migrate_installDate() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     data.setInstallDate(LocalDate.now(CLOCK).minusDays(5));
     data.validateAndMigrate();
     assertThat(data.installTime()).is(about5DaysAgo);
@@ -175,7 +181,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void validate_should_reset_lastUseDate_if_before_installTime() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     var now = OffsetDateTime.now(CLOCK);
 
     data.setInstallTime(now);
@@ -186,7 +192,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void validate_should_reset_numDays_if_lastUseDate_unset() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     data.setNumUseDays(3);
 
     data.validateAndMigrate();
@@ -196,7 +202,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void validate_should_fix_numDays_if_incorrect() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     var installTime = OffsetDateTime.now(CLOCK).minusDays(10);
     var lastUseDate = installTime.plusDays(3).toLocalDate();
     data.setInstallTime(installTime);
@@ -213,7 +219,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_replace_fix_suggestion_snippet_status() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
 
     var suggestionId = UUID.randomUUID().toString();
     data.fixSuggestionResolved(suggestionId, FixSuggestionStatus.ACCEPTED, 0);
@@ -230,7 +236,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_track_findings_filtered_by_type() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getFindingsFilteredCountersByType()).isEmpty();
 
     data.findingsFiltered("severity");
@@ -248,7 +254,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_clear_findings_filtered_counters() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
 
     data.findingsFiltered("severity");
     data.findingsFiltered("location");
@@ -260,7 +266,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_track_dependency_risk_investigated() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getDependencyRiskInvestigatedRemotelyCount()).isZero();
     assertThat(data.getDependencyRiskInvestigatedLocallyCount()).isZero();
 
@@ -277,7 +283,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_clear_dependency_risk_investigated_counts_after_ping() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
 
     data.incrementDependencyRiskInvestigatedRemotelyCount();
     data.incrementDependencyRiskInvestigatedLocallyCount();
@@ -291,7 +297,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_increment_new_bindings_counters_per_origin() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
 
     assertThat(data.getNewBindingsPropertiesFileCount()).isZero();
     assertThat(data.getNewBindingsRemoteUrlCount()).isZero();
@@ -311,7 +317,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_reset_new_bindings_counters_on_clear_after_ping() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     data.incrementNewBindingsPropertiesFileCount();
     data.incrementNewBindingsRemoteUrlCount();
     data.incrementNewBindingsProjectNameCount();
@@ -327,7 +333,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_increment_suggested_remote_bindings_count() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getSuggestedRemoteBindingsCount()).isZero();
     data.incrementSuggestedRemoteBindingsCount();
     data.incrementSuggestedRemoteBindingsCount();
@@ -336,7 +342,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_increment_mcp_server_settings_requested_count() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getMcpServerConfigurationRequestedCount()).isZero();
     data.incrementMcpServerConfigurationRequestedCount();
     data.incrementMcpServerConfigurationRequestedCount();
@@ -345,7 +351,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_find_mcp_integration_enabled() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.isMcpIntegrationEnabled()).isFalse();
     data.setMcpIntegrationEnabled(true);
     assertThat(data.isMcpIntegrationEnabled()).isTrue();
@@ -353,7 +359,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_find_mcp_transport_mode_used() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getMcpTransportModeUsed()).isNull();
     data.setMcpTransportModeUsed(McpTransportMode.HTTP);
     assertThat(data.getMcpTransportModeUsed()).isEqualTo(McpTransportMode.HTTP);
@@ -361,7 +367,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_increment_link_clicked_count_for_each_link_separately() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getLabsLinkClickedCount()).isEmpty();
 
     data.ideLabsLinkClicked("1");
@@ -376,7 +382,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_increment_feedback_link_clicked_count_for_each_link_separately() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getLabsFeedbackLinkClickedCount()).isEmpty();
 
     data.ideLabsFeedbackLinkClicked("1");
@@ -391,7 +397,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_reset_link_clicked_data_after_ping() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
 
     data.ideLabsLinkClicked("1");
     data.ideLabsLinkClicked("2");
@@ -406,7 +412,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_track_supported_languages_panel_opened() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getSupportedLanguagesPanelOpenedCount()).isZero();
 
     data.incrementSupportedLanguagesPanelOpenedCount();
@@ -416,7 +422,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_track_supported_languages_panel_cta_clicked() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
     assertThat(data.getSupportedLanguagesPanelCtaClickedCount()).isZero();
 
     data.incrementSupportedLanguagesPanelCtaClickedCount();
@@ -427,7 +433,7 @@ class TelemetryLocalStorageTests {
 
   @Test
   void should_clear_supported_languages_panel_counts_after_ping() {
-    var data = new TelemetryLocalStorage();
+    var data = newStorage();
 
     data.incrementSupportedLanguagesPanelOpenedCount();
     data.incrementSupportedLanguagesPanelCtaClickedCount();

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
@@ -20,10 +20,10 @@
 package org.sonarsource.sonarlint.core.telemetry;
 
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Set;
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingType.PRE_COMMIT_ANALYSIS_TYPE;
 
 class TelemetryManagerTests {
+  private static final Clock CLOCK = Clock.systemDefaultZone();
   private static final int DEFAULT_NOTIF_CLICKED = 5;
   private static final int DEFAULT_NOTIF_COUNT = 10;
   private static final int DEFAULT_HELP_AND_FEEDBACK_COUNT = 12;
@@ -230,7 +231,7 @@ class TelemetryManagerTests {
       data.fixSuggestionResolved("suggestionId", FixSuggestionStatus.ACCEPTED, 0);
       data.incrementTaintVulnerabilitiesInvestigatedLocallyCount();
       data.incrementTaintVulnerabilitiesInvestigatedRemotelyCount();
-      data.setLastUploadTime(LocalDateTime.now(ZoneId.systemDefault()).minusDays(2));
+      data.setLastUploadTime(LocalDateTime.now(CLOCK).minusDays(2));
       data.setNumUseDays(5);
       data.notifications().put(FOO_EVENT, new TelemetryNotificationsCounter(DEFAULT_NOTIF_COUNT, DEFAULT_NOTIF_CLICKED));
       data.getHelpAndFeedbackLinkClickedCounter().put(SUGGEST_FEATURE, new TelemetryHelpAndFeedbackCounter(DEFAULT_HELP_AND_FEEDBACK_COUNT));
@@ -264,9 +265,9 @@ class TelemetryManagerTests {
   private void createAndSaveSampleData(TelemetryLocalStorageManager storage) {
     storage.tryUpdateAtomically(data -> {
       data.setEnabled(false);
-      data.setInstallTime(OffsetDateTime.now(ZoneId.systemDefault()).minusDays(10));
-      data.setLastUseDate(LocalDate.now(ZoneId.systemDefault()).minusDays(3));
-      data.setLastUploadTime(LocalDateTime.now(ZoneId.systemDefault()).minusDays(2));
+      data.setInstallTime(OffsetDateTime.now(CLOCK).minusDays(10));
+      data.setLastUseDate(LocalDate.now(CLOCK).minusDays(3));
+      data.setLastUploadTime(LocalDateTime.now(CLOCK).minusDays(2));
       data.setNumUseDays(5);
       data.notifications().put(FOO_EVENT, new TelemetryNotificationsCounter(DEFAULT_NOTIF_COUNT, DEFAULT_NOTIF_CLICKED));
       data.getHelpAndFeedbackLinkClickedCounter().put(SUGGEST_FEATURE, new TelemetryHelpAndFeedbackCounter(DEFAULT_HELP_AND_FEEDBACK_COUNT));

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryManagerTests.java
@@ -21,9 +21,11 @@ package org.sonarsource.sonarlint.core.telemetry;
 
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Set;
@@ -53,7 +55,7 @@ import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.AnalysisReportingType.PRE_COMMIT_ANALYSIS_TYPE;
 
 class TelemetryManagerTests {
-  private static final Clock CLOCK = Clock.systemDefaultZone();
+  private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-05-07T10:00:00Z"), ZoneId.systemDefault());
   private static final int DEFAULT_NOTIF_CLICKED = 5;
   private static final int DEFAULT_NOTIF_COUNT = 10;
   private static final int DEFAULT_HELP_AND_FEEDBACK_COUNT = 12;
@@ -69,8 +71,8 @@ class TelemetryManagerTests {
   @BeforeEach
   void setUp(@TempDir Path temp) {
     client = mock(TelemetryHttpClient.class);
-    storageManager = new TelemetryLocalStorageManager(temp.resolve("storage"), mock(InitializeParams.class));
-    telemetryManager = new TelemetryManager(storageManager, client);
+    storageManager = new TelemetryLocalStorageManager(temp.resolve("storage"), mock(InitializeParams.class), CLOCK);
+    telemetryManager = new TelemetryManager(storageManager, client, CLOCK);
   }
 
   @Test
@@ -87,7 +89,7 @@ class TelemetryManagerTests {
   @Test
   void disable_should_trigger_optout() {
     var mockStorageManager = mockTelemetryStorage();
-    var manager = new TelemetryManager(mockStorageManager, client);
+    var manager = new TelemetryManager(mockStorageManager, client, CLOCK);
     var telemetryPayload = getTelemetryLiveAttributesDto();
 
     manager.disable(telemetryPayload);

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtilsTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryUtilsTests.java
@@ -20,6 +20,8 @@
 package org.sonarsource.sonarlint.core.telemetry;
 
 import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -39,14 +41,16 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.sonarsource.sonarlint.core.telemetry.TelemetryUtils.isGracePeriodElapsedAndDayChanged;
 
 class TelemetryUtilsTests {
+  private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-07T10:00:00Z"), ZoneId.systemDefault());
+
   @Test
   void dayChanged_should_return_true_for_null() {
-    assertThat(isGracePeriodElapsedAndDayChanged(null)).isTrue();
+    assertThat(isGracePeriodElapsedAndDayChanged((LocalDate) null, FIXED_CLOCK)).isTrue();
   }
 
   @Test
   void dayChanged_should_return_true_if_older() {
-    assertThat(isGracePeriodElapsedAndDayChanged(LocalDate.now(ZoneId.systemDefault()).minusDays(1))).isTrue();
+    assertThat(isGracePeriodElapsedAndDayChanged(LocalDate.now(FIXED_CLOCK).minusDays(1), FIXED_CLOCK)).isTrue();
   }
 
   @Test
@@ -72,17 +76,17 @@ class TelemetryUtilsTests {
 
   @Test
   void dayChanged_should_return_false_if_same() {
-    assertThat(isGracePeriodElapsedAndDayChanged(LocalDate.now(ZoneId.systemDefault()))).isFalse();
+    assertThat(isGracePeriodElapsedAndDayChanged(LocalDate.now(FIXED_CLOCK), FIXED_CLOCK)).isFalse();
   }
 
   @Test
   void dayChanged_with_hours_should_return_true_for_null() {
-    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(null, 1)).isTrue();
+    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(null, 1, FIXED_CLOCK)).isTrue();
   }
 
   @Test
   void dayChanged_with_hours_should_return_false_if_day_same() {
-    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(LocalDateTime.now(ZoneId.systemDefault()), 100)).isFalse();
+    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(LocalDateTime.now(FIXED_CLOCK), 100, FIXED_CLOCK)).isFalse();
   }
 
   @Test
@@ -113,16 +117,16 @@ class TelemetryUtilsTests {
 
   @Test
   void dayChanged_with_hours_should_return_false_if_different_day_but_within_hours() {
-    var date = LocalDateTime.now(ZoneId.systemDefault()).minusDays(1);
-    var hours = date.until(LocalDateTime.now(ZoneId.systemDefault()), ChronoUnit.HOURS);
-    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(date, hours + 1)).isFalse();
+    var date = LocalDateTime.now(FIXED_CLOCK).minusDays(1);
+    var hours = date.until(LocalDateTime.now(FIXED_CLOCK), ChronoUnit.HOURS);
+    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(date, hours + 1, FIXED_CLOCK)).isFalse();
   }
 
   @Test
   void dayChanged_with_hours_should_return_true_if_different_day_and_beyond_hours() {
-    var date = LocalDateTime.now(ZoneId.systemDefault()).minusDays(1);
-    var hours = date.until(LocalDateTime.now(ZoneId.systemDefault()), ChronoUnit.HOURS);
-    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(date, hours)).isTrue();
+    var date = LocalDateTime.now(FIXED_CLOCK).minusDays(1);
+    var hours = date.until(LocalDateTime.now(FIXED_CLOCK), ChronoUnit.HOURS);
+    assertThat(TelemetryUtils.isGracePeriodElapsedAndDayChanged(date, hours, FIXED_CLOCK)).isTrue();
   }
 
   @Test

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
@@ -22,7 +22,6 @@ package org.sonarsource.sonarlint.core.client.utils;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 public class DateUtils {
@@ -36,7 +35,7 @@ public class DateUtils {
   }
 
   public static String toAge(long time, Clock clock) {
-    var creation = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneId.systemDefault());
+    var creation = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), clock.getZone());
     var now = LocalDateTime.now(clock);
 
     var years = ChronoUnit.YEARS.between(creation, now);

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
@@ -19,6 +19,7 @@
  */
 package org.sonarsource.sonarlint.core.client.utils;
 
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -31,8 +32,12 @@ public class DateUtils {
   }
 
   public static String toAge(long time) {
+    return toAge(time, Clock.systemDefaultZone());
+  }
+
+  public static String toAge(long time, Clock clock) {
     var creation = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneId.systemDefault());
-    var now = LocalDateTime.now(ZoneId.systemDefault());
+    var now = LocalDateTime.now(clock);
 
     var years = ChronoUnit.YEARS.between(creation, now);
     if (years > 0) {

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/DateUtilsTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/DateUtilsTests.java
@@ -19,6 +19,8 @@
  */
 package org.sonarsource.sonarlint.core.client.utils;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import org.junit.jupiter.api.Test;
@@ -27,20 +29,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class DateUtilsTests {
 
+  private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2026-05-07T10:00:00Z"), ZoneId.systemDefault());
+  private static final long FIXED_NOW_MILLIS = FIXED_CLOCK.millis();
+
   @Test
   void testAge() {
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 100)).isEqualTo("few seconds ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 65_000)).isEqualTo("1 minute ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 3_600_000 - 100_000)).isEqualTo("1 hour ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 2 * 3_600_000 - 100_000)).isEqualTo("2 hours ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 24 * 3_600_000 - 100_000)).isEqualTo("1 day ago");
-    assertThat(DateUtils.toAge(LocalDateTime.now(ZoneId.systemDefault()).minusMonths(5)
+    assertThat(DateUtils.toAge(FIXED_NOW_MILLIS - 100, FIXED_CLOCK)).isEqualTo("few seconds ago");
+    assertThat(DateUtils.toAge(FIXED_NOW_MILLIS - 65_000, FIXED_CLOCK)).isEqualTo("1 minute ago");
+    assertThat(DateUtils.toAge(FIXED_NOW_MILLIS - 3_600_000 - 100_000, FIXED_CLOCK)).isEqualTo("1 hour ago");
+    assertThat(DateUtils.toAge(FIXED_NOW_MILLIS - 2 * 3_600_000 - 100_000, FIXED_CLOCK)).isEqualTo("2 hours ago");
+    assertThat(DateUtils.toAge(FIXED_NOW_MILLIS - 24 * 3_600_000 - 100_000, FIXED_CLOCK)).isEqualTo("1 day ago");
+    assertThat(DateUtils.toAge(LocalDateTime.now(FIXED_CLOCK).minusMonths(5)
       .atZone(ZoneId.systemDefault())
       .toInstant()
-      .toEpochMilli())).isEqualTo("5 months ago");
-    assertThat(DateUtils.toAge(LocalDateTime.now(ZoneId.systemDefault()).minusMonths(15)
+      .toEpochMilli(), FIXED_CLOCK)).isEqualTo("5 months ago");
+    assertThat(DateUtils.toAge(LocalDateTime.now(FIXED_CLOCK).minusMonths(15)
       .atZone(ZoneId.systemDefault())
       .toInstant()
-      .toEpochMilli())).isEqualTo("1 year ago");
+      .toEpochMilli(), FIXED_CLOCK)).isEqualTo("1 year ago");
   }
 }

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -24,7 +24,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Clock;
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,7 +88,7 @@ import static utils.AnalysisUtils.analyzeFileAndGetIssue;
 import static utils.AnalysisUtils.analyzeFileAndGetIssues;
 
 class TelemetryMediumTests {
-  private static final Clock CLOCK = Clock.systemDefaultZone();
+  private static final Clock CLOCK = Clock.fixed(Instant.parse("2026-05-07T10:00:00Z"), ZoneId.systemDefault());
 
   @RegisterExtension
   static WireMockExtension telemetryEndpointMock = WireMockExtension.newInstance()

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -198,7 +198,7 @@ class TelemetryMediumTests {
     await().untilAsserted(() -> assertThat(backend.telemetryFileContent().enabled()).isTrue());
 
     // Emulate another process has disabled telemetry
-    var telemetryLocalStorageManager = new TelemetryLocalStorageManager(backend.telemetryFilePath(), mock(InitializeParams.class));
+    var telemetryLocalStorageManager = new TelemetryLocalStorageManager(backend.telemetryFilePath(), mock(InitializeParams.class), CLOCK);
     telemetryLocalStorageManager.tryUpdateAtomically(data -> data.setEnabled(false));
 
     assertThat(backend.getTelemetryService().getStatus().get().isEnabled()).isFalse();

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -23,8 +23,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -86,6 +86,7 @@ import static utils.AnalysisUtils.analyzeFileAndGetIssue;
 import static utils.AnalysisUtils.analyzeFileAndGetIssues;
 
 class TelemetryMediumTests {
+  private static final Clock CLOCK = Clock.systemDefaultZone();
 
   @RegisterExtension
   static WireMockExtension telemetryEndpointMock = WireMockExtension.newInstance()
@@ -651,7 +652,7 @@ class TelemetryMediumTests {
   @SonarLintTest
   void it_should_apply_telemetry_migration(SonarLintTestHarness harness) throws ExecutionException, InterruptedException {
     var backend = harness.newBackend()
-      .withTelemetryMigration(new TelemetryMigrationDto(OffsetDateTime.now(ZoneId.systemDefault()), 42, false))
+      .withTelemetryMigration(new TelemetryMigrationDto(OffsetDateTime.now(CLOCK), 42, false))
       .withTelemetryEnabled()
       .start();
 

--- a/medium-tests/src/test/java/mediumtest/promotion/CampaignMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/promotion/CampaignMediumTests.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -467,7 +468,7 @@ class CampaignMediumTests {
 
   private void saveTelemetryInstallTime(String productKey, int daysAgo) {
     var telemetryPath = getTelemetryPath(productKey);
-    TelemetryLocalStorageManager telemetryStorageManager = new TelemetryLocalStorageManager(telemetryPath, mock(InitializeParams.class));
+    TelemetryLocalStorageManager telemetryStorageManager = new TelemetryLocalStorageManager(telemetryPath, mock(InitializeParams.class), Clock.systemDefaultZone());
     telemetryStorageManager.tryUpdateAtomically(data -> data.setInstallTime(OffsetDateTime.now(ZoneId.systemDefault()).minusDays(daysAgo)));
   }
 

--- a/medium-tests/src/test/java/mediumtest/promotion/CampaignMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/promotion/CampaignMediumTests.java
@@ -469,7 +469,7 @@ class CampaignMediumTests {
   private void saveTelemetryInstallTime(String productKey, int daysAgo) {
     var telemetryPath = getTelemetryPath(productKey);
     TelemetryLocalStorageManager telemetryStorageManager = new TelemetryLocalStorageManager(telemetryPath, mock(InitializeParams.class), Clock.systemDefaultZone());
-    telemetryStorageManager.tryUpdateAtomically(data -> data.setInstallTime(OffsetDateTime.now(ZoneId.systemDefault()).minusDays(daysAgo)));
+    telemetryStorageManager.tryUpdateAtomically(data -> data.setInstallTime(OffsetDateTime.now(Clock.systemDefaultZone()).minusDays(daysAgo)));
   }
 
   private Path getCampaignsPath(String productKey) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Dependency Injection:**
  - Injected `Clock` into `TelemetryLocalStorage`, `TelemetryLocalStorageManager`, `TelemetryManager`, and `CampaignService` to remove dependence on system time.
  - Added a `Clock` bean to the core Spring application context.
- **Refactoring:**
  - Updated `DateUtils.toAge` and `TelemetryUtils.isGracePeriodElapsedAndDayChanged` with `Clock`-aware overloads for consistent time handling.
  - Modified `TelemetryLocalStorage` methods to use an injectable `Clock` instead of `ZoneId.systemDefault()`.
  - Introduced a `postDeserialize` hook in `FileStorageManager` to correctly re-inject `Clock` into `TelemetryLocalStorage` after deserialization.
- **Testing:**
  - Replaced `ZoneId.systemDefault()` with a fixed `Clock` in telemetry unit and medium tests to ensure deterministic results.


<sub>This will update automatically on new commits.</sub>