### PR TITLE
SLCORE-2400 SLCORE-2401 Support cancellation and return file patterns

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/sca/ScaAnalysisManager.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/sca/ScaAnalysisManager.java
@@ -1,0 +1,272 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.sca;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import jakarta.annotation.PreDestroy;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+import org.sonarsource.sonarlint.core.commons.util.FailSafeExecutors;
+import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcClient;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.AnalyzeDependencyRiskProjectParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.AnalyzeDependencyRiskProjectResponse;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.AnalyzeDependencyRiskProjectTrigger;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.CancelDependencyRiskAnalysisResponse;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.DependencyRiskAnalysisStatusResponse;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.sca.DidChangeDependencyRiskAnalysisStatusParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.sca.DidChangeDependencyRiskAnalysisStatusParams.DependencyRiskAnalysisStatus;
+
+public class ScaAnalysisManager {
+  private static final SonarLintLogger LOG = SonarLintLogger.get();
+
+  private final ScaProjectAnalysisService scaProjectAnalysisService;
+  private final SonarLintRpcClient client;
+  private final ExecutorService executorService = FailSafeExecutors.newSingleThreadExecutor("sonarlint-sca-analysis");
+  private final AtomicReference<RunningAnalysis> runningAnalysis = new AtomicReference<>();
+
+  public ScaAnalysisManager(ScaProjectAnalysisService scaProjectAnalysisService, SonarLintRpcClient client) {
+    this.scaProjectAnalysisService = scaProjectAnalysisService;
+    this.client = client;
+  }
+
+  public AnalyzeDependencyRiskProjectResponse analyzeProject(AnalyzeDependencyRiskProjectParams params) {
+    while (true) {
+      var currentAnalysis = runningAnalysis.get();
+      if (currentAnalysis != null) {
+        return handleAlreadyRunningAnalysis(params, currentAnalysis);
+      }
+      var newAnalysis = new RunningAnalysis(params);
+      if (runningAnalysis.compareAndSet(null, newAnalysis)) {
+        return runAnalysisAndAwait(newAnalysis);
+      }
+    }
+  }
+
+  public DependencyRiskAnalysisStatusResponse getStatus() {
+    var analysis = runningAnalysis.get();
+    if (analysis == null) {
+      return new DependencyRiskAnalysisStatusResponse(false, null, null, false);
+    }
+    return new DependencyRiskAnalysisStatusResponse(true, analysis.configurationScopeId(), analysis.trigger(), analysis.isRerunRequested());
+  }
+
+  public CancelDependencyRiskAnalysisResponse cancelAnalysis(String configurationScopeId) {
+    var analysis = runningAnalysis.get();
+    if (analysis == null || (configurationScopeId != null && !analysis.configurationScopeId().equals(configurationScopeId))) {
+      return new CancelDependencyRiskAnalysisResponse(false);
+    }
+    analysis.clearRerunRequested();
+    return new CancelDependencyRiskAnalysisResponse(analysis.cancel());
+  }
+
+  @PreDestroy
+  public void shutdown() {
+    var analysis = runningAnalysis.get();
+    if (analysis != null) {
+      analysis.cancel();
+    }
+    if (!MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS)) {
+      LOG.warn("Unable to stop SCA analysis executor service in a timely manner");
+    }
+  }
+
+  private AnalyzeDependencyRiskProjectResponse handleAlreadyRunningAnalysis(AnalyzeDependencyRiskProjectParams params, RunningAnalysis currentAnalysis) {
+    if (params.getTrigger() == AnalyzeDependencyRiskProjectTrigger.AUTOMATIC) {
+      currentAnalysis.requestRerun(params);
+    }
+    return currentAnalysis.awaitResult();
+  }
+
+  private AnalyzeDependencyRiskProjectResponse runAnalysisAndAwait(RunningAnalysis analysis) {
+    analysis.start();
+    notifyStatus(analysis, DependencyRiskAnalysisStatus.STARTED, false, null);
+    return analysis.awaitResult();
+  }
+
+  private void onAnalysisCompleted(RunningAnalysis analysis, Throwable error) {
+    if (!runningAnalysis.compareAndSet(analysis, null)) {
+      return;
+    }
+    var status = toStatus(error);
+    notifyStatus(analysis, status, analysis.isRerunRequested(), toMessage(error));
+    var rerunParams = analysis.consumeRerunParams();
+    if (status != DependencyRiskAnalysisStatus.CANCELLED && rerunParams != null) {
+      startBackgroundAnalysis(rerunParams);
+    }
+  }
+
+  private void startBackgroundAnalysis(AnalyzeDependencyRiskProjectParams params) {
+    while (runningAnalysis.get() == null) {
+      var newAnalysis = new RunningAnalysis(params);
+      if (runningAnalysis.compareAndSet(null, newAnalysis)) {
+        newAnalysis.start();
+        notifyStatus(newAnalysis, DependencyRiskAnalysisStatus.STARTED, false, null);
+        return;
+      }
+    }
+  }
+
+  private static DependencyRiskAnalysisStatus toStatus(Throwable error) {
+    if (error == null) {
+      return DependencyRiskAnalysisStatus.COMPLETED;
+    }
+    if (isCancellation(error)) {
+      return DependencyRiskAnalysisStatus.CANCELLED;
+    }
+    return DependencyRiskAnalysisStatus.FAILED;
+  }
+
+  private static boolean isCancellation(Throwable error) {
+    var current = error;
+    while (current != null) {
+      if (current instanceof CancellationException || current instanceof InterruptedException) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private static String toMessage(Throwable error) {
+    if (error == null || isCancellation(error)) {
+      return null;
+    }
+    var cause = unwrap(error);
+    return cause.getMessage();
+  }
+
+  private static RuntimeException toRuntimeException(Throwable error) {
+    var cause = unwrap(error);
+    if (cause instanceof RuntimeException runtimeException) {
+      return runtimeException;
+    }
+    return new CompletionException(cause);
+  }
+
+  private static Throwable unwrap(Throwable error) {
+    var current = error;
+    while (current instanceof CompletionException && current.getCause() != null) {
+      current = current.getCause();
+    }
+    return current;
+  }
+
+  private void notifyStatus(RunningAnalysis analysis, DependencyRiskAnalysisStatus status, boolean rerunRequested, String message) {
+    try {
+      client.didChangeDependencyRiskAnalysisStatus(new DidChangeDependencyRiskAnalysisStatusParams(analysis.configurationScopeId(), status, analysis.trigger(), rerunRequested, message));
+    } catch (Exception e) {
+      LOG.warn("Unable to notify client of SCA analysis status change", e);
+    }
+  }
+
+  private class RunningAnalysis {
+    private final AnalyzeDependencyRiskProjectParams params;
+    private final CompletableFuture<AnalyzeDependencyRiskProjectResponse> result = new CompletableFuture<>();
+    private volatile Future<?> future;
+    private volatile AnalyzeDependencyRiskProjectParams rerunParams;
+    private volatile boolean started;
+    private volatile boolean cancellationRequested;
+
+    private RunningAnalysis(AnalyzeDependencyRiskProjectParams params) {
+      this.params = params;
+    }
+
+    private void start() {
+      future = executorService.submit(() -> {
+        started = true;
+        Throwable error = null;
+        try {
+          var response = scaProjectAnalysisService.analyzeProject(params);
+          if (cancellationRequested) {
+            error = new CancellationException();
+            result.completeExceptionally(error);
+          } else {
+            result.complete(response);
+          }
+        } catch (Throwable t) {
+          error = t;
+          result.completeExceptionally(t);
+        } finally {
+          onAnalysisCompleted(this, error);
+        }
+      });
+      if (future.isCancelled()) {
+        var error = new CancellationException();
+        result.completeExceptionally(error);
+        onAnalysisCompleted(this, error);
+      }
+    }
+
+    private AnalyzeDependencyRiskProjectResponse awaitResult() {
+      try {
+        return result.join();
+      } catch (CompletionException e) {
+        throw toRuntimeException(e);
+      }
+    }
+
+    private boolean cancel() {
+      var currentFuture = future;
+      if (currentFuture == null) {
+        return false;
+      }
+      cancellationRequested = true;
+      var cancelled = currentFuture.cancel(true);
+      if (cancelled && !started) {
+        var error = new CancellationException();
+        result.completeExceptionally(error);
+        onAnalysisCompleted(this, error);
+      }
+      return cancelled;
+    }
+
+    private String configurationScopeId() {
+      return params.getConfigurationScopeId();
+    }
+
+    private AnalyzeDependencyRiskProjectTrigger trigger() {
+      return params.getTrigger();
+    }
+
+    private boolean isRerunRequested() {
+      return rerunParams != null;
+    }
+
+    private void requestRerun(AnalyzeDependencyRiskProjectParams params) {
+      rerunParams = params;
+    }
+
+    private AnalyzeDependencyRiskProjectParams consumeRerunParams() {
+      var params = rerunParams;
+      rerunParams = null;
+      return params;
+    }
+
+    private void clearRerunRequested() {
+      rerunParams = null;
+    }
+  }
+}

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientDelegate.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcClient;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.config.binding.BindingSuggestionDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.plugin.PluginStatusDto;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.AnalyzeDependencyRiskProjectTrigger;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.DependencyRiskDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.tracking.TaintVulnerabilityDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.binding.AssistBindingParams;
@@ -59,6 +60,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.message.ShowSoonUnsupp
 import org.sonarsource.sonarlint.core.rpc.protocol.client.plugin.DidSkipLoadingPluginParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.progress.ReportProgressParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.progress.StartProgressParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.sca.DidChangeDependencyRiskAnalysisStatusParams.DependencyRiskAnalysisStatus;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.TelemetryClientLiveAttributesResponse;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
@@ -205,6 +207,10 @@ public interface SonarLintRpcClientDelegate {
 
   default void didChangeDependencyRisks(String configurationScopeId, Set<UUID> closedDependencyRiskIds, List<DependencyRiskDto> addedDependencyRisks,
     List<DependencyRiskDto> updatedDependencyRisks) {
+  }
+
+  default void didChangeDependencyRiskAnalysisStatus(String configurationScopeId, DependencyRiskAnalysisStatus status, AnalyzeDependencyRiskProjectTrigger trigger,
+    boolean rerunRequested, @Nullable String message) {
   }
 
   default Path getBaseDir(String configurationScopeId) throws ConfigScopeNotFoundException {

--- a/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
+++ b/client/rpc-java-client/src/main/java/org/sonarsource/sonarlint/core/rpc/client/SonarLintRpcClientImpl.java
@@ -84,6 +84,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.plugin.DidSkipLoadingP
 import org.sonarsource.sonarlint.core.rpc.protocol.client.progress.ReportProgressParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.progress.StartProgressParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.promotion.PromoteExtraEnabledLanguagesInConnectedModeParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.sca.DidChangeDependencyRiskAnalysisStatusParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.sca.DidChangeDependencyRisksParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.sync.DidSynchronizeConfigurationScopeParams;
@@ -364,6 +365,12 @@ public class SonarLintRpcClientImpl implements SonarLintRpcClient {
   public void didChangeDependencyRisks(DidChangeDependencyRisksParams params) {
     notify(() -> delegate.didChangeDependencyRisks(params.getConfigurationScopeId(), params.getClosedDependencyRiskIds(), params.getAddedDependencyRisks(),
       params.getUpdatedDependencyRisks()));
+  }
+
+  @Override
+  public void didChangeDependencyRiskAnalysisStatus(DidChangeDependencyRiskAnalysisStatusParams params) {
+    notify(() -> delegate.didChangeDependencyRiskAnalysisStatus(params.getConfigurationScopeId(), params.getStatus(), params.getTrigger(), params.isRerunRequested(),
+      params.getMessage()));
   }
 
   @Override

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/SonarLintRpcClient.java
@@ -76,6 +76,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.plugin.DidSkipLoadingP
 import org.sonarsource.sonarlint.core.rpc.protocol.client.progress.ReportProgressParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.progress.StartProgressParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.promotion.PromoteExtraEnabledLanguagesInConnectedModeParams;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.sca.DidChangeDependencyRiskAnalysisStatusParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.sca.DidChangeDependencyRisksParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.sync.DidSynchronizeConfigurationScopeParams;
@@ -276,6 +277,10 @@ public interface SonarLintRpcClient {
    */
   @JsonNotification
   void didChangeDependencyRisks(DidChangeDependencyRisksParams params);
+
+  @JsonNotification
+  default void didChangeDependencyRiskAnalysisStatus(DidChangeDependencyRiskAnalysisStatusParams params) {
+  }
 
   @JsonNotification
   void noBindingSuggestionFound(NoBindingSuggestionFoundParams params);

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/AnalyzeDependencyRiskProjectTrigger.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/AnalyzeDependencyRiskProjectTrigger.java
@@ -1,0 +1,25 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.backend.sca;
+
+public enum AnalyzeDependencyRiskProjectTrigger {
+  MANUAL,
+  AUTOMATIC
+}

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/CancelDependencyRiskAnalysisParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/CancelDependencyRiskAnalysisParams.java
@@ -1,0 +1,40 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.backend.sca;
+
+import javax.annotation.Nullable;
+
+public class CancelDependencyRiskAnalysisParams {
+  @Nullable
+  private final String configurationScopeId;
+
+  public CancelDependencyRiskAnalysisParams() {
+    this(null);
+  }
+
+  public CancelDependencyRiskAnalysisParams(@Nullable String configurationScopeId) {
+    this.configurationScopeId = configurationScopeId;
+  }
+
+  @Nullable
+  public String getConfigurationScopeId() {
+    return configurationScopeId;
+  }
+}

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/CancelDependencyRiskAnalysisResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/CancelDependencyRiskAnalysisResponse.java
@@ -1,0 +1,32 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.backend.sca;
+
+public class CancelDependencyRiskAnalysisResponse {
+  private final boolean cancelled;
+
+  public CancelDependencyRiskAnalysisResponse(boolean cancelled) {
+    this.cancelled = cancelled;
+  }
+
+  public boolean isCancelled() {
+    return cancelled;
+  }
+}

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/DependencyRiskAnalysisStatusResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/DependencyRiskAnalysisStatusResponse.java
@@ -1,0 +1,57 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.backend.sca;
+
+import javax.annotation.Nullable;
+
+public class DependencyRiskAnalysisStatusResponse {
+  private final boolean running;
+  @Nullable
+  private final String configurationScopeId;
+  @Nullable
+  private final AnalyzeDependencyRiskProjectTrigger trigger;
+  private final boolean rerunRequested;
+
+  public DependencyRiskAnalysisStatusResponse(boolean running, @Nullable String configurationScopeId, @Nullable AnalyzeDependencyRiskProjectTrigger trigger,
+    boolean rerunRequested) {
+    this.running = running;
+    this.configurationScopeId = configurationScopeId;
+    this.trigger = trigger;
+    this.rerunRequested = rerunRequested;
+  }
+
+  public boolean isRunning() {
+    return running;
+  }
+
+  @Nullable
+  public String getConfigurationScopeId() {
+    return configurationScopeId;
+  }
+
+  @Nullable
+  public AnalyzeDependencyRiskProjectTrigger getTrigger() {
+    return trigger;
+  }
+
+  public boolean isRerunRequested() {
+    return rerunRequested;
+  }
+}

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/DependencyRiskRpcService.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/DependencyRiskRpcService.java
@@ -40,6 +40,15 @@ public interface DependencyRiskRpcService {
   @JsonRequest
   CompletableFuture<AnalyzeDependencyRiskProjectResponse> analyzeProject(AnalyzeDependencyRiskProjectParams params);
 
+  @JsonRequest
+  CompletableFuture<DependencyRiskAnalysisStatusResponse> getAnalysisStatus(GetDependencyRiskAnalysisStatusParams params);
+
+  @JsonRequest
+  CompletableFuture<CancelDependencyRiskAnalysisResponse> cancelAnalysis(CancelDependencyRiskAnalysisParams params);
+
+  @JsonRequest
+  CompletableFuture<DependencyRiskSupportedFilePatternsResponse> getSupportedFilePatterns();
+
     /**
    * <p> It changes a status of a Dependency Risk (SCA finding) that exists on the server. In detail, it is responsible for:
    * <ul>

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/DependencyRiskSupportedFilePatternsResponse.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/DependencyRiskSupportedFilePatternsResponse.java
@@ -1,0 +1,36 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.backend.sca;
+
+import java.util.List;
+
+public class DependencyRiskSupportedFilePatternsResponse {
+
+  private final List<String> patterns;
+
+  public DependencyRiskSupportedFilePatternsResponse(List<String> patterns) {
+    this.patterns = patterns;
+  }
+
+  public List<String> getPatterns() {
+    return patterns;
+  }
+
+}

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/GetDependencyRiskAnalysisStatusParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/backend/sca/GetDependencyRiskAnalysisStatusParams.java
@@ -1,0 +1,23 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.backend.sca;
+
+public class GetDependencyRiskAnalysisStatusParams {
+}

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/sca/DidChangeDependencyRiskAnalysisStatusParams.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/sca/DidChangeDependencyRiskAnalysisStatusParams.java
@@ -1,0 +1,69 @@
+/*
+ * SonarLint Core - RPC Protocol
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.rpc.protocol.client.sca;
+
+import javax.annotation.Nullable;
+import org.sonarsource.sonarlint.core.rpc.protocol.backend.sca.AnalyzeDependencyRiskProjectTrigger;
+
+public class DidChangeDependencyRiskAnalysisStatusParams {
+  private final String configurationScopeId;
+  private final DependencyRiskAnalysisStatus status;
+  private final AnalyzeDependencyRiskProjectTrigger trigger;
+  private final boolean rerunRequested;
+  @Nullable
+  private final String message;
+
+  public DidChangeDependencyRiskAnalysisStatusParams(String configurationScopeId, DependencyRiskAnalysisStatus status, AnalyzeDependencyRiskProjectTrigger trigger,
+    boolean rerunRequested, @Nullable String message) {
+    this.configurationScopeId = configurationScopeId;
+    this.status = status;
+    this.trigger = trigger;
+    this.rerunRequested = rerunRequested;
+    this.message = message;
+  }
+
+  public String getConfigurationScopeId() {
+    return configurationScopeId;
+  }
+
+  public DependencyRiskAnalysisStatus getStatus() {
+    return status;
+  }
+
+  public AnalyzeDependencyRiskProjectTrigger getTrigger() {
+    return trigger;
+  }
+
+  public boolean isRerunRequested() {
+    return rerunRequested;
+  }
+
+  @Nullable
+  public String getMessage() {
+    return message;
+  }
+
+  public enum DependencyRiskAnalysisStatus {
+    STARTED,
+    COMPLETED,
+    FAILED,
+    CANCELLED
+  }
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **SCA analysis orchestration:**
  - Added `ScaAnalysisManager` to manage lifecycle, cancellation, and status tracking for dependency risk analysis.
  - Implemented `cancelAnalysis` and `getAnalysisStatus` RPC endpoints to provide visibility and control over running jobs.
- **Support for analysis features:**
  - Added `getSupportedFilePatterns` to retrieve SCA scanner file patterns.
  - Included `AnalyzeDependencyRiskProjectTrigger` to distinguish between manual and automatic analysis requests.
- **Protocol updates:**
  - Introduced new RPC notifications and parameters for tracking status changes, including `DidChangeDependencyRiskAnalysisStatusParams`.

<sub>This will update automatically on new commits.</sub>