### PR TITLE
SLCORE-2421 Convert arguments to time zone-aware types before computing a duration between them

### DIFF
--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/DateUtils.java
@@ -19,9 +19,9 @@
  */
 package org.sonarsource.sonarlint.core.client.utils;
 
+import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 
 public class DateUtils {
@@ -31,8 +31,12 @@ public class DateUtils {
   }
 
   public static String toAge(long time) {
-    var creation = LocalDateTime.ofInstant(Instant.ofEpochMilli(time), ZoneId.systemDefault());
-    var now = LocalDateTime.now(ZoneId.systemDefault());
+    return toAge(time, Clock.systemDefaultZone());
+  }
+
+  static String toAge(long time, Clock clock) {
+    var creation = Instant.ofEpochMilli(time).atZone(clock.getZone());
+    var now = ZonedDateTime.now(clock);
 
     var years = ChronoUnit.YEARS.between(creation, now);
     if (years > 0) {

--- a/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/DateUtilsTests.java
+++ b/client/java-client-utils/src/test/java/org/sonarsource/sonarlint/core/client/utils/DateUtilsTests.java
@@ -19,28 +19,36 @@
  */
 package org.sonarsource.sonarlint.core.client.utils;
 
-import java.time.LocalDateTime;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class DateUtilsTests {
 
+  private static final ZoneId ZONE = ZoneId.of("UTC");
+  private static final Instant NOW = Instant.parse("2026-06-01T12:00:00Z");
+  private static final Clock CLOCK = Clock.fixed(NOW, ZONE);
+
   @Test
-  void testAge() {
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 100)).isEqualTo("few seconds ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 65_000)).isEqualTo("1 minute ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 3_600_000 - 100_000)).isEqualTo("1 hour ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 2 * 3_600_000 - 100_000)).isEqualTo("2 hours ago");
-    assertThat(DateUtils.toAge(System.currentTimeMillis() - 24 * 3_600_000 - 100_000)).isEqualTo("1 day ago");
-    assertThat(DateUtils.toAge(LocalDateTime.now(ZoneId.systemDefault()).minusMonths(5)
-      .atZone(ZoneId.systemDefault())
-      .toInstant()
-      .toEpochMilli())).isEqualTo("5 months ago");
-    assertThat(DateUtils.toAge(LocalDateTime.now(ZoneId.systemDefault()).minusMonths(15)
-      .atZone(ZoneId.systemDefault())
-      .toInstant()
-      .toEpochMilli())).isEqualTo("1 year ago");
+  void should_format_age_relative_to_clock() {
+    assertThat(toAge(NOW.minusMillis(100))).isEqualTo("few seconds ago");
+    assertThat(toAge(NOW.minusMillis(65_000))).isEqualTo("1 minute ago");
+    assertThat(toAge(NOW.minusMillis(3_600_000 + 100_000))).isEqualTo("1 hour ago");
+    assertThat(toAge(NOW.minusMillis(2 * 3_600_000 + 100_000))).isEqualTo("2 hours ago");
+    assertThat(toAge(NOW.minusMillis(24 * 3_600_000 + 100_000))).isEqualTo("1 day ago");
+    assertThat(toAge(now().minusMonths(5).toInstant())).isEqualTo("5 months ago");
+    assertThat(toAge(now().minusMonths(15).toInstant())).isEqualTo("1 year ago");
+  }
+
+  private static ZonedDateTime now() {
+    return ZonedDateTime.ofInstant(NOW, ZONE);
+  }
+
+  private static String toAge(Instant creation) {
+    return DateUtils.toAge(creation.toEpochMilli(), CLOCK);
   }
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Refactor:**
  - Introduce a testable `toAge(long, Clock)` method in `DateUtils` to replace static system calls.
  - Migrate time calculation to `ZonedDateTime` for proper time zone-aware duration handling.
- **Testing:**
  - Replace dynamic system clock tests with `Clock.fixed` for predictable test outcomes.
  - Update `DateUtilsTests` to use the injected clock for verifying relative time formatting.

<sub>This will update automatically on new commits.</sub>