### PR TITLE
SLCORE-2423 Fix shadow scans

### DIFF
--- a/.github/workflows/shadow_scans.yml
+++ b/.github/workflows/shadow_scans.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   scan:
-    runs-on: sonar-xs-public
+    runs-on: sonar-m
     name: Scan on shadow platforms
     permissions:
       id-token: write

--- a/.github/workflows/shadow_scans.yml
+++ b/.github/workflows/shadow_scans.yml
@@ -27,6 +27,14 @@ jobs:
           artifactory-reader-role: private-reader
           artifactory-deployer-role: qa-deployer
           scanner-java-opts: '-Xmx2g'
+      - name: Upload failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: shadow-scans-test-report
+          path: |
+            **/target/surefire-reports/**
+            **/target/failsafe-reports/**
       - name: Run IRIS sync
         uses: SonarSource/unified-dogfooding-actions/run-iris@54cee68ff08f10645c757675c59d232063e0b947 # 1.0.0
         with:

--- a/.github/workflows/shadow_scans.yml
+++ b/.github/workflows/shadow_scans.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           version: 2026.4.11
+      - name: Install dotnet for Omnisharp tests
+        run: |
+          mise use dotnet@8
       - uses: SonarSource/ci-github-actions/build-maven@9456e3aab93a6c6d0c459b977aaa594bda102e29 # 1.4.0 # dogfood
         with:
           maven-args: -Dcommercial -Dsonar.coverage.jacoco.xmlReportPaths=${{ github.workspace }}/report-aggregate/target/site/jacoco-aggregate/jacoco.xml

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/BindingSuggestionProviderTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/BindingSuggestionProviderTests.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -92,6 +93,13 @@ class BindingSuggestionProviderTests {
   void setup() {
     when(sonarProjectsCache.getTextSearchIndex(anyString(), any(SonarLintCancelMonitor.class))).thenReturn(new TextSearchIndex<>());
     logTester.clear();
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Drain the provider's async executor so a queued computation from this test cannot log into the
+    // (static, shared) logTester during a later test - which otherwise breaks assertions on empty logs.
+    underTest.shutdown();
   }
 
   @Test

--- a/medium-tests/src/test/java/mediumtest/EffectiveRulesMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/EffectiveRulesMediumTests.java
@@ -125,7 +125,7 @@ class EffectiveRulesMediumTests {
 
     var futureResponse = backend.getRulesService().getEffectiveRuleDetails(new GetEffectiveRuleDetailsParams("scopeId", "python:SXXXX", null));
 
-    assertThat(futureResponse).failsWithin(1, TimeUnit.SECONDS)
+    assertThat(futureResponse).failsWithin(1, TimeUnit.MINUTES)
       .withThrowableOfType(ExecutionException.class)
       .withCauseInstanceOf(ResponseErrorException.class)
       .withMessageContaining("Could not find rule 'python:SXXXX' in embedded rules");
@@ -237,7 +237,7 @@ class EffectiveRulesMediumTests {
 
     var futureResponse = backend.getRulesService().getEffectiveRuleDetails(new GetEffectiveRuleDetailsParams("scopeId", "python:S139", null));
 
-    assertThat(futureResponse).failsWithin(1, TimeUnit.SECONDS)
+    assertThat(futureResponse).failsWithin(1, TimeUnit.MINUTES)
       .withThrowableOfType(ExecutionException.class)
       .withCauseInstanceOf(ResponseErrorException.class)
       .withMessageContaining("Connection 'connectionId' is not valid");
@@ -254,7 +254,7 @@ class EffectiveRulesMediumTests {
 
     var futureResponse = backend.getRulesService().getEffectiveRuleDetails(new GetEffectiveRuleDetailsParams("scopeId", "python:S139", null));
 
-    assertThat(futureResponse).failsWithin(3, TimeUnit.SECONDS)
+    assertThat(futureResponse).failsWithin(1, TimeUnit.MINUTES)
       .withThrowableOfType(ExecutionException.class)
       .havingCause()
       .isInstanceOfSatisfying(ResponseErrorException.class, ex -> {

--- a/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/OpenIssueInIdeMediumTests.java
@@ -367,7 +367,7 @@ class OpenIssueInIdeMediumTests {
     var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
     assertThat(response.statusCode()).isEqualTo(400);
-    verify(client).showMessage(MessageType.ERROR,
+    verify(client, timeout(2000)).showMessage(MessageType.ERROR,
       "Invalid request to SonarQube backend. The 'server' parameter should not be SonarQube Cloud URL, use it only to specify URL of a SonarQube Server.");
   }
 
@@ -384,7 +384,7 @@ class OpenIssueInIdeMediumTests {
     var response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
 
     assertThat(response.statusCode()).isEqualTo(400);
-    verify(client).showMessage(MessageType.ERROR,
+    verify(client, timeout(2000)).showMessage(MessageType.ERROR,
       "Invalid request to SonarQube backend. The 'server' parameter should not be SonarQube Cloud URL, use it only to specify URL of a SonarQube Server.");
   }
 

--- a/medium-tests/src/test/java/mediumtest/promotion/CampaignMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/promotion/CampaignMediumTests.java
@@ -92,12 +92,11 @@ class CampaignMediumTests {
       .start(client);
 
     var campaignsFile = getCampaignsPath(DEFAULT_KEY);
-    await().until(() -> Files.exists(campaignsFile));
-    assertThat(getCampaigns(campaignsFile))
+    await().untilAsserted(() -> assertThat(getCampaigns(campaignsFile))
       .hasSize(1)
       .contains(Map.entry(
         "feedback_2026_01",
-        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "IGNORE")));
+        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "IGNORE"))));
   }
 
   @SonarLintTest
@@ -109,12 +108,11 @@ class CampaignMediumTests {
       .start(client);
 
     var campaignsFile = getCampaignsPath(DEFAULT_KEY);
-    await().until(() -> Files.exists(campaignsFile));
-    assertThat(getCampaigns(campaignsFile))
+    await().untilAsserted(() -> assertThat(getCampaigns(campaignsFile))
       .hasSize(1)
       .contains(Map.entry(
         "feedback_2026_01",
-        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "IGNORE")));
+        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "IGNORE"))));
     verify(client, never()).openUrlInBrowser(any());
   }
 
@@ -135,12 +133,11 @@ class CampaignMediumTests {
       .start(client);
 
     var campaignsFile = getCampaignsPath(DEFAULT_KEY);
-    await().until(() -> Files.exists(campaignsFile));
-    assertThat(getCampaigns(campaignsFile))
+    await().untilAsserted(() -> assertThat(getCampaigns(campaignsFile))
       .hasSize(1)
       .contains(Map.entry(
         "feedback_2026_01",
-        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "IGNORE")));
+        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "IGNORE"))));
     verify(client, never()).openUrlInBrowser(any());
   }
 
@@ -231,12 +228,11 @@ class CampaignMediumTests {
       .start(client);
 
     var campaignsFile = getCampaignsPath(DEFAULT_KEY);
-    await().until(() -> Files.exists(campaignsFile));
-    assertThat(getCampaigns(campaignsFile))
+    await().untilAsserted(() -> assertThat(getCampaigns(campaignsFile))
       .hasSize(1)
       .contains(Map.entry(
         "feedback_2026_01",
-        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "MAYBE_LATER")));
+        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "MAYBE_LATER"))));
     verify(client, never()).openUrlInBrowser(any());
   }
 
@@ -253,19 +249,18 @@ class CampaignMediumTests {
       .start(client);
 
     var campaignsFile = getCampaignsPath(DEFAULT_KEY);
-    await().until(() -> Files.exists(campaignsFile));
-    assertThat(getCampaigns(campaignsFile))
+    await().untilAsserted(() -> assertThat(getCampaigns(campaignsFile))
       .hasSize(1)
       .contains(Map.entry(
         "feedback_2026_01",
-        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "LOVE_IT")));
+        new CampaignsLocalStorage.Campaign("feedback_2026_01", LocalDate.now(ZoneId.systemDefault()), "LOVE_IT"))));
 
     ArgumentCaptor<List<MessageActionItem>> actionsArgumentCaptor = ArgumentCaptor.forClass(List.class);
     var messageTypeCaptor = ArgumentCaptor.forClass(MessageType.class);
     var messageCaptor = ArgumentCaptor.forClass(String.class);
     var openInBrowserCaptor = ArgumentCaptor.forClass(URL.class);
 
-    verify(client, times(2)).showMessageRequest(messageTypeCaptor.capture(),
+    verify(client, timeout(2000).times(2)).showMessageRequest(messageTypeCaptor.capture(),
       messageCaptor.capture(),
       actionsArgumentCaptor.capture());
     // showMessageRequest will be called twice - once for the feedback, and second time for the community fallback
@@ -275,7 +270,7 @@ class CampaignMediumTests {
     assertThat(actionsArgumentCaptor.getAllValues().get(1)).hasSize(1);
     assertThat(actionsArgumentCaptor.getAllValues().get(1).get(0)).extracting(MessageActionItem::getKey, MessageActionItem::getDisplayText, MessageActionItem::isPrimaryAction)
       .containsExactly("OPEN_COMMUNITY", "Open Community Forum", true);
-    verify(client, times(1)).openUrlInBrowser(openInBrowserCaptor.capture());
+    verify(client, timeout(2000).times(1)).openUrlInBrowser(openInBrowserCaptor.capture());
     assertThat(openInBrowserCaptor.getValue()).hasToString("https://community.sonarsource.com/c/sl/11");
   }
 

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintTestRpcServer.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/SonarLintTestRpcServer.java
@@ -78,12 +78,14 @@ public class SonarLintTestRpcServer implements SonarLintRpcServer {
   private final PipedInputStream clientToServerInputStream;
   private final PipedOutputStream serverToClientOutputStream;
   private final JsonRpcSpyInputStream serverToClientInputStream;
+  private final SonarLintRpcClientDelegate client;
   private Path userHome;
   private Path workDir;
   private Path storageRoot;
   private String productKey;
 
   public SonarLintTestRpcServer(SonarLintRpcClientDelegate client) throws IOException {
+    this.client = client;
     clientToServerOutputStream = new JsonRpcSpyOutputStream();
     clientToServerInputStream = new PipedInputStream(clientToServerOutputStream);
 
@@ -94,6 +96,11 @@ public class SonarLintTestRpcServer implements SonarLintRpcServer {
     this.clientLauncher = new ClientJsonRpcLauncher(serverToClientInputStream, clientToServerOutputStream, client);
     this.serverUsingRpc = clientLauncher.getServerProxy();
     this.serverUsingJava = serverLauncher.getServer();
+  }
+
+  /** The client delegate this backend was started with (e.g. a {@code FakeSonarLintRpcClient} in medium tests). */
+  public SonarLintRpcClientDelegate getClient() {
+    return client;
   }
 
   @Override

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/junit5/SonarLintTestHarness.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/junit5/SonarLintTestHarness.java
@@ -28,6 +28,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -36,7 +37,8 @@ import org.sonarsource.sonarlint.core.test.utils.SonarLintBackendFixture;
 import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.server.ServerFixture;
 
-public class SonarLintTestHarness extends TypeBasedParameterResolver<SonarLintTestHarness> implements BeforeAllCallback, AfterEachCallback, AfterAllCallback {
+public class SonarLintTestHarness extends TypeBasedParameterResolver<SonarLintTestHarness>
+  implements BeforeAllCallback, AfterTestExecutionCallback, AfterEachCallback, AfterAllCallback {
   private static final Logger LOG = Logger.getLogger(SonarLintTestHarness.class.getName());
   private static final long SHUTDOWN_TIMEOUT_SECONDS = 10;
 
@@ -58,6 +60,32 @@ public class SonarLintTestHarness extends TypeBasedParameterResolver<SonarLintTe
   public void afterAll(ExtensionContext context) {
     if (isStatic) {
       shutdownAll();
+    }
+  }
+
+  @Override
+  public void afterTestExecution(ExtensionContext context) {
+    // Runs before afterEach (which shuts the backends down), so the captured client logs are still available.
+    // On failure, dump them to stdout so they are retained in the Surefire report instead of being discarded.
+    if (context.getExecutionException().isPresent()) {
+      dumpBackendLogs(context);
+    }
+  }
+
+  // Stdout is intentional here: on failure the captured backend logs must be retained in the Surefire
+  // report (and the uploaded CI artifact). The test logback configuration defines no console appender,
+  // so routing through a logger would silently drop them - hence the deliberate System.out use.
+  @SuppressWarnings("java:S106")
+  private void dumpBackendLogs(ExtensionContext context) {
+    var testName = context.getDisplayName();
+    for (var i = 0; i < backends.size(); i++) {
+      var client = backends.get(i).getClient();
+      if (client instanceof SonarLintBackendFixture.FakeSonarLintRpcClient fakeClient) {
+        var dump = new StringBuilder("===== BACKEND LOGS (backend #" + i + ") for failed test: " + testName + " =====\n");
+        fakeClient.getLogs().forEach(log -> dump.append(log).append('\n'));
+        dump.append("===== END BACKEND LOGS (backend #").append(i).append(") =====");
+        System.out.println(dump);
+      }
     }
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Environment and Infrastructure:**
  - Upgraded CI runner from `sonar-xs-public` to `sonar-m` for increased memory and CPU capacity.
  - Installed `dotnet@8` via `mise` in the `shadow_scans.yml` workflow to support OmniSharp tests.
- **Diagnostics and Monitoring:**
  - Implemented automatic dumping of backend logs to stdout in `SonarLintTestHarness` when a test fails.
  - Added `upload-artifact` step to `shadow_scans.yml` to persist `surefire` and `failsafe` reports upon failure.
- **Test Infrastructure:**
  - Added `getClient()` to `SonarLintTestRpcServer` to allow test hooks access to client-side diagnostics.
- **Test Stability:**
  - Refactored `CampaignMediumTests` to use `await().untilAsserted` for more reliable state verification.
  - Added `timeout(2000)` to `verify` calls in `OpenIssueInIdeMediumTests` to address intermittent race conditions.
  - Added `tearDown` to `BindingSuggestionProviderTests` to drain async executors and prevent cross-test log contamination.

<sub>This will update automatically on new commits.</sub>