### PR TITLE
SLCORE-2430 Re-enable SQS DEV IT axis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -200,9 +200,9 @@ jobs:
             sc: true
             sc_token_path: sonarcloud-it-US
             region: US
-#          - name: SQDogfood
-#            sq_version: DEV
-#            category: "-DexcludedGroups=SonarCloud"
+          - name: SQDogfood
+            sq_version: DEV
+            category: "-DexcludedGroups=SonarCloud"
           - name: SQLatest
             sq_version: LATEST_RELEASE
             category: "-DexcludedGroups=SonarCloud"


### PR DESCRIPTION
----
## Summary by Gitar

- **CI/CD configuration:**
  - Uncommented the `SQDogfood` integration test axis in `.github/workflows/build.yml` to re-enable SQS DEV IT checks.

<sub>This will update automatically on new commits.</sub>