### PR TITLE
SLCORE-2313 Avoid concurrent modification for file exclusions

### DIFF
--- a/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/command/AnalyzeCommandTest.java
+++ b/backend/analysis-engine/src/test/java/org/sonarsource/sonarlint/core/analysis/command/AnalyzeCommandTest.java
@@ -64,7 +64,6 @@ class AnalyzeCommandTest {
     assertThat(cmd1.shouldCancelPost(cmd2)).isFalse();
   }
 
-
   @Test
   void if_should_cancel_task_in_queue_when_canceled() {
     var cmd = newAnalyzeCommand(Set.of(), Map.of());

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisService.java
@@ -535,13 +535,14 @@ public class AnalysisService {
 
   public CompletableFuture<AnalysisResult> scheduleAnalysis(String configurationScopeId, UUID analysisId, Set<URI> files, Map<String, String> extraProperties,
     boolean shouldFetchServerIssues, TriggerType triggerType, SonarLintCancelMonitor cancelChecker) {
+    var filesSnapshot = Set.copyOf(files);
     var rawIssues = new ArrayList<RawIssue>();
     var trace = newAnalysisTrace();
     var analysisTask = new AnalyzeCommand(configurationScopeId, analysisId, triggerType,
-      () -> getAnalysisConfigForEngine(configurationScopeId, files, extraProperties, false, triggerType, trace),
+      () -> getAnalysisConfigForEngine(configurationScopeId, filesSnapshot, extraProperties, false, triggerType, trace),
       issue -> streamIssue(configurationScopeId, analysisId, rawIssues, issue), trace, cancelChecker,
       taskManager, inputFiles -> analysisStarted(configurationScopeId, analysisId, inputFiles), () -> analysisReadinessByConfigScopeId.getOrDefault(configurationScopeId, false),
-      files, extraProperties);
+      filesSnapshot, extraProperties);
     return schedule(configurationScopeId, analysisTask, analysisId, rawIssues, shouldFetchServerIssues, trace);
   }
 
@@ -606,12 +607,13 @@ public class AnalysisService {
 
   private AnalyzeCommand getAnalyzeCommand(String configurationScopeId, Set<URI> files, ArrayList<RawIssue> rawIssues, boolean hotspotsOnly, TriggerType triggerType,
     UUID analysisId) {
+    var filesSnapshot = Set.copyOf(files);
     var trace = newAnalysisTrace();
     return new AnalyzeCommand(configurationScopeId, analysisId, triggerType,
-      () -> getAnalysisConfigForEngine(configurationScopeId, files, Map.of(), hotspotsOnly, triggerType, trace),
+      () -> getAnalysisConfigForEngine(configurationScopeId, filesSnapshot, Map.of(), hotspotsOnly, triggerType, trace),
       issue -> streamIssue(configurationScopeId, analysisId, rawIssues, issue), trace,
       new SonarLintCancelMonitor(), taskManager, inputFiles -> analysisStarted(configurationScopeId, analysisId, inputFiles),
-      () -> analysisReadinessByConfigScopeId.getOrDefault(configurationScopeId, false), files, Map.of());
+      () -> analysisReadinessByConfigScopeId.getOrDefault(configurationScopeId, false), filesSnapshot, Map.of());
   }
 
   private void reanalyseOpenFiles(Predicate<String> configScopeFilter) {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/OpenFilesRepository.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/fs/OpenFilesRepository.java
@@ -20,7 +20,6 @@
 package org.sonarsource.sonarlint.core.fs;
 
 import java.net.URI;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,7 +32,7 @@ public class OpenFilesRepository {
    * @return true if the file was previously not considered open; it is a newly opened file
    */
   public boolean considerOpened(String configurationScopeId, URI fileUri) {
-    var openFiles = openFilesByConfigScopeId.computeIfAbsent(configurationScopeId, k -> new HashSet<>());
+    var openFiles = openFilesByConfigScopeId.computeIfAbsent(configurationScopeId, k -> ConcurrentHashMap.newKeySet());
     return openFiles.add(fileUri);
   }
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Concurrency improvements:**
  - Replaced `HashSet` with `ConcurrentHashMap.newKeySet()` in `OpenFilesRepository` to ensure thread-safe file tracking.
- **Analysis scheduling:**
  - Captured immutable snapshots of the `files` set in `AnalysisService` before scheduling tasks to prevent concurrent modification issues during analysis execution.

<sub>This will update automatically on new commits.</sub>