### PR TITLE
SLCORE-2485 Add Rust as a supported language

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/SonarLanguage.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/api/SonarLanguage.java
@@ -50,6 +50,7 @@ public enum SonarLanguage {
   PYTHON("py", SonarPlugin.PYTHON, "Python", new String[]{".py"}, "sonar.python.file.suffixes"),
   RPG("rpg", SonarPlugin.RPG, "RPG", new String[]{".rpg", ".rpgle"}, "sonar.rpg.file.suffixes"),
   RUBY("ruby", SonarPlugin.RUBY, "Ruby", new String[]{".rb"}, "sonar.ruby.file.suffixes"),
+  RUST("rust", SonarPlugin.RUST, "Rust", new String[]{".rs"}, "sonar.rust.file.suffixes"),
   SCALA("scala", SonarPlugin.SCALA, "Scala", new String[]{".scala"}, "sonar.scala.file.suffixes"),
   SECRETS("secrets", SonarPlugin.TEXT, "Secrets", new String[0], "sonar.secrets.file.suffixes"),
   TEXT("text", SonarPlugin.TEXT, "Text", new String[0], "sonar.text.file.suffixes"),

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/plugins/SonarPlugin.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/plugins/SonarPlugin.java
@@ -47,6 +47,7 @@ public enum SonarPlugin implements SonarArtifact {
   PYTHON("python"),
   RPG("rpg"),
   RUBY("ruby"),
+  RUST("rustenterprise"),
   SCALA("sonarscala"),
   SONARLINT_OMNISHARP("omnisharp", Set.of(
     Dependency.onOneOf(CS_OSS, CSHARP_ENTERPRISE),

--- a/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/Language.java
+++ b/client/java-client-utils/src/main/java/org/sonarsource/sonarlint/core/client/utils/Language.java
@@ -41,6 +41,7 @@ public enum Language {
   PYTHON("Python"),
   RPG("RPG"),
   RUBY("Ruby"),
+  RUST("Rust"),
   SCALA("Scala"),
   SECRETS("Secrets"),
   TEXT("Text"),
@@ -114,6 +115,8 @@ public enum Language {
         return RPG;
       case RUBY:
         return RUBY;
+      case RUST:
+        return RUST;
       case SCALA:
         return SCALA;
       case SECRETS:

--- a/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/Language.java
+++ b/rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/common/Language.java
@@ -50,6 +50,7 @@ public enum Language {
   PYTHON,
   RPG,
   RUBY,
+  RUST,
   SCALA,
   SECRETS,
   TEXT,


### PR DESCRIPTION
Adds Rust as a supported language so an embedded Rust plugin (plugin key `rustenterprise`, language key `rust`, repository `rust`) gets its sensor executed in standalone mode. Modeled on the existing Go language.

- `SonarLanguage` (backend/commons): add `RUST("rust", SonarPlugin.RUST, "Rust", {".rs"}, "sonar.rust.file.suffixes")`
- `SonarPlugin` (backend/commons): add `RUST("rustenterprise")`
- RPC `Language` enum (rpc-protocol): add `RUST`
- java-client-utils `Language` enum: add `RUST` constant + `fromDto` mapping

The `Language` ⇄ `SonarLanguage` converters use `valueOf(name())`, so name parity wires the mapping automatically. No behavior changes to other languages.