### PR TITLE
SLCORE-2496 Update log level when detecting duplicate config scope

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/ConfigurationService.java
@@ -57,7 +57,7 @@ public class ConfigurationService {
       var bindingConfigInReferential = adapt(bindingDto);
       var previous = repository.addOrReplace(configScopeInReferential, bindingConfigInReferential);
       if (previous != null) {
-        LOG.error("Duplicate configuration scope registered: {}", addedDto.getId());
+        LOG.debug("Updating configuration scope '{}'", addedDto.getId());
       } else {
         LOG.debug("Added configuration scope '{}'", configScopeInReferential.id());
         addedIds.add(new ConfigurationScopeWithBinding(configScopeInReferential, bindingConfigInReferential));

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/ConfigurationServiceTests.java
@@ -114,7 +114,7 @@ class ConfigurationServiceTests {
     assertThat(repository.getConfigScopeIds()).containsOnly("id1");
     assertThat(repository.getBindingConfiguration("id1")).usingRecursiveComparison().isEqualTo(BINDING_DTO_2);
 
-    assertThat(logTester.logs(LogOutput.Level.ERROR)).containsExactly("Duplicate configuration scope registered: id1");
+    assertThat(logTester.logs(LogOutput.Level.DEBUG)).contains("Updating configuration scope 'id1'");
   }
 
   @Test


### PR DESCRIPTION
----
## Summary by Gitar

- **Logging changes:**
  - Changed log level from `error` to `debug` in `ConfigurationService` when a duplicate configuration scope is detected.

<sub>This will update automatically on new commits.</sub>