### PR TITLE
SLCORE-2502 Avoid infinite retry when downloading plugins from the server

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloader.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloader.java
@@ -82,6 +82,7 @@ public class ServerPluginDownloader {
     } catch (Exception e) {
       LOG.error("Failed to download plugin '{}' for connection '{}'", serverPlugin.getKey(), connectionId, e);
       fireFailedEvent(connectionId, sonarPlugin);
+      throw propagateFailure(e);
     }
   }
 
@@ -92,49 +93,38 @@ public class ServerPluginDownloader {
       LOG.error("Failed to download companion plugin '{}' for connection '{}'", plugin.getKey(), connectionId, e);
       eventPublisher.publishEvent(new PluginStatusUpdateEvent(connectionId,
         List.of(PluginStatus.forCompanion(plugin.getKey(), ArtifactState.FAILED, null, null, null))));
+      throw propagateFailure(e);
     }
   }
 
   private void downloadPluginAndFireEvent(String connectionId, ServerPlugin serverPlugin, SonarPlugin sonarPlugin) {
-    var state = downloadPluginSync(connectionId, serverPlugin);
-    if (state == ArtifactState.SYNCED) {
-      var pluginKey = serverPlugin.getKey();
-      var storedPath = storageService.connection(connectionId).plugins().getStoredPluginPathsByKey().get(pluginKey);
-      var source = sourceFor(connectionId);
-      var version = storedPath != null ? PluginJarUtils.readVersion(storedPath) : null;
-      var statuses = sonarPlugin.getLanguages().stream()
-        .map(l -> PluginStatus.forLanguage(l, ArtifactState.SYNCED, source, version, null, storedPath, null))
-        .toList();
-      eventPublisher.publishEvent(new PluginStatusUpdateEvent(connectionId, statuses));
-    } else {
-      fireFailedEvent(connectionId, sonarPlugin);
-    }
+    downloadPluginSyncOrThrow(connectionId, serverPlugin);
+    var pluginKey = serverPlugin.getKey();
+    var storedPath = storageService.connection(connectionId).plugins().getStoredPluginPathsByKey().get(pluginKey);
+    var source = sourceFor(connectionId);
+    var version = storedPath != null ? PluginJarUtils.readVersion(storedPath) : null;
+    var statuses = sonarPlugin.getLanguages().stream()
+      .map(l -> PluginStatus.forLanguage(l, ArtifactState.SYNCED, source, version, null, storedPath, null))
+      .toList();
+    eventPublisher.publishEvent(new PluginStatusUpdateEvent(connectionId, statuses));
   }
 
   private void downloadUnknownPluginAndFireEvent(String connectionId, ServerPlugin plugin) {
-    var state = downloadPluginSync(connectionId, plugin);
-    var storedPath = state == ArtifactState.SYNCED
-      ? storageService.connection(connectionId).plugins().getStoredPluginPathsByKey().get(plugin.getKey())
-      : null;
+    downloadPluginSyncOrThrow(connectionId, plugin);
+    var storedPath = storageService.connection(connectionId).plugins().getStoredPluginPathsByKey().get(plugin.getKey());
     var source = sourceFor(connectionId);
     eventPublisher.publishEvent(new PluginStatusUpdateEvent(connectionId,
-      List.of(PluginStatus.forCompanion(plugin.getKey(), state, source, storedPath, null))));
+      List.of(PluginStatus.forCompanion(plugin.getKey(), ArtifactState.SYNCED, source, storedPath, null))));
   }
 
-  ArtifactState downloadPluginSync(String connectionId, ServerPlugin serverPlugin) {
+  void downloadPluginSyncOrThrow(String connectionId, ServerPlugin serverPlugin) {
     var pluginKey = serverPlugin.getKey();
     LOG.info("[SYNC] Downloading plugin '{}'", serverPlugin.getFilename());
-    try {
-      var cancelMonitor = new SonarLintCancelMonitor();
-      sonarQubeClientManager.withActiveClient(connectionId,
-        api -> api.plugins().getPlugin(pluginKey,
-          binary -> storageService.connection(connectionId).plugins().store(serverPlugin, binary),
-          cancelMonitor));
-      return ArtifactState.SYNCED;
-    } catch (Exception e) {
-      LOG.error("Failed to download plugin '{}' for connection '{}'", pluginKey, connectionId, e);
-      return ArtifactState.FAILED;
-    }
+    var cancelMonitor = new SonarLintCancelMonitor();
+    sonarQubeClientManager.withActiveClient(connectionId,
+      api -> api.plugins().getPlugin(pluginKey,
+        binary -> storageService.connection(connectionId).plugins().store(serverPlugin, binary),
+        cancelMonitor));
   }
 
   private void fireFailedEvent(String connectionId, SonarPlugin sonarPlugin) {
@@ -148,6 +138,13 @@ public class ServerPluginDownloader {
     var connection = connectionConfigurationRepository.getConnectionById(connectionId);
     var isSonarQubeCloud = connection != null && connection.getKind() == ConnectionKind.SONARCLOUD;
     return isSonarQubeCloud ? ArtifactOrigin.SONARQUBE_CLOUD : ArtifactOrigin.SONARQUBE_SERVER;
+  }
+
+  private static RuntimeException propagateFailure(Exception e) {
+    if (e instanceof RuntimeException runtimeException) {
+      return runtimeException;
+    }
+    return new IllegalStateException("Unexpected checked exception during plugin download", e);
   }
 
 }

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloaderTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloaderTest.java
@@ -45,7 +45,6 @@ import org.sonarsource.sonarlint.core.serverconnection.storage.PluginsStorage;
 import org.sonarsource.sonarlint.core.storage.StorageService;
 import org.springframework.context.ApplicationEventPublisher;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -136,14 +135,13 @@ class ServerPluginDownloaderTest {
   }
 
   @Test
-  void should_perform_synchronous_download_and_return_state() {
+  void should_perform_synchronous_download() {
     downloadExecutor = mock(ExecutorService.class);
     var downloader = new ServerPluginDownloader(storageService, sonarQubeClientManager, connectionRepo, eventPublisher, downloadExecutor);
     var serverPlugin = mockServerPlugin("custom-plugin");
 
-    var state = downloader.downloadPluginSync("conn", serverPlugin);
+    downloader.downloadPluginSyncOrThrow("conn", serverPlugin);
 
-    assertThat(state).isEqualTo(ArtifactState.SYNCED);
     verify(sonarQubeClientManager).withActiveClient(any(), any());
   }
 

--- a/medium-tests/src/test/java/mediumtest/plugin/ServerPluginDownloadMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/plugin/ServerPluginDownloadMediumTests.java
@@ -1,0 +1,82 @@
+/*
+ * SonarLint Core - Medium Tests
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package mediumtest.plugin;
+
+import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
+import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
+import org.sonarsource.sonarlint.core.test.utils.server.ServerFixture;
+import utils.TestPlugin;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.sonarsource.sonarlint.core.rpc.protocol.common.Language.JAVA;
+
+class ServerPluginDownloadMediumTests {
+
+  private static final String CONFIG_SCOPE_ID = "configScopeId";
+  private static final String CONNECTION_ID = "connectionId";
+  private static final String ORGANIZATION_KEY = "org";
+  private static final String PROJECT_KEY = "projectKey";
+  private static final String PLUGIN_DOWNLOAD_URL = "/api/plugins/download?plugin=java";
+
+  @SonarLintTest
+  void failed_server_plugin_download_should_not_trigger_infinite_reload_loop_for_sonarqube_cloud_us_region(SonarLintTestHarness harness) {
+    var server = harness.newFakeSonarCloudServer()
+      .withOrganization(ORGANIZATION_KEY, organization -> organization.withProject(PROJECT_KEY, project -> project.withBranch("main")))
+      .withPlugin(TestPlugin.JAVA)
+      .start();
+    // Keep the failing response in flight briefly so a regression would have time to rearm
+    // another download attempt while the first one is still completing.
+    server.getMockServer().stubFor(get(urlEqualTo(PLUGIN_DOWNLOAD_URL))
+      .atPriority(1)
+      .willReturn(aResponse().withStatus(404).withFixedDelay(200)));
+
+    var backend = harness.newBackend()
+      .withSonarQubeCloudUsRegionUri(server.baseUrl())
+      .withSonarQubeCloudUsRegionApiUri(server.baseUrl())
+      .withSonarCloudConnection(CONNECTION_ID, ORGANIZATION_KEY, "US", true, storage -> storage
+        .withProject(PROJECT_KEY, project -> project
+          .withRuleSet("java", ruleSet -> ruleSet.withActiveRule("java:S106", "MAJOR"))
+          .withMainBranch("main")))
+      .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
+      .withExtraEnabledLanguagesInConnectedMode(JAVA)
+      .start();
+
+    try {
+      // We expect exactly one failed download attempt. The `during` window proves the count stays
+      // stable for a while instead of entering the old reload/download loop.
+      await().during(2, SECONDS).atMost(15, SECONDS)
+        .untilAsserted(() -> assertThat(countPluginDownloadRequests(server)).isEqualTo(1));
+    } finally {
+      harness.shutdown(backend);
+    }
+  }
+
+  private static long countPluginDownloadRequests(ServerFixture.Server server) {
+    return server.getMockServer().getAllServeEvents().stream()
+      .filter(event -> PLUGIN_DOWNLOAD_URL.equals(event.getRequest().getUrl()))
+      .count();
+  }
+
+}


### PR DESCRIPTION
----
## Summary by Gitar

- **Logic adjustments:**
  - Refactored `downloadPluginSync` to `downloadPluginSyncOrThrow`, removing local error swallowing to propagate download failures and prevent infinite retry loops.
  - Added `propagateFailure` helper in `ServerPluginDownloader` to ensure exceptions are correctly rethrown during plugin download.
- **Testing:**
  - Added `ServerPluginDownloadMediumTests` to verify that a failed download request only triggers a single attempt.

<sub>This will update automatically on new commits.</sub>