### PR TITLE
SLCORE-2511 Taint sync crashes on unknown stored language

### DIFF
--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/EntityMapper.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/storage/EntityMapper.java
@@ -169,7 +169,17 @@ public class EntityMapper {
     if (languages == null) {
       return Set.of();
     }
-    return Arrays.stream(languages).map(SonarLanguage::valueOf).collect(Collectors.toSet());
+    return Arrays.stream(languages)
+      .map(language -> {
+        try {
+          return SonarLanguage.valueOf(language);
+        } catch (IllegalArgumentException e) {
+          LOG.warn("Failed to deserialize language {}", language);
+          return null;
+        }
+      })
+      .filter(Objects::nonNull)
+      .collect(Collectors.toSet());
   }
 
   public String[] serializeLanguages(Set<SonarLanguage> enabledLanguages) {

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/EntityMapperTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/EntityMapperTests.java
@@ -27,6 +27,7 @@ import org.jooq.JSON;
 import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarlint.core.commons.ImpactSeverity;
 import org.sonarsource.sonarlint.core.commons.SoftwareQuality;
+import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.commons.api.TextRangeWithHash;
 import org.sonarsource.sonarlint.core.serverconnection.issues.ServerTaintIssue;
 
@@ -74,6 +75,13 @@ class EntityMapperTests {
         "{\"filePath\":\"" + stringPath + "\",\"textRange\":{\"startLine\":5,\"startLineOffset\":6,\"endLine\":7,\"endLineOffset\":8,\"hash\":\"hash2\"}," +
         "\"message\":\"Message 2\"}]},{\"locations\":[{\"filePath\":\"" + stringPath + "\"," +
         "\"textRange\":{\"startLine\":1,\"startLineOffset\":2,\"endLine\":3,\"endLineOffset\":4,\"hash\":\"hash1\"},\"message\":\"Message 1\"}]}]");
+  }
+
+  @Test
+  void should_deserialize_languages_and_skip_unknown_names() {
+    var languages = underTest.deserializeLanguages(new String[] {"JAVA", "FUTURE_LANGUAGE", "PYTHON"});
+
+    assertThat(languages).containsExactlyInAnyOrder(SonarLanguage.JAVA, SonarLanguage.PYTHON);
   }
 
   @Test

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/EntityMapperTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/storage/EntityMapperTests.java
@@ -25,15 +25,20 @@ import java.util.EnumMap;
 import java.util.List;
 import org.jooq.JSON;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.commons.ImpactSeverity;
 import org.sonarsource.sonarlint.core.commons.SoftwareQuality;
 import org.sonarsource.sonarlint.core.commons.api.SonarLanguage;
 import org.sonarsource.sonarlint.core.commons.api.TextRangeWithHash;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.serverconnection.issues.ServerTaintIssue;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EntityMapperTests {
+
+  @RegisterExtension
+  private static final SonarLintLogTester logTester = new SonarLintLogTester();
 
   private final EntityMapper underTest = new EntityMapper();
 


### PR DESCRIPTION
----
## Summary by Gitar

- **Bug fixes:**
  - Prevented crashes during taint synchronization by gracefully handling unknown `SonarLanguage` values in `EntityMapper`.
  - Added a log warning and filtered out invalid language strings instead of throwing an `IllegalArgumentException` during deserialization.

<sub>This will update automatically on new commits.</sub>