### PR TITLE
SLCORE-2319 Enable Omnisharp tests on Windows

### DIFF
--- a/medium-tests/src/test/java/mediumtest/ConnectedIssueMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/ConnectedIssueMediumTests.java
@@ -27,8 +27,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.AssertionsForInterfaceTypes;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
@@ -305,9 +303,9 @@ class ConnectedIssueMediumTests {
   }
 
   @SonarLintTest
-  // disabled on Windows for now, failure probably related to the setup of the environment
-  @DisabledOnOs(OS.WINDOWS)
-  void simpleCsharp(SonarLintTestHarness harness, @TempDir Path baseDir) {
+  void simpleCsharp(SonarLintTestHarness harness, @TempDir Path baseDir) throws Exception {
+    // Resolve 8.3 short Windows path (e.g. RUNNER~1) to its real form, or OmniSharp won't match the file to the project (SLCORE-2319)
+    baseDir = baseDir.toRealPath();
     var inputFile = createFile(baseDir, "Foo.cs", """
       public class Foo {
         public void Bar() {

--- a/medium-tests/src/test/java/mediumtest/StandaloneIssueMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/StandaloneIssueMediumTests.java
@@ -35,8 +35,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.analysis.AnalyzeFilesAndTrackParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.issue.GetEffectiveIssueDetailsParams;
@@ -258,9 +256,9 @@ class StandaloneIssueMediumTests {
   }
 
   @SonarLintTest
-  // disabled on Windows for now, failure probably related to the setup of the environment
-  @DisabledOnOs(OS.WINDOWS)
-  void simpleCsharp(SonarLintTestHarness harness, @TempDir Path baseDir) {
+  void simpleCsharp(SonarLintTestHarness harness, @TempDir Path baseDir) throws Exception {
+    // Resolve 8.3 short Windows path (e.g. RUNNER~1) to its real form, or OmniSharp won't match the file to the project (SLCORE-2319)
+    baseDir = baseDir.toRealPath();
     var inputFile = createFile(baseDir, "Foo.cs", """
       public class Foo {
         public void Bar() {


### PR DESCRIPTION
----
## Summary by Gitar

- **Test configuration:**
  - Removed unnecessary test exclusions for `ConnectedIssueMediumTests` and `StandaloneIssueMediumTests` to enable Omnisharp tests on Windows.
- **Bug fix:**
  - Added `baseDir.toRealPath()` to canonicalize file paths, preventing issues where OmniSharp fails to link files due to Windows 8.3 short paths.

<sub>This will update automatically on new commits.</sub>