### PR TITLE
SLCORE-2514 USER-2264 Split multiple Git installations by line instead of a fragile join/split roundtrip

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/NativeGitLocator.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/NativeGitLocator.java
@@ -20,7 +20,7 @@
 package org.sonarsource.sonarlint.core.commons.util.git;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.commons.lang3.SystemUtils;
@@ -56,17 +56,23 @@ public class NativeGitLocator {
   private static Optional<String> locateGitOnWindows() {
     var lines = new ArrayList<String>();
     var result = callWhereTool(lines::add);
-    return locateGitOnWindows(result, String.join("\n", lines));
+    return locateGitOnWindows(result, lines);
   }
 
-  static Optional<String> locateGitOnWindows(ProcessWrapperFactory.ProcessExecutionResult result, String lines) {
+  static Optional<String> locateGitOnWindows(ProcessWrapperFactory.ProcessExecutionResult result, List<String> lines) {
     // Windows will search current directory in addition to the PATH variable, which is unsecure.
     // To avoid it we use where.exe to find git binary only in PATH.
-
-    if (result.exitCode() == 0 && lines.contains("git.exe")) {
-      var out = Arrays.stream(lines.split(System.lineSeparator())).map(String::trim).findFirst();
-      LOG.debug("Found git.exe at {}", out);
-      return out;
+    // where.exe prints one path per line, so we pick the first one pointing to git.exe. The lines are
+    // already split by the process reader, so we must not join and re-split them (line separators differ).
+    if (result.exitCode() == 0) {
+      var gitExecutablePath = lines.stream()
+        .map(String::trim)
+        .filter(line -> line.contains("git.exe"))
+        .findFirst();
+      if (gitExecutablePath.isPresent()) {
+        LOG.debug("Found git.exe at {}", gitExecutablePath.get());
+        return gitExecutablePath;
+      }
     }
     LOG.debug("git.exe not found in PATH. PATH value was: " + System.getProperty("PATH"));
     return Optional.empty();

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/NativeGitLocatorTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/git/NativeGitLocatorTests.java
@@ -21,6 +21,7 @@ package org.sonarsource.sonarlint.core.commons.util.git;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.assertj.core.api.AssertionsForClassTypes;
@@ -77,17 +78,21 @@ class NativeGitLocatorTests {
 
   private static Stream<Arguments> gitLocations() {
     return Stream.of(
-      Arguments.of(result(0, ""), Optional.empty()),
+      Arguments.of(result(0), Optional.empty()),
       Arguments.of(result(1, "invalid location"), Optional.empty()),
+      Arguments.of(result(0, "invalid location"), Optional.empty()),
       Arguments.of(result(0, "C:\\Program Files\\Git\\bin\\git.exe"), Optional.of("C:\\Program Files\\Git\\bin\\git.exe")),
-      Arguments.of(result(0, "C:\\Users\\user.name\\AppData\\Local\\Programs\\Git\\cmd\\git.exe" + System.lineSeparator() +
-                             "C:\\Users\\user.name\\AppData\\Local\\Programs\\Git\\mingw64\\bin\\git.exe"), Optional.of("C:\\Users\\user.name\\AppData\\Local\\Programs\\Git\\cmd\\git.exe")));
+      // Multiple Git installations on the PATH: where.exe returns one path per line and we must pick the first one (SLCORE / USER-2264).
+      Arguments.of(result(0, "C:\\Users\\user.name\\AppData\\Local\\Programs\\Git\\cmd\\git.exe",
+        "C:\\Users\\user.name\\AppData\\Local\\Programs\\Git\\mingw64\\bin\\git.exe"), Optional.of("C:\\Users\\user.name\\AppData\\Local\\Programs\\Git\\cmd\\git.exe")),
+      Arguments.of(result(0, "C:\\Program Files\\Git\\cmd\\git.exe", "C:\\Program Files\\Git2ndrun\\bin\\git.exe"),
+        Optional.of("C:\\Program Files\\Git\\cmd\\git.exe")));
   }
 
-  private static TestData result(int code, String output) {
-    return new TestData(new ProcessWrapperFactory.ProcessExecutionResult(code), output);
+  private static TestData result(int code, String... lines) {
+    return new TestData(new ProcessWrapperFactory.ProcessExecutionResult(code), List.of(lines));
   }
 
-  private record TestData(ProcessWrapperFactory.ProcessExecutionResult whereToolResult, String lines) {
+  private record TestData(ProcessWrapperFactory.ProcessExecutionResult whereToolResult, List<String> lines) {
   }
 }


### PR DESCRIPTION
## What

Fixes [USER-2264](https://sonarsource.atlassian.net/browse/USER-2264): on Windows, multiple Git installations on the `PATH` were not split correctly, so all detected paths were concatenated into a single bogus executable string (e.g. `Cannot run program "C:\...\git.exe\nC:\...\git.exe"`).

## Root cause

`NativeGitLocator` collected the already-split output of `where.exe` into a list, **joined it with `"\n"`**, then **split it again on `System.lineSeparator()`** (`\r\n` on Windows). The separators never matched, so the split returned the whole blob as one element and `findFirst()` returned every path joined together.

The existing test masked this: it built its input using `System.lineSeparator()` (matching the split), and was `@EnabledOnOs(WINDOWS)`, so the mismatched production combination was never exercised.

## Fix

`ProcessWrapper` already delivers clean, terminator-free lines via `BufferedReader.readLine()`. So we pass the `List<String>` straight through and pick the first line pointing to `git.exe` — dropping the join/split roundtrip entirely. No more dependency on `System.lineSeparator()`.

## Tests

- The static parser now takes a `List<String>`.
- Added a regression case matching the ticket (two Git installations) plus an exit-0-but-invalid case.


[USER-2264]: https://sonarsource.atlassian.net/browse/USER-2264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ