### PR TITLE
SLCORE-2515 Warn users that SQS 9.9 will soon be unsupported

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelper.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelper.java
@@ -46,7 +46,8 @@ public class VersionSoonUnsupportedHelper {
 
   private static final String UNSUPPORTED_NOTIFICATION_ID = "sonarlint.unsupported.%s.%s.id";
   private static final String NOTIFICATION_MESSAGE = "The version '%s' used by the current connection '%s' will be soon unsupported. " +
-    "Please consider upgrading to the latest %s LTS version to ensure continued support and access to the latest features.";
+    "Please consider upgrading to the latest supported SonarQube LTS release (SonarQube Server %s or SonarQube Community Build %s) " +
+    "to ensure continued support and access to the latest features.";
   private static final SonarLintLogger LOG = SonarLintLogger.get();
   private final SonarLintRpcClient client;
   private final ConfigurationRepository configRepository;
@@ -109,7 +110,8 @@ public class VersionSoonUnsupportedHelper {
                 new ShowSoonUnsupportedMessageParams(
                   String.format(UNSUPPORTED_NOTIFICATION_ID, connectionId, version.getName()),
                   configScopeId,
-                  String.format(NOTIFICATION_MESSAGE, version.getName(), connectionId, VersionUtils.getCurrentLts())));
+                  String.format(NOTIFICATION_MESSAGE, version.getName(), connectionId, VersionUtils.getCurrentLts().getName(),
+                    VersionUtils.getCurrentCommunityBuildLts().getName())));
               LOG.debug(String.format("Connection '%s' with version '%s' is detected to be soon unsupported",
                 connection.getConnectionId(), version.getName()));
             }

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelperTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/VersionSoonUnsupportedHelperTests.java
@@ -85,7 +85,7 @@ class VersionSoonUnsupportedHelperTests {
     configRepository.addOrReplace(new ConfigurationScope(CONFIG_SCOPE_ID_2, null, false, ""), bindingConfiguration);
     connectionRepository.addOrReplace(SQ_CONNECTION);
     when(synchronizationService.readOrSynchronizeServerVersion(eq(SQ_CONNECTION_ID), any(), any(SonarLintCancelMonitor.class)))
-      .thenReturn(VersionUtils.getMinimalSupportedVersion());
+      .thenReturn(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT);
 
     underTest.configurationScopesAdded(new ConfigurationScopesAddedWithBindingEvent(Set.of(
       new ConfigurationScopeWithBinding(
@@ -96,7 +96,7 @@ class VersionSoonUnsupportedHelperTests {
         BindingConfiguration.noBinding()))));
 
     await().untilAsserted(() -> assertThat(logTester.logs(LogOutput.Level.DEBUG))
-      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.getMinimalSupportedVersion().getName() + "' is detected to be soon unsupported"));
+      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT.getName() + "' is detected to be soon unsupported"));
   }
 
   @Test
@@ -110,9 +110,9 @@ class VersionSoonUnsupportedHelperTests {
     var serverApi = mock(ServerApi.class);
     var serverApi2 = mock(ServerApi.class);
     when(synchronizationService.readOrSynchronizeServerVersion(eq(SQ_CONNECTION_ID), eq(serverApi), any(SonarLintCancelMonitor.class)))
-      .thenReturn(VersionUtils.getMinimalSupportedVersion());
+      .thenReturn(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT);
     when(synchronizationService.readOrSynchronizeServerVersion(eq(SQ_CONNECTION_ID_2), eq(serverApi2), any(SonarLintCancelMonitor.class)))
-      .thenReturn(Version.create(VersionUtils.getMinimalSupportedVersion() + ".9"));
+      .thenReturn(Version.create(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT + ".9"));
 
     underTest.configurationScopesAdded(new ConfigurationScopesAddedWithBindingEvent(Set.of(
       new ConfigurationScopeWithBinding(
@@ -124,8 +124,8 @@ class VersionSoonUnsupportedHelperTests {
 
     await().untilAsserted(() -> assertThat(logTester.logs(LogOutput.Level.DEBUG))
       .containsOnly(
-        "Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.getMinimalSupportedVersion().getName() + "' is detected to be soon unsupported",
-        "Connection '" + SQ_CONNECTION_ID_2 + "' with version '" + VersionUtils.getMinimalSupportedVersion() + ".9' is detected to be soon unsupported"));
+        "Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT.getName() + "' is detected to be soon unsupported",
+        "Connection '" + SQ_CONNECTION_ID_2 + "' with version '" + VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT + ".9' is detected to be soon unsupported"));
   }
 
   @Test
@@ -143,13 +143,13 @@ class VersionSoonUnsupportedHelperTests {
     connectionRepository.addOrReplace(SQ_CONNECTION);
     var serverApi = mock(ServerApi.class);
     when(synchronizationService.readOrSynchronizeServerVersion(eq(SQ_CONNECTION_ID), eq(serverApi), any(SonarLintCancelMonitor.class)))
-      .thenReturn(VersionUtils.getMinimalSupportedVersion());
+      .thenReturn(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT);
 
     underTest.bindingConfigChanged(new BindingConfigChangedEvent(CONFIG_SCOPE_ID, null,
       new BindingConfiguration(SQ_CONNECTION_ID, "", false)));
 
     await().untilAsserted(() -> assertThat(logTester.logs(LogOutput.Level.DEBUG))
-      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.getMinimalSupportedVersion().getName() + "' is detected to be soon unsupported"));
+      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT.getName() + "' is detected to be soon unsupported"));
   }
 
   @Test
@@ -157,7 +157,7 @@ class VersionSoonUnsupportedHelperTests {
     connectionRepository.addOrReplace(SQ_CONNECTION);
     var serverApi = mock(ServerApi.class);
     when(synchronizationService.readOrSynchronizeServerVersion(eq(SQ_CONNECTION_ID), eq(serverApi), any(SonarLintCancelMonitor.class)))
-      .thenReturn(VersionUtils.getMinimalSupportedVersion());
+      .thenReturn(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT);
 
     underTest.bindingConfigChanged(new BindingConfigChangedEvent(CONFIG_SCOPE_ID, null,
       new BindingConfiguration(SQ_CONNECTION_ID, "", false)));
@@ -165,7 +165,7 @@ class VersionSoonUnsupportedHelperTests {
       new BindingConfiguration(SQ_CONNECTION_ID, "", false)));
 
     await().untilAsserted(() -> assertThat(logTester.logs(LogOutput.Level.DEBUG))
-      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.getMinimalSupportedVersion().getName() + "' is detected to be soon unsupported"));
+      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT.getName() + "' is detected to be soon unsupported"));
   }
 
   @Test
@@ -173,13 +173,13 @@ class VersionSoonUnsupportedHelperTests {
     connectionRepository.addOrReplace(SQ_CONNECTION);
     var serverApi = mock(ServerApi.class);
     when(synchronizationService.readOrSynchronizeServerVersion(eq(SQ_CONNECTION_ID), eq(serverApi), any(SonarLintCancelMonitor.class)))
-      .thenReturn(Version.create(VersionUtils.getMinimalSupportedVersion().getName() + ".9"));
+      .thenReturn(Version.create(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT.getName() + ".9"));
 
     underTest.bindingConfigChanged(new BindingConfigChangedEvent(CONFIG_SCOPE_ID, null,
       new BindingConfiguration(SQ_CONNECTION_ID, "", false)));
 
     await().untilAsserted(() -> assertThat(logTester.logs(LogOutput.Level.DEBUG))
-      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.getMinimalSupportedVersion().getName() + ".9' is detected to be soon unsupported"));
+      .containsOnly("Connection '" + SQ_CONNECTION_ID + "' with version '" + VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT.getName() + ".9' is detected to be soon unsupported"));
   }
 
   @Test

--- a/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtils.java
+++ b/backend/server-connection/src/main/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtils.java
@@ -23,26 +23,33 @@ import org.sonarsource.sonarlint.core.commons.Version;
 
 public class VersionUtils {
 
-  private static final Version CURRENT_LTS = Version.create("9.9");
-  private static final Version MINIMAL_SUPPORTED_VERSION = Version.create("9.9");
+  private static final Version CURRENT_LTS_SHORT = Version.create("25.1");
+  private static final Version CURRENT_LTS = Version.create("20" + CURRENT_LTS_SHORT);
+  public static final Version MINIMAL_SUPPORTED_VERSION_SHORT = Version.create("9.9");
+  // temporarily force a higher version to keep the check below correct
+  private static final Version MINIMAL_SUPPORTED_VERSION = Version.create("2025.1");
 
   private VersionUtils() {
+    // utility class
   }
 
   /**
-   * Right now since minimal supported version is equal to current LTS (9.9) this method will always return false.
-   * But it's important to keep it for the future when next LTS will be released, and we will have a grace period again.
+   * Versions in the grace-period window should trigger the soon-unsupported warning.
+   *
+   * The check currently uses two version ranges: the legacy or Community Build short numbering from the minimal
+   * supported short version (included) to the current Community Build LTS (excluded), and the SonarQube Server
+   * full-year numbering from the temporary full-year lower bound (included) to the current Server LTS (excluded).
    */
   public static boolean isVersionSupportedDuringGracePeriod(Version currentVersion) {
-    return currentVersion.compareTo(CURRENT_LTS) < 0 &&
-      currentVersion.compareToIgnoreQualifier(MINIMAL_SUPPORTED_VERSION) >= 0;
+    return (currentVersion.compareToIgnoreQualifier(MINIMAL_SUPPORTED_VERSION_SHORT) >= 0 && currentVersion.compareTo(CURRENT_LTS_SHORT) < 0)
+      || (currentVersion.compareTo(MINIMAL_SUPPORTED_VERSION) >= 0 && currentVersion.compareTo(CURRENT_LTS) < 0);
   }
 
   public static Version getCurrentLts() {
     return CURRENT_LTS;
   }
 
-  public static Version getMinimalSupportedVersion() {
-    return MINIMAL_SUPPORTED_VERSION;
+  public static Version getCurrentCommunityBuildLts() {
+    return CURRENT_LTS_SHORT;
   }
 }

--- a/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtilsTests.java
+++ b/backend/server-connection/src/test/java/org/sonarsource/sonarlint/core/serverconnection/VersionUtilsTests.java
@@ -23,27 +23,42 @@ import org.junit.jupiter.api.Test;
 import org.sonarsource.sonarlint.core.commons.Version;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonarsource.sonarlint.core.serverconnection.VersionUtils.getCurrentCommunityBuildLts;
 import static org.sonarsource.sonarlint.core.serverconnection.VersionUtils.getCurrentLts;
-import static org.sonarsource.sonarlint.core.serverconnection.VersionUtils.getMinimalSupportedVersion;
 
 class VersionUtilsTests {
 
   @Test
+  void current_lts_should_be_exposed_for_both_numbering_systems() {
+    assertThat(getCurrentLts()).isEqualTo(Version.create("2025.1"));
+    assertThat(getCurrentCommunityBuildLts()).isEqualTo(Version.create("25.1"));
+  }
+
+  @Test
   void grace_period_should_be_false_if_connected_current_lts() {
     assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(getCurrentLts())).isFalse();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("25.1"))).isFalse();
     assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create(getCurrentLts().getName() + ".1"))).isFalse();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("25.1.1"))).isFalse();
   }
 
   @Test
   void grace_period_should_be_false_if_connected_outdated_version() {
     assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("5.9"))).isFalse();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("9.8"))).isFalse();
   }
 
   @Test
   void grace_period_should_be_true_if_connected_during_grace_period() {
-    // read isVersionSupportedDuringGracePeriod javadoc
-    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(getMinimalSupportedVersion())).isFalse();
-    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create(getMinimalSupportedVersion().getName() + ".1"))).isFalse();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT)).isTrue();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create(VersionUtils.MINIMAL_SUPPORTED_VERSION_SHORT.getName() + ".1"))).isTrue();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("24.12"))).isTrue();
+  }
+
+  @Test
+  void grace_period_should_be_false_if_connected_newer_than_current_lts() {
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("2025.2"))).isFalse();
+    assertThat(VersionUtils.isVersionSupportedDuringGracePeriod(Version.create("25.2"))).isFalse();
   }
 
 }


### PR DESCRIPTION
----
## Summary by Gitar

- **Version support logic:**
  - Updated `VersionUtils` to handle both legacy Community Build versioning and new full-year server versioning.
  - Adjusted `isVersionSupportedDuringGracePeriod` to validate against both `25.1` (Community Build) and `2025.1` (Server LTS) thresholds.
- **User notifications:**
  - Refactored `VersionSoonUnsupportedHelper` to include both the new Server LTS and Community Build LTS versions in warning messages.
- **Test updates:**
  - Updated `VersionSoonUnsupportedHelperTests` and `VersionUtilsTests` to reflect the new versioning thresholds and grace period validation logic.

<sub>This will update automatically on new commits.</sub>