### PR TITLE
SLCORE-2518 Fix flaky tests

### DIFF
--- a/medium-tests/src/test/java/mediumtest/issues/OpenFixSuggestionInIdeMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/issues/OpenFixSuggestionInIdeMediumTests.java
@@ -112,7 +112,7 @@ class OpenFixSuggestionInIdeMediumTests {
       .start(fakeClient);
     waitForScopeRegistration(fakeClient, CONFIG_SCOPE_ID);
 
-    assertThat(backend.telemetryFileContent().getFixSuggestionReceivedCounter()).isEmpty();
+    await().untilAsserted(() -> assertThat(backend.telemetryFileContent().getFixSuggestionReceivedCounter()).isEmpty());
 
     var statusCode = executeOpenFixSuggestionRequestWithoutToken(backend, scServer, FIX_PAYLOAD, ISSUE_KEY, PROJECT_KEY, BRANCH_NAME, ORG_KEY);
 

--- a/medium-tests/src/test/java/mediumtest/monitoring/MonitoringMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/monitoring/MonitoringMediumTests.java
@@ -38,6 +38,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.BackendCap
 import org.sonarsource.sonarlint.core.rpc.protocol.client.issue.RaisedIssueDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.ClientFileDto;
 import org.sonarsource.sonarlint.core.rpc.protocol.common.Language;
+import org.sonarsource.sonarlint.core.test.utils.SonarLintTestRpcServer;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
@@ -450,7 +451,7 @@ class MonitoringMediumTests {
 
     backend.getTelemetryService().disableTelemetry();
 
-    await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertThat(Sentry.isEnabled()).isFalse());
+    awaitTelemetryStatus(backend, false);
   }
 
   @SonarLintTest
@@ -544,11 +545,11 @@ class MonitoringMediumTests {
 
     backend.getTelemetryService().disableTelemetry();
 
-    await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertThat(Sentry.isEnabled()).isFalse());
+    awaitTelemetryStatus(backend, false);
 
     backend.getTelemetryService().enableTelemetry();
 
-    await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertThat(Sentry.isEnabled()).isTrue());
+    awaitTelemetryStatus(backend, true);
   }
 
   @SonarLintTest
@@ -573,7 +574,7 @@ class MonitoringMediumTests {
 
     // Disable telemetry to close Sentry
     backend.getTelemetryService().disableTelemetry();
-    await().atMost(2, TimeUnit.SECONDS).untilAsserted(() -> assertThat(Sentry.isEnabled()).isFalse());
+    awaitTelemetryStatus(backend, false);
 
     // Clear any existing events
     sentryServer.resetAll();
@@ -582,5 +583,13 @@ class MonitoringMediumTests {
     analyzeFileAndGetIssues(inputFile.toUri(), client, backend, CONFIGURATION_SCOPE_ID);
 
     await().during(2000, TimeUnit.MILLISECONDS).untilAsserted(() -> assertThat(sentryServer.getAllServeEvents()).isEmpty());
+  }
+
+  private static void awaitTelemetryStatus(SonarLintTestRpcServer backend, boolean enabled) {
+    await().atMost(2, TimeUnit.SECONDS)
+      .untilAsserted(() -> {
+        assertThat(backend.getTelemetryService().getStatus().get(2, TimeUnit.SECONDS).isEnabled()).isEqualTo(enabled);
+        assertThat(Sentry.isEnabled()).isEqualTo(enabled);
+      });
   }
 }

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/websockets/WebSocketServer.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/websockets/WebSocketServer.java
@@ -65,7 +65,9 @@ public class WebSocketServer {
   }
 
   public List<WebSocketConnection> getConnections() {
-    return connectionsBySocket.values().stream().toList();
+    synchronized (connectionsBySocket) {
+      return List.copyOf(connectionsBySocket.values());
+    }
   }
 
   public class Impl extends org.java_websocket.server.WebSocketServer {


### PR DESCRIPTION
----
## Summary by Gitar

- **Fixed flaky tests:**
  - Replaced direct `Sentry` checks with a robust `awaitTelemetryStatus` helper in `MonitoringMediumTests`.
  - Added `await().untilAsserted()` wrapper to `OpenFixSuggestionInIdeMediumTests` for reliable assertion.
- **Improved test utilities:**
  - Added synchronization to `WebSocketServer.getConnections()` to prevent concurrent modification exceptions during test execution.

<sub>This will update automatically on new commits.</sub>