### PR TITLE
SLCORE-2528 Fix SCA for maven

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,6 @@ jobs:
           sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
           sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
           sonar_props+=("-Dsonar.coverage.jacoco.aggregateXmlReportPaths=${{ github.workspace }}/report-aggregate/target/site/jacoco-aggregate/jacoco.xml")
-          sonar_props+=("-Dsonar.sca.resolveAsRoot=true")
           echo "Maven command: mvn ${maven_goals[*]} ${sonar_props[*]}"
           mvn -B "${maven_goals[@]}" "${sonar_props[@]}"
       - name: Generate test report on failure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,6 +108,7 @@ jobs:
           sonar_props=("-Dsonar.host.url=${SONAR_HOST_URL}" "-Dsonar.token=${SONAR_TOKEN}")
           sonar_props+=("-Dsonar.projectVersion=${CURRENT_VERSION}")
           sonar_props+=("-Dsonar.coverage.jacoco.aggregateXmlReportPaths=${{ github.workspace }}/report-aggregate/target/site/jacoco-aggregate/jacoco.xml")
+          sonar_props+=("-Dsonar.sca.resolveAsRoot=true")
           echo "Maven command: mvn ${maven_goals[*]} ${sonar_props[*]}"
           mvn -B "${maven_goals[@]}" "${sonar_props[@]}"
       - name: Generate test report on failure

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,10 @@
     <sonar.coverage.exclusions>buildSrc/maven-shade-ext-bnd-transformer/**,backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/git/WinGitUtils.java</sonar.coverage.exclusions>
     <!-- Exclude from the duplication detection deprecated DTOs that were replaced by new types. They should be removed in 10.3 -->
     <sonar.cpd.exclusions>rpc-protocol/src/main/java/org/sonarsource/sonarlint/core/rpc/protocol/client/analysis/*Dto.java</sonar.cpd.exclusions>
+    <!-- Exclude non-shipped scaffolding (ITs and test-fixture projects) from SCA dependency analysis -->
+    <sonar.sca.exclusions>its/**,backend/plugin-commons/src/test/projects/**</sonar.sca.exclusions>
+    <!-- CI provides mvn on PATH; skip the mvnw wrapper whose distribution download is not authenticated -->
+    <sonar.sca.mavenIgnoreWrapper>true</sonar.sca.mavenIgnoreWrapper>
     <sonar.organization>sonarsource</sonar.organization>
     <h2.version>2.4.240</h2.version>
     <!-- More recent versions require Java 21 -->


### PR DESCRIPTION
We have SCA not working because maven wrapper doesn't pick up the repox credentials. So forcing SCA to use an actual mvn from mise makes SCA actually run the check for maven files.
It is relevant only for maven projects.

----
## Summary by Gitar

- **SCA Configuration:**
    - Added `sonar.sca.exclusions` for `its/tests/projects/**` to exclude test fixtures from dependency analysis.
    - Set `sonar.sca.mavenIgnoreWrapper` to `true` to skip the Maven wrapper and use the system-provided `mvn`.

<sub>This will update automatically on new commits.</sub>