### PR TITLE
SLCORE-2537 Send machine_id and ide_installation_id in IDE telemetry

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarUserHome.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/SonarUserHome.java
@@ -1,0 +1,43 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.annotation.Nullable;
+
+public class SonarUserHome {
+
+  public static final String SONAR_USER_HOME_ENV = "SONAR_USER_HOME";
+
+  private SonarUserHome() {
+  }
+
+  public static Path get() {
+    return home(System.getenv(SONAR_USER_HOME_ENV));
+  }
+
+  static Path home(@Nullable String sonarHome) {
+    if (sonarHome != null) {
+      return Paths.get(sonarHome);
+    }
+    return Paths.get(System.getProperty("user.home")).resolve(".sonar");
+  }
+}

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/SonarUserHomeTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/SonarUserHomeTests.java
@@ -1,0 +1,39 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons;
+
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SonarUserHomeTests {
+
+  @Test
+  void env_setting_should_override_default_home() {
+    var customHome = "/custom/home";
+    assertThat(SonarUserHome.home(customHome)).isEqualTo(Paths.get(customHome));
+  }
+
+  @Test
+  void default_home_should_be_in_user_home() {
+    assertThat(SonarUserHome.get()).isEqualTo(Paths.get(System.getProperty("user.home")).resolve(".sonar"));
+  }
+}

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetrySpringConfig.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetrySpringConfig.java
@@ -32,7 +32,8 @@ import org.springframework.context.annotation.Import;
   TelemetryManager.class,
   TelemetryLocalStorageManager.class,
   TelemetryHttpClient.class,
-  TelemetryServerAttributesProvider.class
+  TelemetryServerAttributesProvider.class,
+  MachineIdProvider.class
 })
 public class TelemetrySpringConfig {
 

--- a/backend/telemetry/pom.xml
+++ b/backend/telemetry/pom.xml
@@ -83,6 +83,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProvider.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProvider.java
@@ -1,0 +1,103 @@
+/*
+ * SonarLint Core - Telemetry
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.telemetry;
+
+import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+import javax.annotation.CheckForNull;
+import org.sonarsource.sonarlint.core.commons.SonarUserHome;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
+import org.sonarsource.sonarlint.core.telemetry.common.TelemetryUserSetting;
+import org.springframework.context.annotation.Lazy;
+
+public class MachineIdProvider {
+
+  private static final SonarLintLogger LOG = SonarLintLogger.get();
+  private static final String USER_FILE_NAME = "user";
+
+  private final TelemetryUserSetting userSetting;
+  private boolean resolved;
+  private String cachedMachineId;
+
+  public MachineIdProvider(@Lazy TelemetryUserSetting userSetting) {
+    this.userSetting = userSetting;
+  }
+
+  @CheckForNull
+  public synchronized String getMachineId() {
+    if (!userSetting.isTelemetryEnabledByUser()) {
+      return null;
+    }
+    if (!resolved) {
+      cachedMachineId = resolveFromDisk();
+      resolved = true;
+    }
+    return cachedMachineId;
+  }
+
+  @CheckForNull
+  private static String resolveFromDisk() {
+    try {
+      var userFile = SonarUserHome.get().resolve(USER_FILE_NAME);
+      var existing = tryRead(userFile);
+      if (existing != null) {
+        return existing;
+      }
+      Files.createDirectories(userFile.getParent());
+      return createOrReadWinner(userFile);
+    } catch (Exception e) {
+      LOG.debug("Unable to resolve machine id", e);
+      return null;
+    }
+  }
+
+  private static String createOrReadWinner(Path userFile) throws IOException {
+    var candidate = UUID.randomUUID().toString();
+    try {
+      return writeExclusively(userFile, candidate);
+    } catch (FileAlreadyExistsException e) {
+      var winner = tryRead(userFile);
+      if (winner != null) {
+        return winner;
+      }
+      Files.deleteIfExists(userFile);
+      return writeExclusively(userFile, candidate);
+    }
+  }
+
+  private static String writeExclusively(Path userFile, String id) throws IOException {
+    Files.writeString(userFile, id, StandardOpenOption.CREATE_NEW);
+    return id;
+  }
+
+  @CheckForNull
+  private static String tryRead(Path userFile) {
+    try {
+      var content = Files.readString(userFile).trim();
+      return content.isEmpty() ? null : content;
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClient.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClient.java
@@ -26,6 +26,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.SystemUtils;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.http.HttpClient;
@@ -59,8 +60,10 @@ public class TelemetryHttpClient {
   private final HttpClient client;
   private final String endpoint;
   private final Map<String, Object> additionalAttributes;
+  private final MachineIdProvider machineIdProvider;
 
-  public TelemetryHttpClient(InitializeParams initializeParams, HttpClientProvider httpClientProvider, @Qualifier("telemetryEndpoint") String telemetryEndpoint) {
+  public TelemetryHttpClient(InitializeParams initializeParams, HttpClientProvider httpClientProvider, @Qualifier("telemetryEndpoint") String telemetryEndpoint,
+    MachineIdProvider machineIdProvider) {
     TelemetryClientConstantAttributesDto attributes = initializeParams.getTelemetryConstantAttributes();
     this.product = attributes.getProductName();
     this.version = attributes.getProductVersion();
@@ -70,18 +73,21 @@ public class TelemetryHttpClient {
     this.client = httpClientProvider.getHttpClientWithoutAuth();
     this.endpoint = telemetryEndpoint;
     this.additionalAttributes = attributes.getAdditionalAttributes();
+    this.machineIdProvider = machineIdProvider;
   }
 
   void upload(TelemetryLocalStorage data, TelemetryLiveAttributes telemetryLiveAttributes) {
+    var machineId = machineIdProvider.getMachineId();
+    var ideInstallationId = data.ensureIdeInstallationId();
     try {
-      sendPost(createPayload(data, telemetryLiveAttributes));
+      sendPost(createPayload(data, telemetryLiveAttributes, machineId, ideInstallationId));
     } catch (Throwable catchEmAll) {
       if (InternalDebug.isEnabled()) {
         LOG.error("Failed to upload telemetry data", catchEmAll);
       }
     }
     try {
-      sendMetricsPostIfNeeded(new TelemetryMeasuresBuilder(platform, product, data, telemetryLiveAttributes).build());
+      sendMetricsPostIfNeeded(new TelemetryMeasuresBuilder(platform, product, data, telemetryLiveAttributes, machineId, ideInstallationId).build());
     } catch (Throwable catchEmAll) {
       if (InternalDebug.isEnabled()) {
         LOG.error("Failed to upload telemetry metrics data", catchEmAll);
@@ -91,7 +97,7 @@ public class TelemetryHttpClient {
 
   void optOut(TelemetryLocalStorage data, TelemetryLiveAttributes telemetryLiveAttributes) {
     try {
-      sendDelete(createPayload(data, telemetryLiveAttributes));
+      sendDelete(createPayload(data, telemetryLiveAttributes, null, null));
     } catch (Throwable catchEmAll) {
       if (InternalDebug.isEnabled()) {
         LOG.error("Failed to upload telemetry opt-out", catchEmAll);
@@ -99,7 +105,7 @@ public class TelemetryHttpClient {
     }
   }
 
-  private TelemetryPayload createPayload(TelemetryLocalStorage data, TelemetryLiveAttributes telemetryLiveAttrs) {
+  private TelemetryPayload createPayload(TelemetryLocalStorage data, TelemetryLiveAttributes telemetryLiveAttrs, @Nullable String machineId, @Nullable String ideInstallationId) {
     var systemTime = OffsetDateTime.now(ZoneId.systemDefault());
     var daysSinceInstallation = data.installTime().until(systemTime, ChronoUnit.DAYS);
     var analyzers = TelemetryUtils.toPayload(data.analyzers());
@@ -136,7 +142,8 @@ public class TelemetryHttpClient {
       telemetryLiveAttrs.usesConnectedMode(), telemetryLiveAttrs.usesSonarCloud(), systemTime, data.installTime(), platform, jre,
       telemetryLiveAttrs.getNodeVersion(), analyzers, notifications, showHotspotPayload, showIssuePayload,
       taintVulnerabilitiesPayload, telemetryRulesPayload, hotspotPayload, issuePayload, helpAndFeedbackPayload,
-      fixSuggestionPayload, countIssuesWithPossibleAiFixFromIde, cleanAsYouCodePayload, shareConnectedModePayload, mergedAdditionalAttributes);
+      fixSuggestionPayload, countIssuesWithPossibleAiFixFromIde, cleanAsYouCodePayload, shareConnectedModePayload,
+      machineId, ideInstallationId, mergedAdditionalAttributes);
   }
 
   private void sendPost(TelemetryPayload payload) {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorage.java
@@ -51,6 +51,8 @@ public class TelemetryLocalStorage implements LocalStorage {
   private LocalDate lastUseDate;
   private LocalDateTime lastUploadDateTime;
   private OffsetDateTime installTime;
+  @Nullable
+  private String ideInstallationId;
   private long numUseDays;
   private boolean enabled;
   private final Map<String, TelemetryAnalyzerPerformance> analyzers;
@@ -174,6 +176,18 @@ public class TelemetryLocalStorage implements LocalStorage {
 
   public void setInstallTime(OffsetDateTime installTime) {
     this.installTime = installTime;
+  }
+
+  @CheckForNull
+  public String ideInstallationId() {
+    return ideInstallationId;
+  }
+
+  String ensureIdeInstallationId() {
+    if (ideInstallationId == null) {
+      ideInstallationId = UUID.randomUUID().toString();
+    }
+    return ideInstallationId;
   }
 
   void setLastUseDate(@Nullable LocalDate date) {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManager.java
@@ -25,7 +25,9 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.commons.storage.local.FileStorageManager;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.InitializeParams;
@@ -87,5 +89,16 @@ public class TelemetryLocalStorageManager {
 
   public OffsetDateTime installTime() {
     return getStorage().installTime();
+  }
+
+  @CheckForNull
+  public String ideInstallationId() {
+    var existing = getStorage().ideInstallationId();
+    if (existing != null) {
+      return existing;
+    }
+    var minted = new AtomicReference<String>();
+    tryUpdateAtomically(storage -> minted.set(storage.ensureIdeInstallationId()));
+    return minted.get();
   }
 }

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/gessie/GessieHttpClient.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/gessie/GessieHttpClient.java
@@ -23,34 +23,70 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import java.util.Map.Entry;
 import java.util.concurrent.CompletableFuture;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.http.HttpClient;
 import org.sonarsource.sonarlint.core.http.HttpClientProvider;
 import org.sonarsource.sonarlint.core.telemetry.InternalDebug;
+import org.sonarsource.sonarlint.core.telemetry.MachineIdProvider;
+import org.sonarsource.sonarlint.core.telemetry.TelemetryLocalStorageManager;
 import org.sonarsource.sonarlint.core.telemetry.gessie.event.GessieEvent;
+import org.sonarsource.sonarlint.core.telemetry.gessie.event.GessieIdentity;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 public class GessieHttpClient {
 
   private static final SonarLintLogger LOG = SonarLintLogger.get();
+  private static final String EVENT_PAYLOAD_KEY = "event_payload";
 
   private final Gson gson = configureGson();
   private final HttpClient client;
   private final String endpoint;
+  private final MachineIdProvider machineIdProvider;
+  private final TelemetryLocalStorageManager telemetryLocalStorageManager;
 
   public GessieHttpClient(HttpClientProvider httpClientProvider,
     @Qualifier("gessieEndpoint") String gessieEndpoint,
-    @Qualifier("gessieApiKey") String gessieApiKey) {
+    @Qualifier("gessieApiKey") String gessieApiKey,
+    MachineIdProvider machineIdProvider,
+    TelemetryLocalStorageManager telemetryLocalStorageManager) {
     this.client = httpClientProvider.getHttpClientWithXApiKeyAndRetries(gessieApiKey);
     this.endpoint = gessieEndpoint;
+    this.machineIdProvider = machineIdProvider;
+    this.telemetryLocalStorageManager = telemetryLocalStorageManager;
   }
 
   public void postEvent(GessieEvent event) {
-    var json = gson.toJson(event);
+    var json = gson.toJson(mergeIdentity(event));
     logGessiePayload(json);
     var futureResponse = client.postAsync(endpoint + "/ide", HttpClient.JSON_CONTENT_TYPE, json);
     handleGessieResponse(futureResponse);
+  }
+
+  private JsonObject mergeIdentity(GessieEvent event) {
+    var eventJson = gson.toJsonTree(event).getAsJsonObject();
+    var eventPayloadElement = eventJson.get(EVENT_PAYLOAD_KEY);
+    if (eventPayloadElement != null && eventPayloadElement.isJsonObject()) {
+      var identity = new GessieIdentity(machineIdProvider.getMachineId(), telemetryLocalStorageManager.ideInstallationId());
+      var identityJson = gson.toJsonTree(identity).getAsJsonObject();
+      mergeObjects(identityJson, eventPayloadElement.getAsJsonObject());
+    }
+    return eventJson;
+  }
+
+  private static JsonObject mergeObjects(JsonObject source, JsonObject target) {
+    for (Entry<String, JsonElement> entry : source.entrySet()) {
+      var value = entry.getValue();
+      if (!target.has(entry.getKey())) {
+        target.add(entry.getKey(), value);
+      } else if (value.isJsonObject()) {
+        mergeObjects((JsonObject) value, target.getAsJsonObject(entry.getKey()));
+      }
+    }
+    return target;
   }
 
   private void logGessiePayload(String json) {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/gessie/GessieService.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/gessie/GessieService.java
@@ -54,7 +54,7 @@ public class GessieService {
           new GessieMetadata.GessieSource(SonarLintDomain.fromProductKey(telemetryConstantAttributes.getProductKey())),
           "Analytics.Editor.PluginActivated",
           Long.toString(Instant.now().toEpochMilli()),
-          "0"),
+          "1"),
         new MessagePayload("Gessie integration test event", "slcore_start")
       ));
     }

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/gessie/event/GessieIdentity.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/gessie/event/GessieIdentity.java
@@ -1,0 +1,28 @@
+/*
+ * SonarLint Core - Telemetry
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.telemetry.gessie.event;
+
+import javax.annotation.Nullable;
+
+public record GessieIdentity(
+  @Nullable String machineId,
+  @Nullable String ideInstallationId
+) {
+}

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresBuilder.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.telemetry.TelemetryLiveAttributes;
 import org.sonarsource.sonarlint.core.telemetry.TelemetryLocalStorage;
 
@@ -42,12 +43,19 @@ public class TelemetryMeasuresBuilder {
   private final String product;
   private final TelemetryLocalStorage storage;
   private final TelemetryLiveAttributes liveAttributes;
+  @Nullable
+  private final String machineId;
+  @Nullable
+  private final String ideInstallationId;
 
-  public TelemetryMeasuresBuilder(String platform, String product, TelemetryLocalStorage storage, TelemetryLiveAttributes liveAttributes) {
+  public TelemetryMeasuresBuilder(String platform, String product, TelemetryLocalStorage storage, TelemetryLiveAttributes liveAttributes,
+    @Nullable String machineId, @Nullable String ideInstallationId) {
     this.platform = platform;
     this.product = product;
     this.storage = storage;
     this.liveAttributes = liveAttributes;
+    this.machineId = machineId;
+    this.ideInstallationId = ideInstallationId;
   }
 
   public TelemetryMeasuresPayload build() {
@@ -87,7 +95,8 @@ public class TelemetryMeasuresBuilder {
 
     addSupportedLanguagesPanelMeasures(values);
 
-    return new TelemetryMeasuresPayload(UUID.randomUUID().toString(), platform, storage.installTime(), product, TelemetryMeasuresDimension.INSTALLATION, values);
+    return new TelemetryMeasuresPayload(UUID.randomUUID().toString(), machineId, ideInstallationId, platform, storage.installTime(), product,
+      TelemetryMeasuresDimension.INSTALLATION, values);
   }
 
   private void addPerformanceMeasures(ArrayList<TelemetryMeasuresValue> values) {

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/measures/payload/TelemetryMeasuresPayload.java
@@ -23,9 +23,12 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.annotations.SerializedName;
 import java.time.OffsetDateTime;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.sonarsource.sonarlint.core.commons.storage.adapter.OffsetDateTimeAdapter;
 
 public record TelemetryMeasuresPayload(@SerializedName("message_uuid") String messageUuid,
+                                       @SerializedName("machine_id") @Nullable String machineId,
+                                       @SerializedName("ide_installation_id") @Nullable String ideInstallationId,
                                        @SerializedName("os") String os,
                                        @SerializedName("install_time") OffsetDateTime installTime,
                                        @SerializedName("sonarlint_product") String product,

--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayload.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayload.java
@@ -116,6 +116,14 @@ public class TelemetryPayload {
   @SerializedName("shared_connected_mode")
   private final ShareConnectedModePayload shareConnectedModePayload;
 
+  @SerializedName("machine_id")
+  @Nullable
+  private final String machineId;
+
+  @SerializedName("ide_installation_id")
+  @Nullable
+  private final String ideInstallationId;
+
   private final transient Map<String, Object> additionalAttributes;
 
   public TelemetryPayload(long daysSinceInstallation, long daysOfUse, String product, String version, String ideVersion, @Nullable String platform, @Nullable String architecture,
@@ -124,7 +132,7 @@ public class TelemetryPayload {
     ShowIssuePayload showIssuePayload, TaintVulnerabilitiesPayload taintVulnerabilitiesPayload, TelemetryRulesPayload telemetryRulesPayload, HotspotPayload hotspotPayload,
     IssuePayload issuePayload, TelemetryHelpAndFeedbackPayload helpAndFeedbackPayload, TelemetryFixSuggestionPayload[] aiFixSuggestionsPayload,
     int countIssuesWithPossibleAiFixFromIde, CleanAsYouCodePayload cleanAsYouCodePayload, ShareConnectedModePayload shareConnectedModePayload,
-    Map<String, Object> additionalAttributes) {
+    @Nullable String machineId, @Nullable String ideInstallationId, Map<String, Object> additionalAttributes) {
     this.daysSinceInstallation = daysSinceInstallation;
     this.daysOfUse = daysOfUse;
     this.product = product;
@@ -152,6 +160,8 @@ public class TelemetryPayload {
     this.countIssuesWithPossibleAiFixFromIde = countIssuesWithPossibleAiFixFromIde;
     this.cleanAsYouCodePayload = cleanAsYouCodePayload;
     this.shareConnectedModePayload = shareConnectedModePayload;
+    this.machineId = machineId;
+    this.ideInstallationId = ideInstallationId;
     this.additionalAttributes = additionalAttributes;
   }
 
@@ -265,6 +275,16 @@ public class TelemetryPayload {
 
   public int getCountIssuesWithPossibleAiFixFromIde() {
     return countIssuesWithPossibleAiFixFromIde;
+  }
+
+  @Nullable
+  public String getMachineId() {
+    return machineId;
+  }
+
+  @Nullable
+  public String getIdeInstallationId() {
+    return ideInstallationId;
   }
 
   public String toJson() {

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProviderTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProviderTests.java
@@ -1,0 +1,155 @@
+/*
+ * SonarLint Core - Telemetry
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.telemetry;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.sonarsource.sonarlint.core.commons.SonarUserHome;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
+import org.sonarsource.sonarlint.core.telemetry.common.TelemetryUserSetting;
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SystemStubsExtension.class)
+class MachineIdProviderTests {
+
+  @RegisterExtension
+  private static final SonarLintLogTester logTester = new SonarLintLogTester();
+
+  @SystemStub
+  EnvironmentVariables environmentVariables;
+
+  @Test
+  void should_return_null_when_telemetry_is_disabled(@TempDir Path tempDir) {
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
+    var userSetting = telemetryEnabled(false);
+
+    var machineId = new MachineIdProvider(userSetting).getMachineId();
+
+    assertThat(machineId).isNull();
+    assertThat(tempDir.resolve("user")).doesNotExist();
+  }
+
+  @Test
+  void should_create_and_persist_a_new_machine_id_when_file_is_absent(@TempDir Path tempDir) {
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
+    var userSetting = telemetryEnabled(true);
+
+    var machineId = new MachineIdProvider(userSetting).getMachineId();
+
+    assertThat(machineId).isNotBlank();
+    assertThat(UUID.fromString(machineId)).isNotNull();
+    assertThat(tempDir.resolve("user")).exists().hasContent(machineId);
+  }
+
+  @Test
+  void should_read_an_existing_machine_id_verbatim(@TempDir Path tempDir) throws IOException {
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
+    var cliWrittenId = "97323cbb-914c-49e2-b603-9260861dbb7b";
+    Files.writeString(tempDir.resolve("user"), cliWrittenId);
+    var userSetting = telemetryEnabled(true);
+
+    var machineId = new MachineIdProvider(userSetting).getMachineId();
+
+    assertThat(machineId).isEqualTo(cliWrittenId);
+  }
+
+  @Test
+  void should_recreate_a_blank_file(@TempDir Path tempDir) throws IOException {
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
+    Files.writeString(tempDir.resolve("user"), "  ");
+    var userSetting = telemetryEnabled(true);
+
+    var machineId = new MachineIdProvider(userSetting).getMachineId();
+
+    assertThat(machineId).isNotBlank();
+    assertThat(tempDir.resolve("user")).hasContent(machineId);
+  }
+
+  @Test
+  void should_return_null_when_the_shared_home_cannot_be_created(@TempDir Path tempDir) {
+    var unwritableParent = tempDir.resolve("not-a-directory");
+    unwritableParent.toFile().getParentFile().mkdirs();
+    try {
+      Files.writeString(unwritableParent, "blocking file");
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, unwritableParent.resolve("sonar").toString());
+    var userSetting = telemetryEnabled(true);
+
+    var machineId = new MachineIdProvider(userSetting).getMachineId();
+
+    assertThat(machineId).isNull();
+  }
+
+  @Test
+  void should_cache_the_resolved_value_for_the_provider_lifetime(@TempDir Path tempDir) {
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
+    var userSetting = telemetryEnabled(true);
+    var provider = new MachineIdProvider(userSetting);
+
+    var first = provider.getMachineId();
+    try {
+      Files.writeString(tempDir.resolve("user"), UUID.randomUUID().toString());
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+    var second = provider.getMachineId();
+
+    assertThat(second).isEqualTo(first);
+  }
+
+  @Test
+  void concurrent_creation_should_converge_on_the_same_value(@TempDir Path tempDir) throws InterruptedException {
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
+    var userSetting = telemetryEnabled(true);
+    var results = new String[10];
+    ExecutorService pool = Executors.newFixedThreadPool(10);
+    for (var i = 0; i < results.length; i++) {
+      var index = i;
+      pool.submit(() -> results[index] = new MachineIdProvider(userSetting).getMachineId());
+    }
+    pool.shutdown();
+    pool.awaitTermination(10, TimeUnit.SECONDS);
+
+    assertThat(results).isNotNull().allSatisfy(id -> assertThat(id).isEqualTo(results[0]));
+  }
+
+  private static TelemetryUserSetting telemetryEnabled(boolean enabled) {
+    var userSetting = mock(TelemetryUserSetting.class);
+    when(userSetting.isTelemetryEnabledByUser()).thenReturn(enabled);
+    return userSetting;
+  }
+}

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryHttpClientTests.java
@@ -38,6 +38,7 @@ import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.McpTransport
 import org.sonarsource.sonarlint.core.rpc.protocol.client.telemetry.TelemetryClientLiveAttributesResponse;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
@@ -49,16 +50,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class TelemetryHttpClientTests {
+  private static final String STUBBED_MACHINE_ID = "97323cbb-914c-49e2-b603-9260861dbb7b";
+
   @RegisterExtension
   private static final SonarLintLogTester logTester = new SonarLintLogTester();
   private static final String PLATFORM = SystemUtils.OS_NAME;
   private static final String ARCHITECTURE = SystemUtils.OS_ARCH;
 
   private TelemetryHttpClient underTest;
+  private MachineIdProvider machineIdProvider;
 
   @RegisterExtension
   static WireMockExtension telemetryMock = WireMockExtension.newInstance()
@@ -71,7 +77,9 @@ class TelemetryHttpClientTests {
     when(initializeParams.getTelemetryConstantAttributes())
       .thenReturn(new TelemetryClientConstantAttributesDto(null, "product", "version", "ideversion", Map.of("additionalKey", "additionalValue")));
 
-    underTest = new TelemetryHttpClient(initializeParams, HttpClientProvider.forTesting(), telemetryMock.baseUrl());
+    machineIdProvider = mock(MachineIdProvider.class);
+    when(machineIdProvider.getMachineId()).thenReturn(STUBBED_MACHINE_ID);
+    underTest = new TelemetryHttpClient(initializeParams, HttpClientProvider.forTesting(), telemetryMock.baseUrl(), machineIdProvider);
   }
 
   @Test
@@ -86,6 +94,21 @@ class TelemetryHttpClientTests {
         equalToJson(
           "{\"days_since_installation\":0,\"days_of_use\":0,\"sonarlint_version\":\"version\",\"sonarlint_product\":\"product\",\"ide_version\":\"ideversion\",\"platform\":\"" + PLATFORM + "\",\"architecture\":\"" + ARCHITECTURE + "\"}",
           true, true))));
+  }
+
+  @Test
+  void opt_out_should_never_include_or_mint_an_identifier() {
+    telemetryMock.stubFor(delete("/")
+      .willReturn(aResponse()));
+    var telemetryLocalStorage = new TelemetryLocalStorage();
+
+    underTest.optOut(telemetryLocalStorage, getTelemetryLiveAttributesDto());
+
+    await().untilAsserted(() -> telemetryMock.verify(deleteRequestedFor(urlEqualTo("/"))
+      .withRequestBody(containing("\"machine_id\":null"))
+      .withRequestBody(containing("\"ide_installation_id\":null"))));
+    verify(machineIdProvider, never()).getMachineId();
+    assertThat(telemetryLocalStorage.ideInstallationId()).isNull();
   }
 
   @Test

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageManagerTests.java
@@ -216,4 +216,25 @@ class TelemetryLocalStorageManagerTests {
     assertThat(numUseDays).isEqualTo(42);
     assertThat(actualInstallTime).isEqualTo(expectedInstallTime);
   }
+
+  @Test
+  void ideInstallationId_should_mint_and_persist_on_first_access() {
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+
+    var ideInstallationId = storage.ideInstallationId();
+
+    assertThat(ideInstallationId).isNotBlank();
+    assertThat(UUID.fromString(ideInstallationId)).isNotNull();
+    assertThat(storage.tryRead().ideInstallationId()).isEqualTo(ideInstallationId);
+  }
+
+  @Test
+  void ideInstallationId_should_be_stable_across_calls() {
+    var storage = new TelemetryLocalStorageManager(filePath, mock(InitializeParams.class));
+
+    var first = storage.ideInstallationId();
+    var second = storage.ideInstallationId();
+
+    assertThat(second).isEqualTo(first);
+  }
 }

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/TelemetryLocalStorageTests.java
@@ -437,4 +437,32 @@ class TelemetryLocalStorageTests {
     assertThat(data.getSupportedLanguagesPanelCtaClickedCount()).isZero();
   }
 
+  @Test
+  void ideInstallationId_should_be_absent_until_first_accessed() {
+    var data = new TelemetryLocalStorage();
+    assertThat(data.ideInstallationId()).isNull();
+  }
+
+  @Test
+  void ensureIdeInstallationId_should_mint_once_and_reuse_afterwards() {
+    var data = new TelemetryLocalStorage();
+
+    var minted = data.ensureIdeInstallationId();
+
+    assertThat(minted).isNotBlank();
+    assertThat(UUID.fromString(minted)).isNotNull();
+    assertThat(data.ideInstallationId()).isEqualTo(minted);
+    assertThat(data.ensureIdeInstallationId()).isEqualTo(minted);
+  }
+
+  @Test
+  void ideInstallationId_should_survive_clear_after_ping() {
+    var data = new TelemetryLocalStorage();
+    var ideInstallationId = data.ensureIdeInstallationId();
+
+    data.clearAfterPing();
+
+    assertThat(data.ideInstallationId()).isEqualTo(ideInstallationId);
+  }
+
 }

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/gessie/GessieHttpClientTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/gessie/GessieHttpClientTests.java
@@ -31,24 +31,31 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.http.HttpClientProvider;
+import org.sonarsource.sonarlint.core.telemetry.MachineIdProvider;
+import org.sonarsource.sonarlint.core.telemetry.TelemetryLocalStorageManager;
 import org.sonarsource.sonarlint.core.telemetry.gessie.event.GessieEvent;
 import org.sonarsource.sonarlint.core.telemetry.gessie.event.GessieMetadata;
 import org.sonarsource.sonarlint.core.telemetry.gessie.event.payload.MessagePayload;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.core.telemetry.gessie.event.GessieMetadata.GessieSource;
 import static org.sonarsource.sonarlint.core.telemetry.gessie.event.GessieMetadata.SonarLintDomain;
 
 class GessieHttpClientTests {
 
   private static final String IDE_ENDPOINT = "/ide";
+  private static final String MACHINE_ID = "97323cbb-914c-49e2-b603-9260861dbb7b";
+  private static final String INSTALLATION_ID = "1b4ab807-d005-42b8-8ddd-ba5ab68a1770";
 
   private GessieHttpClient tested;
 
@@ -62,7 +69,11 @@ class GessieHttpClientTests {
 
   @BeforeEach
   void setUp() {
-    tested = new GessieHttpClient(HttpClientProvider.forTesting(), mockGessie.baseUrl(), "value");
+    var machineIdProvider = mock(MachineIdProvider.class);
+    when(machineIdProvider.getMachineId()).thenReturn(MACHINE_ID);
+    var telemetryLocalStorageManager = mock(TelemetryLocalStorageManager.class);
+    when(telemetryLocalStorageManager.ideInstallationId()).thenReturn(INSTALLATION_ID);
+    tested = new GessieHttpClient(HttpClientProvider.forTesting(), mockGessie.baseUrl(), "value", machineIdProvider, telemetryLocalStorageManager);
   }
 
   @Test
@@ -102,6 +113,21 @@ class GessieHttpClientTests {
     await().untilAsserted(() -> mockGessie.verify(postRequestedFor(urlEqualTo(IDE_ENDPOINT))
       .withHeader("x-api-key", new EqualToPattern("value"))
       .withRequestBody(equalToJson(fileContent))));
+  }
+
+  @Test
+  void should_serialize_a_null_machine_id_as_explicit_null() {
+    var machineIdProvider = mock(MachineIdProvider.class);
+    when(machineIdProvider.getMachineId()).thenReturn(null);
+    var telemetryLocalStorageManager = mock(TelemetryLocalStorageManager.class);
+    when(telemetryLocalStorageManager.ideInstallationId()).thenReturn(INSTALLATION_ID);
+    tested = new GessieHttpClient(HttpClientProvider.forTesting(), mockGessie.baseUrl(), "value", machineIdProvider, telemetryLocalStorageManager);
+    mockGessie.stubFor(post(IDE_ENDPOINT).willReturn(aResponse().withStatus(202)));
+
+    tested.postEvent(getPayload());
+
+    await().untilAsserted(() -> mockGessie.verify(postRequestedFor(urlEqualTo(IDE_ENDPOINT))
+      .withRequestBody(containing("\"machine_id\":null"))));
   }
 
   private String getTestJson(String fileName) throws URISyntaxException, IOException {

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryMeasuresPayloadTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryMeasuresPayloadTests.java
@@ -48,6 +48,8 @@ class TelemetryMeasuresPayloadTests {
 
     var m = new TelemetryMeasuresPayload(
       messageUuid,
+      "97323cbb-914c-49e2-b603-9260861dbb7b",
+      "1b4ab807-d005-42b8-8ddd-ba5ab68a1770",
       "Linux Ubuntu 24.04",
       installTime,
       "SonarQube for IDE",
@@ -59,6 +61,8 @@ class TelemetryMeasuresPayloadTests {
 
     assertThat(s).isEqualTo("{" +
       "\"message_uuid\":\"25318599-9aec-4e1d-a535-1bfa4f7fcf39\"," +
+      "\"machine_id\":\"97323cbb-914c-49e2-b603-9260861dbb7b\"," +
+      "\"ide_installation_id\":\"1b4ab807-d005-42b8-8ddd-ba5ab68a1770\"," +
       "\"os\":\"Linux Ubuntu 24.04\"," +
       "\"install_time\":\"2017-11-10T12:01:14.984+02:00\"," +
       "\"sonarlint_product\":\"SonarQube for IDE\"," +
@@ -105,11 +109,21 @@ class TelemetryMeasuresPayloadTests {
       "]}");
 
     assertThat(m.messageUuid()).isEqualTo(messageUuid);
+    assertThat(m.machineId()).isEqualTo("97323cbb-914c-49e2-b603-9260861dbb7b");
+    assertThat(m.ideInstallationId()).isEqualTo("1b4ab807-d005-42b8-8ddd-ba5ab68a1770");
     assertThat(m.os()).isEqualTo("Linux Ubuntu 24.04");
     assertThat(m.installTime()).isEqualTo(installTime);
     assertThat(m.product()).isEqualTo("SonarQube for IDE");
     assertThat(m.dimension()).isEqualTo(TelemetryMeasuresDimension.INSTALLATION);
     assertValues(m.values());
+  }
+
+  @Test
+  void machineIdAndIdeInstallationId_should_serialize_as_explicit_null_when_absent() {
+    var m = new TelemetryMeasuresPayload("25318599-9aec-4e1d-a535-1bfa4f7fcf39", null, null,
+      "Linux Ubuntu 24.04", OffsetDateTime.now(), "SonarQube for IDE", TelemetryMeasuresDimension.INSTALLATION, List.of());
+
+    assertThat(m.toJson()).contains("\"machine_id\":null", "\"ide_installation_id\":null");
   }
 
   private List<TelemetryMeasuresValue> generateMeasures() {

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayloadTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/payload/TelemetryPayloadTests.java
@@ -78,7 +78,8 @@ class TelemetryPayloadTests {
     var m = new TelemetryPayload(4, 15, "SLI", "2.4", "Pycharm 3.2", "platform", "architecture",
       true, true, systemTime, installTime, "Windows 10", "1.8.0", "10.5.2", perf,
       notifPayload, showHotspotPayload, showIssuePayload, taintVulnerabilitiesPayload, rulesPayload, hotspotPayload, issuePayload, helpAndFeedbackPayload,
-      aiFixSuggestionsPayload, 1, cleanAsYouCodePayload, sharedConnectedModePayload, additionalProps);
+      aiFixSuggestionsPayload, 1, cleanAsYouCodePayload, sharedConnectedModePayload,
+      "97323cbb-914c-49e2-b603-9260861dbb7b", "1b4ab807-d005-42b8-8ddd-ba5ab68a1770", additionalProps);
     var s = m.toJson();
 
     assertThat(s).isEqualTo("{\"days_since_installation\":4,"
@@ -108,6 +109,8 @@ class TelemetryPayloadTests {
       + "\"count_issues_with_possible_ai_fix_from_ide\":1,"
       + "\"cayc\":{\"new_code_focus\":{\"enabled\":true,\"changes\":2}},"
       + "\"shared_connected_mode\":{\"manual_bindings_count\":3,\"imported_bindings_count\":2,\"auto_bindings_count\":1,\"exported_connected_mode_count\":4},"
+      + "\"machine_id\":\"97323cbb-914c-49e2-b603-9260861dbb7b\","
+      + "\"ide_installation_id\":\"1b4ab807-d005-42b8-8ddd-ba5ab68a1770\","
       + "\"aString\":\"stringValue\","
       + "\"aBool\":false,"
       + "\"aNumber\":1.5,"
@@ -143,6 +146,8 @@ class TelemetryPayloadTests {
     assertThat(m.getIdeVersion()).isEqualTo("Pycharm 3.2");
     assertThat(m.getPlatform()).isEqualTo("platform");
     assertThat(m.getArchitecture()).isEqualTo("architecture");
+    assertThat(m.getMachineId()).isEqualTo("97323cbb-914c-49e2-b603-9260861dbb7b");
+    assertThat(m.getIdeInstallationId()).isEqualTo("1b4ab807-d005-42b8-8ddd-ba5ab68a1770");
     assertThat(m.getInstallTime()).hasToString("2017-11-10T12:01:14.984123123+02:00");
     assertThat(m.os()).isEqualTo("Windows 10");
     assertThat(m.jre()).isEqualTo("1.8.0");

--- a/backend/telemetry/src/test/resources/response/gessie/GessieHttpClientTest/GessieRequest.json
+++ b/backend/telemetry/src/test/resources/response/gessie/GessieHttpClientTest/GessieRequest.json
@@ -10,6 +10,8 @@
   },
   "event_payload": {
     "message": "Test event",
-    "trigger": "test"
+    "trigger": "test",
+    "machine_id": "97323cbb-914c-49e2-b603-9260861dbb7b",
+    "ide_installation_id": "1b4ab807-d005-42b8-8ddd-ba5ab68a1770"
   }
 }

--- a/medium-tests/pom.xml
+++ b/medium-tests/pom.xml
@@ -97,6 +97,10 @@
           <configuration>
             <forkCount>0.25C</forkCount>
             <reuseForks>true</reuseForks>
+            <environmentVariables>
+              <!-- Isolate MachineIdProvider from the real ~/.sonar/user during medium tests -->
+              <SONAR_USER_HOME>${project.build.directory}/sonar-user-home-test</SONAR_USER_HOME>
+            </environmentVariables>
           </configuration>
         </plugin>
       <plugin>

--- a/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/TelemetryMediumTests.java
@@ -70,7 +70,13 @@ import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
 import utils.TestPlugin;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.delete;
+import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.matching;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
@@ -183,6 +189,44 @@ class TelemetryMediumTests {
         "}", true, true))));
 
     System.clearProperty("sonarlint.internal.telemetry.initialDelay");
+  }
+
+  @SonarLintTest
+  void it_should_send_machine_id_and_ide_installation_id_on_upload(SonarLintTestHarness harness) {
+    System.setProperty("sonarlint.internal.telemetry.initialDelay", "0");
+    var fakeClient = harness.newFakeClient().build();
+    when(fakeClient.getTelemetryLiveAttributes()).thenReturn(new TelemetryClientLiveAttributesResponse(emptyMap()));
+
+    var backend = harness.newBackend()
+      .withTelemetryEnabled(telemetryEndpointMock.baseUrl() + "/sonarlint-telemetry")
+      .withEnabledLanguageInStandaloneMode(Language.JS)
+      .start(fakeClient);
+
+    await().untilAsserted(() -> assertThat(backend.telemetryFileContent().ideInstallationId()).isNotBlank());
+    var ideInstallationId = backend.telemetryFileContent().ideInstallationId();
+
+    await().untilAsserted(() -> telemetryEndpointMock.verify(postRequestedFor(urlEqualTo("/sonarlint-telemetry"))
+      .withRequestBody(matchingJsonPath("$.machine_id", matching("[0-9a-f-]{36}")))
+      .withRequestBody(matchingJsonPath("$.ide_installation_id", equalTo(ideInstallationId)))));
+    System.clearProperty("sonarlint.internal.telemetry.initialDelay");
+  }
+
+  @SonarLintTest
+  void it_should_omit_machine_id_and_ide_installation_id_on_opt_out(SonarLintTestHarness harness) throws ExecutionException, InterruptedException {
+    telemetryEndpointMock.stubFor(delete("/sonarlint-telemetry").willReturn(aResponse().withStatus(200)));
+    var backend = harness.newBackend()
+      .withSonarQubeConnection("connectionId")
+      .withBoundConfigScope("scopeId", "connectionId", "projectKey")
+      .withTelemetryEnabled(telemetryEndpointMock.baseUrl() + "/sonarlint-telemetry")
+      .start();
+    assertThat(backend.getTelemetryService().getStatus().get().isEnabled()).isTrue();
+
+    backend.getTelemetryService().disableTelemetry();
+
+    assertThat(backend.telemetryFileContent().ideInstallationId()).isNull();
+    await().untilAsserted(() -> telemetryEndpointMock.verify(deleteRequestedFor(urlEqualTo("/sonarlint-telemetry"))
+      .withRequestBody(containing("\"machine_id\":null"))
+      .withRequestBody(containing("\"ide_installation_id\":null"))));
   }
 
   @SonarLintTest

--- a/medium-tests/src/test/java/mediumtest/gessie/GessieIntegrationMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/gessie/GessieIntegrationMediumTests.java
@@ -84,7 +84,7 @@ class GessieIntegrationMediumTests {
     var fileContent = getTestJson("GessieRequest");
     await().untilAsserted(() -> gessieEndpointMock.verify(postRequestedFor(urlEqualTo(IDE_ENDPOINT))
       .withHeader("x-api-key", new EqualToPattern("value"))
-      .withRequestBody(equalToJson(fileContent))));
+      .withRequestBody(equalToJson(fileContent, true, true))));
   }
 
   @SonarLintTest
@@ -115,7 +115,7 @@ class GessieIntegrationMediumTests {
     await().atMost(15, TimeUnit.SECONDS)
       .untilAsserted(() -> gessieEndpointMock.verify(2, postRequestedFor(urlEqualTo(IDE_ENDPOINT))
       .withHeader("x-api-key", new EqualToPattern("value"))
-      .withRequestBody(equalToJson(fileContent))));
+      .withRequestBody(equalToJson(fileContent, true, true))));
   }
 
   @SonarLintTest
@@ -133,7 +133,7 @@ class GessieIntegrationMediumTests {
       .pollDelay(2, TimeUnit.SECONDS)
       .untilAsserted(() -> gessieEndpointMock.verify(3, postRequestedFor(urlEqualTo(IDE_ENDPOINT))
       .withHeader("x-api-key", new EqualToPattern("value"))
-      .withRequestBody(equalToJson(fileContent))));
+      .withRequestBody(equalToJson(fileContent, true, true))));
   }
 
   private String getTestJson(String fileName) throws URISyntaxException, IOException {

--- a/medium-tests/src/test/resources/response/gessie/GessieIntegrationMediumTests/GessieRequest.json
+++ b/medium-tests/src/test/resources/response/gessie/GessieIntegrationMediumTests/GessieRequest.json
@@ -6,7 +6,7 @@
     },
     "event_type": "Analytics.Editor.PluginActivated",
     "event_timestamp": "${json-unit.any-string}",
-    "event_version": "0"
+    "event_version": "1"
   },
   "event_payload": {
     "message": "Gessie integration test event",


### PR DESCRIPTION
----
## Summary by Gitar

- **Telemetry identity tracking:**
    - Added `MachineIdProvider` and `GessieIdentity` to share `machine_id` and `installation_id` across IDE telemetry and CLI.
    - Updated `TelemetryHttpClient`, `GessieHttpClient`, and measures payloads to include identity fields.

<sub>This will update automatically on new commits.</sub>