### PR TITLE
Override transitive Jetty to 12.0.38 to fix CVE-2026-10050

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,9 @@
          on Jackson 2.x, later versions move flyway-core itself to Jackson 3.x (tools.jackson.core) -->
     <jackson.version>2.22.1</jackson.version>
     <bouncycastle.version>1.84</bouncycastle.version>
+    <!-- Override the Jetty transitively pulled by wiremock-jetty12:3.13.2 (test scope, 12.0.30):
+         fixes CVE-2026-10050 (jetty-security/jetty-client Digest auth bypass), wiremock-jetty12 has no newer release yet -->
+    <jetty.version>12.0.38</jetty.version>
     <!-- On-demand plugin versions -->
     <cfamily.version>6.83.0.100813</cfamily.version>
     <csharp.version>10.31.0.145097</csharp.version>
@@ -109,6 +112,20 @@
          <version>6.2.19</version>
          <type>pom</type>
          <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-bom</artifactId>
+        <version>${jetty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -63,6 +63,18 @@
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-jetty12</artifactId>
     </dependency>
+    <!-- Force the Jetty artifacts affected by CVE-2026-10050 and pinned in the root pom's dependencyManagement
+         (jetty-bom import) to be direct dependencies here, otherwise the pin never propagates to consumers of
+         sonarlint-core-test-utils: wiremock-jetty12 is a direct dependency here and transitively pulls its own
+         older jetty-security/jetty-client versions. -->
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-security</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver3</artifactId>


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Security updates:**
    - Override transitive Jetty version to `12.0.38` via `pom.xml` to fix CVE-2026-10050
    - Add direct dependencies for `jetty-client` and `jetty-security` in `sonarlint-core-test-utils`

<sub>This will update automatically on new commits.</sub>