### PR TITLE
SLCORE-2542 Fix taint severity assertion in SonarCloudTests IT

### DIFF
--- a/its/tests/src/test/java/its/SonarCloudTests.java
+++ b/its/tests/src/test/java/its/SonarCloudTests.java
@@ -602,7 +602,7 @@ class SonarCloudTests extends AbstractConnectedTests {
       assertThat(taintVulnerability.getSeverityMode().isRight()).isTrue();
       assertThat(taintVulnerability.getSeverityMode().getRight().getCleanCodeAttribute()).isEqualTo(CleanCodeAttribute.COMPLETE);
       assertThat(taintVulnerability.getSeverityMode().getRight().getImpacts().getFirst()).extracting("softwareQuality", "impactSeverity").containsExactly(SoftwareQuality.SECURITY,
-        ImpactSeverity.BLOCKER);
+        ImpactSeverity.MEDIUM);
       assertThat(taintVulnerability.getFlows()).isNotEmpty();
       assertThat(taintVulnerability.isOnNewCode()).isTrue();
       // the feature is not enabled for our org


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Test fixes:**
    - Updated taint severity assertion in `SonarCloudTests.java` from `BLOCKER` to `MEDIUM` to prevent flakiness.


<sub>This will update automatically on new commits.</sub>