### PR TITLE
SLCORE-2418 Migrate analyzer download from SQC Web endpoint to CloudFront CDN

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloader.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloader.java
@@ -19,9 +19,11 @@
  */
 package org.sonarsource.sonarlint.core.plugin.source.server;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 import org.sonarsource.sonarlint.core.SonarQubeClientManager;
 import org.sonarsource.sonarlint.core.commons.ConnectionKind;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
@@ -35,6 +37,7 @@ import org.sonarsource.sonarlint.core.plugin.source.ArtifactState;
 import org.sonarsource.sonarlint.core.plugin.source.UniqueTaskExecutor;
 import org.sonarsource.sonarlint.core.repository.connection.ConnectionConfigurationRepository;
 import org.sonarsource.sonarlint.core.serverapi.plugins.ServerPlugin;
+import org.sonarsource.sonarlint.core.serverapi.plugins.SonarCloudCdnPlugins;
 import org.sonarsource.sonarlint.core.storage.StorageService;
 import org.springframework.context.ApplicationEventPublisher;
 
@@ -121,10 +124,14 @@ public class ServerPluginDownloader {
     var pluginKey = serverPlugin.getKey();
     LOG.info("[SYNC] Downloading plugin '{}'", serverPlugin.getFilename());
     var cancelMonitor = new SonarLintCancelMonitor();
-    sonarQubeClientManager.withActiveClient(connectionId,
-      api -> api.plugins().getPlugin(pluginKey, serverPlugin.getHash(),
-        binary -> storageService.connection(connectionId).plugins().store(serverPlugin, binary),
-        cancelMonitor));
+    sonarQubeClientManager.withActiveClient(connectionId, api -> {
+      Consumer<InputStream> store = binary -> storageService.connection(connectionId).plugins().store(serverPlugin, binary);
+      if (api.isSonarCloud()) {
+        new SonarCloudCdnPlugins(api.getHelper()).getPlugin(pluginKey, serverPlugin.getHash(), store, cancelMonitor);
+      } else {
+        api.plugins().getPlugin(pluginKey, store, cancelMonitor);
+      }
+    });
   }
 
   private void fireFailedEvent(String connectionId, SonarPlugin sonarPlugin) {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloader.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloader.java
@@ -122,7 +122,7 @@ public class ServerPluginDownloader {
     LOG.info("[SYNC] Downloading plugin '{}'", serverPlugin.getFilename());
     var cancelMonitor = new SonarLintCancelMonitor();
     sonarQubeClientManager.withActiveClient(connectionId,
-      api -> api.plugins().getPlugin(pluginKey,
+      api -> api.plugins().getPlugin(pluginKey, serverPlugin.getHash(),
         binary -> storageService.connection(connectionId).plugins().store(serverPlugin, binary),
         cancelMonitor));
   }

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloaderTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/server/ServerPluginDownloaderTest.java
@@ -148,6 +148,7 @@ class ServerPluginDownloaderTest {
   private static ServerPlugin mockServerPlugin(String pluginKey) {
     var plugin = mock(ServerPlugin.class);
     when(plugin.getKey()).thenReturn(pluginKey);
+    when(plugin.getHash()).thenReturn("hash");
     return plugin;
   }
 }

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApiHelper.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/ServerApiHelper.java
@@ -93,7 +93,11 @@ public class ServerApiHelper {
   }
 
   public HttpClient.Response getAnonymous(String path, SonarLintCancelMonitor cancelMonitor) {
-    var response = rawGetUrlAnonymous(buildEndpointUrl(path), cancelMonitor);
+    return getAnonymousUrl(buildEndpointUrl(path), cancelMonitor);
+  }
+
+  public HttpClient.Response getAnonymousUrl(String url, SonarLintCancelMonitor cancelMonitor) {
+    var response = rawGetUrlAnonymous(url, cancelMonitor);
     if (!response.isSuccessful()) {
       throw handleError(response);
     }
@@ -281,6 +285,10 @@ public class ServerApiHelper {
 
   public Optional<String> getOrganizationKey() {
     return endpointParams.getOrganization();
+  }
+
+  public String getBaseUrl() {
+    return endpointParams.getBaseUrl();
   }
 
   public <G, F> void getPaginated(String relativeUrlWithoutPaginationParams, CheckedFunction<InputStream, G> responseParser, Function<G, Number> getPagingTotal,

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
@@ -80,8 +80,8 @@ public class PluginsApi {
       throw new IllegalArgumentException("SonarQube Cloud URL must contain a host: " + baseUrl);
     }
     try {
-      var scannerUri = new URI(baseUri.getScheme(), null, "scanner." + host, baseUri.getPort(), null, null, null);
-      return scannerUri + "/plugins/" + urlEncode(key) + "/versions/" + urlEncode(hash) + ".jar";
+      var path = "/plugins/" + key + "/versions/" + hash + ".jar";
+      return new URI(baseUri.getScheme(), null, "scanner." + host, baseUri.getPort(), path, null, null).toASCIIString();
     } catch (URISyntaxException e) {
       throw new IllegalArgumentException("Unable to build the SonarQube Cloud plugin download URL", e);
     }

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
@@ -60,7 +60,7 @@ public class PluginsApi {
   public void getPlugin(String key, String hash, Consumer<InputStream> pluginFileConsumer, SonarLintCancelMonitor cancelMonitor) {
     var url = helper.isSonarCloud()
       ? buildSonarCloudPluginDownloadUrl(helper.getBaseUrl(), key, hash)
-      : "api/plugins/download?plugin=" + urlEncode(key);
+      : ("api/plugins/download?plugin=" + urlEncode(key));
     var start = System.currentTimeMillis();
     try (var response = get(url, cancelMonitor)) {
       pluginFileConsumer.accept(response.bodyAsStream());

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApi.java
@@ -20,6 +20,8 @@
 package org.sonarsource.sonarlint.core.serverapi.plugins;
 
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -27,6 +29,8 @@ import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
 import org.sonarsource.sonarlint.core.http.HttpClient;
 import org.sonarsource.sonarlint.core.serverapi.ServerApiHelper;
+
+import static org.sonarsource.sonarlint.core.serverapi.UrlUtils.urlEncode;
 
 public class PluginsApi {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
@@ -53,8 +57,10 @@ public class PluginsApi {
     return new ServerPlugin(payload.key(), payload.hash(), payload.filename(), payload.sonarLintSupported());
   }
 
-  public void getPlugin(String key, Consumer<InputStream> pluginFileConsumer, SonarLintCancelMonitor cancelMonitor) {
-    var url = "api/plugins/download?plugin=" + key;
+  public void getPlugin(String key, String hash, Consumer<InputStream> pluginFileConsumer, SonarLintCancelMonitor cancelMonitor) {
+    var url = helper.isSonarCloud()
+      ? buildSonarCloudPluginDownloadUrl(helper.getBaseUrl(), key, hash)
+      : "api/plugins/download?plugin=" + urlEncode(key);
     var start = System.currentTimeMillis();
     try (var response = get(url, cancelMonitor)) {
       pluginFileConsumer.accept(response.bodyAsStream());
@@ -63,8 +69,22 @@ public class PluginsApi {
     }
   }
 
-  private HttpClient.Response get(String path, SonarLintCancelMonitor cancelMonitor) {
-    return helper.isSonarCloud() ? helper.getAnonymous(path, cancelMonitor) : helper.get(path, cancelMonitor);
+  private HttpClient.Response get(String url, SonarLintCancelMonitor cancelMonitor) {
+    return helper.isSonarCloud() ? helper.getAnonymousUrl(url, cancelMonitor) : helper.get(url, cancelMonitor);
+  }
+
+  static String buildSonarCloudPluginDownloadUrl(String baseUrl, String key, String hash) {
+    var baseUri = URI.create(baseUrl);
+    var host = baseUri.getHost();
+    if (host == null) {
+      throw new IllegalArgumentException("SonarQube Cloud URL must contain a host: " + baseUrl);
+    }
+    try {
+      var scannerUri = new URI(baseUri.getScheme(), null, "scanner." + host, baseUri.getPort(), null, null, null);
+      return scannerUri + "/plugins/" + urlEncode(key) + "/versions/" + urlEncode(hash) + ".jar";
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Unable to build the SonarQube Cloud plugin download URL", e);
+    }
   }
 
 }

--- a/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/SonarCloudCdnPlugins.java
+++ b/backend/server-api/src/main/java/org/sonarsource/sonarlint/core/serverapi/plugins/SonarCloudCdnPlugins.java
@@ -20,51 +20,47 @@
 package org.sonarsource.sonarlint.core.serverapi.plugins;
 
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.function.Consumer;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
 import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
 import org.sonarsource.sonarlint.core.serverapi.ServerApiHelper;
 
-import static org.sonarsource.sonarlint.core.serverapi.UrlUtils.urlEncode;
-
 /**
- * Client for SonarQube Server/Cloud {@code /api/plugins/*} endpoints.
- * SonarQube Cloud plugin jar downloads go through {@link SonarCloudCdnPlugins} instead.
+ * Downloads SonarQube Cloud analyzer jars from the CloudFront CDN ({@code scanner.<host>}),
+ * which is not part of the SonarQube Web API.
  */
-public class PluginsApi {
+public class SonarCloudCdnPlugins {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
-  public static final String API_PLUGINS_INSTALLED_PATH = "/api/plugins/installed";
 
   private final ServerApiHelper helper;
 
-  public PluginsApi(ServerApiHelper helper) {
+  public SonarCloudCdnPlugins(ServerApiHelper helper) {
     this.helper = helper;
   }
 
-  public List<ServerPlugin> getInstalled(SonarLintCancelMonitor cancelMonitor) {
+  public void getPlugin(String key, String hash, Consumer<InputStream> pluginFileConsumer, SonarLintCancelMonitor cancelMonitor) {
+    var url = buildDownloadUrl(helper.getBaseUrl(), key, hash);
     var start = System.currentTimeMillis();
-    var plugins = helper.isSonarCloud()
-      ? helper.getAnonymousJson(API_PLUGINS_INSTALLED_PATH, InstalledPluginsPayloadDto.class, cancelMonitor)
-      : helper.getJson(API_PLUGINS_INSTALLED_PATH, InstalledPluginsPayloadDto.class, cancelMonitor);
-    var result = Arrays.stream(plugins.plugins()).map(PluginsApi::toInstalledPlugin).toList();
-    var duration = System.currentTimeMillis() - start;
-    LOG.info("Downloaded plugin list in {}ms", duration);
-    return result;
-  }
-
-  private static ServerPlugin toInstalledPlugin(InstalledPluginsPayloadDto.InstalledPluginPayloadDto payload) {
-    return new ServerPlugin(payload.key(), payload.hash(), payload.filename(), payload.sonarLintSupported());
-  }
-
-  public void getPlugin(String key, Consumer<InputStream> pluginFileConsumer, SonarLintCancelMonitor cancelMonitor) {
-    var path = "api/plugins/download?plugin=" + urlEncode(key);
-    var start = System.currentTimeMillis();
-    try (var response = helper.get(path, cancelMonitor)) {
+    try (var response = helper.getAnonymousUrl(url, cancelMonitor)) {
       pluginFileConsumer.accept(response.bodyAsStream());
       var duration = System.currentTimeMillis() - start;
       LOG.info("Downloaded '{}' in {}ms", key, duration);
+    }
+  }
+
+  static String buildDownloadUrl(String baseUrl, String key, String hash) {
+    var baseUri = URI.create(baseUrl);
+    var host = baseUri.getHost();
+    if (host == null) {
+      throw new IllegalArgumentException("SonarQube Cloud URL must contain a host: " + baseUrl);
+    }
+    try {
+      var path = "/plugins/" + key + "/versions/" + hash + ".jar";
+      return new URI(baseUri.getScheme(), null, "scanner." + host, baseUri.getPort(), path, null, null).toASCIIString();
+    } catch (URISyntaxException e) {
+      throw new IllegalArgumentException("Unable to build the SonarQube Cloud plugin download URL", e);
     }
   }
 

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
@@ -63,6 +63,8 @@ class PluginsApiTests {
       .isEqualTo("https://scanner.sonarcloud.io/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
     assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarqube.us/", "java", "de5308f43260d357acc97712ce4c5475"))
       .isEqualTo("https://scanner.sonarqube.us/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
+    assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarcloud.io", "java plugin", "plugin hash"))
+      .isEqualTo("https://scanner.sonarcloud.io/plugins/java%20plugin/versions/plugin%20hash.jar");
   }
 
 }

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
@@ -19,22 +19,14 @@
  */
 package org.sonarsource.sonarlint.core.serverapi.plugins;
 
-import java.io.ByteArrayInputStream;
-import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
-import org.sonarsource.sonarlint.core.http.HttpClient;
 import org.sonarsource.sonarlint.core.serverapi.MockWebServerExtensionWithProtobuf;
-import org.sonarsource.sonarlint.core.serverapi.ServerApiHelper;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 class PluginsApiTests {
   @RegisterExtension
@@ -62,46 +54,7 @@ class PluginsApiTests {
     var underTest = new PluginsApi(mockServer.serverApiHelper());
     mockServer.addStringResponse("/api/plugins/download?plugin=pluginKey", "content");
 
-    underTest.getPlugin("pluginKey", "hash", stream -> assertThat(stream).hasContent("content"), new SonarLintCancelMonitor());
-  }
-
-  @Test
-  void should_return_sonarcloud_plugin_content() {
-    var helper = mock(ServerApiHelper.class);
-    var response = mock(HttpClient.Response.class);
-    var cancelMonitor = new SonarLintCancelMonitor();
-    when(helper.isSonarCloud()).thenReturn(true);
-    when(helper.getBaseUrl()).thenReturn("https://sonarcloud.io");
-    when(helper.getAnonymousUrl("https://scanner.sonarcloud.io/plugins/pluginKey/versions/hash.jar", cancelMonitor)).thenReturn(response);
-    when(response.bodyAsStream()).thenReturn(new ByteArrayInputStream("content".getBytes(UTF_8)));
-    var underTest = new PluginsApi(helper);
-
-    underTest.getPlugin("pluginKey", "hash", stream -> assertThat(stream).hasContent("content"), cancelMonitor);
-  }
-
-  @Test
-  void should_build_sonarcloud_plugin_download_urls() {
-    assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarcloud.io", "java", "de5308f43260d357acc97712ce4c5475"))
-      .isEqualTo("https://scanner.sonarcloud.io/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
-    assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarqube.us/", "java", "de5308f43260d357acc97712ce4c5475"))
-      .isEqualTo("https://scanner.sonarqube.us/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
-    assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarcloud.io", "java plugin", "plugin hash"))
-      .isEqualTo("https://scanner.sonarcloud.io/plugins/java%20plugin/versions/plugin%20hash.jar");
-  }
-
-  @Test
-  void should_reject_sonarcloud_url_without_host() {
-    assertThatThrownBy(() -> PluginsApi.buildSonarCloudPluginDownloadUrl("sonarcloud.io", "java", "hash"))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("SonarQube Cloud URL must contain a host: sonarcloud.io");
-  }
-
-  @Test
-  void should_wrap_error_when_sonarcloud_plugin_download_url_cannot_be_built() {
-    assertThatThrownBy(() -> PluginsApi.buildSonarCloudPluginDownloadUrl("https://[::1]", "java", "hash"))
-      .isInstanceOf(IllegalArgumentException.class)
-      .hasMessage("Unable to build the SonarQube Cloud plugin download URL")
-      .hasCauseInstanceOf(URISyntaxException.class);
+    underTest.getPlugin("pluginKey", stream -> assertThat(stream).hasContent("content"), new SonarLintCancelMonitor());
   }
 
 }

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
@@ -54,7 +54,15 @@ class PluginsApiTests {
     var underTest = new PluginsApi(mockServer.serverApiHelper());
     mockServer.addStringResponse("/api/plugins/download?plugin=pluginKey", "content");
 
-    underTest.getPlugin("pluginKey", stream -> assertThat(stream).hasContent("content"), new SonarLintCancelMonitor());
+    underTest.getPlugin("pluginKey", "hash", stream -> assertThat(stream).hasContent("content"), new SonarLintCancelMonitor());
+  }
+
+  @Test
+  void should_build_sonarcloud_plugin_download_urls() {
+    assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarcloud.io", "java", "de5308f43260d357acc97712ce4c5475"))
+      .isEqualTo("https://scanner.sonarcloud.io/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
+    assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarqube.us/", "java", "de5308f43260d357acc97712ce4c5475"))
+      .isEqualTo("https://scanner.sonarqube.us/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
   }
 
 }

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/PluginsApiTests.java
@@ -19,14 +19,22 @@
  */
 package org.sonarsource.sonarlint.core.serverapi.plugins;
 
+import java.io.ByteArrayInputStream;
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
+import org.sonarsource.sonarlint.core.http.HttpClient;
 import org.sonarsource.sonarlint.core.serverapi.MockWebServerExtensionWithProtobuf;
+import org.sonarsource.sonarlint.core.serverapi.ServerApiHelper;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class PluginsApiTests {
   @RegisterExtension
@@ -50,11 +58,25 @@ class PluginsApiTests {
   }
 
   @Test
-  void should_return_plugin_content() {
+  void should_return_sonarqube_server_plugin_content() {
     var underTest = new PluginsApi(mockServer.serverApiHelper());
     mockServer.addStringResponse("/api/plugins/download?plugin=pluginKey", "content");
 
     underTest.getPlugin("pluginKey", "hash", stream -> assertThat(stream).hasContent("content"), new SonarLintCancelMonitor());
+  }
+
+  @Test
+  void should_return_sonarcloud_plugin_content() {
+    var helper = mock(ServerApiHelper.class);
+    var response = mock(HttpClient.Response.class);
+    var cancelMonitor = new SonarLintCancelMonitor();
+    when(helper.isSonarCloud()).thenReturn(true);
+    when(helper.getBaseUrl()).thenReturn("https://sonarcloud.io");
+    when(helper.getAnonymousUrl("https://scanner.sonarcloud.io/plugins/pluginKey/versions/hash.jar", cancelMonitor)).thenReturn(response);
+    when(response.bodyAsStream()).thenReturn(new ByteArrayInputStream("content".getBytes(UTF_8)));
+    var underTest = new PluginsApi(helper);
+
+    underTest.getPlugin("pluginKey", "hash", stream -> assertThat(stream).hasContent("content"), cancelMonitor);
   }
 
   @Test
@@ -65,6 +87,21 @@ class PluginsApiTests {
       .isEqualTo("https://scanner.sonarqube.us/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
     assertThat(PluginsApi.buildSonarCloudPluginDownloadUrl("https://sonarcloud.io", "java plugin", "plugin hash"))
       .isEqualTo("https://scanner.sonarcloud.io/plugins/java%20plugin/versions/plugin%20hash.jar");
+  }
+
+  @Test
+  void should_reject_sonarcloud_url_without_host() {
+    assertThatThrownBy(() -> PluginsApi.buildSonarCloudPluginDownloadUrl("sonarcloud.io", "java", "hash"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("SonarQube Cloud URL must contain a host: sonarcloud.io");
+  }
+
+  @Test
+  void should_wrap_error_when_sonarcloud_plugin_download_url_cannot_be_built() {
+    assertThatThrownBy(() -> PluginsApi.buildSonarCloudPluginDownloadUrl("https://[::1]", "java", "hash"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Unable to build the SonarQube Cloud plugin download URL")
+      .hasCauseInstanceOf(URISyntaxException.class);
   }
 
 }

--- a/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/SonarCloudCdnPluginsTests.java
+++ b/backend/server-api/src/test/java/org/sonarsource/sonarlint/core/serverapi/plugins/SonarCloudCdnPluginsTests.java
@@ -1,0 +1,79 @@
+/*
+ * SonarLint Core - Server API
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.serverapi.plugins;
+
+import java.io.ByteArrayInputStream;
+import java.net.URISyntaxException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
+import org.sonarsource.sonarlint.core.commons.progress.SonarLintCancelMonitor;
+import org.sonarsource.sonarlint.core.http.HttpClient;
+import org.sonarsource.sonarlint.core.serverapi.ServerApiHelper;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SonarCloudCdnPluginsTests {
+  @RegisterExtension
+  private static final SonarLintLogTester logTester = new SonarLintLogTester();
+
+  @Test
+  void should_return_sonarcloud_plugin_content() {
+    var helper = mock(ServerApiHelper.class);
+    var response = mock(HttpClient.Response.class);
+    var cancelMonitor = new SonarLintCancelMonitor();
+    when(helper.getBaseUrl()).thenReturn("https://sonarcloud.io");
+    when(helper.getAnonymousUrl("https://scanner.sonarcloud.io/plugins/pluginKey/versions/hash.jar", cancelMonitor)).thenReturn(response);
+    when(response.bodyAsStream()).thenReturn(new ByteArrayInputStream("content".getBytes(UTF_8)));
+    var underTest = new SonarCloudCdnPlugins(helper);
+
+    underTest.getPlugin("pluginKey", "hash", stream -> assertThat(stream).hasContent("content"), cancelMonitor);
+  }
+
+  @Test
+  void should_build_sonarcloud_plugin_download_urls() {
+    assertThat(SonarCloudCdnPlugins.buildDownloadUrl("https://sonarcloud.io", "java", "de5308f43260d357acc97712ce4c5475"))
+      .isEqualTo("https://scanner.sonarcloud.io/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
+    assertThat(SonarCloudCdnPlugins.buildDownloadUrl("https://sonarqube.us/", "java", "de5308f43260d357acc97712ce4c5475"))
+      .isEqualTo("https://scanner.sonarqube.us/plugins/java/versions/de5308f43260d357acc97712ce4c5475.jar");
+    assertThat(SonarCloudCdnPlugins.buildDownloadUrl("https://sonarcloud.io", "java plugin", "plugin hash"))
+      .isEqualTo("https://scanner.sonarcloud.io/plugins/java%20plugin/versions/plugin%20hash.jar");
+  }
+
+  @Test
+  void should_reject_sonarcloud_url_without_host() {
+    assertThatThrownBy(() -> SonarCloudCdnPlugins.buildDownloadUrl("sonarcloud.io", "java", "hash"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("SonarQube Cloud URL must contain a host: sonarcloud.io");
+  }
+
+  @Test
+  void should_wrap_error_when_sonarcloud_plugin_download_url_cannot_be_built() {
+    assertThatThrownBy(() -> SonarCloudCdnPlugins.buildDownloadUrl("https://[::1]", "java", "hash"))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessage("Unable to build the SonarQube Cloud plugin download URL")
+      .hasCauseInstanceOf(URISyntaxException.class);
+  }
+
+}

--- a/medium-tests/src/test/java/mediumtest/plugin/ServerPluginDownloadMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/plugin/ServerPluginDownloadMediumTests.java
@@ -19,17 +19,25 @@
  */
 package mediumtest.plugin;
 
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import java.net.Proxy;
+import java.net.URI;
+import java.util.List;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.sonarsource.sonarlint.core.rpc.protocol.client.http.ProxyDto;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
-import org.sonarsource.sonarlint.core.test.utils.server.ServerFixture;
 import utils.TestPlugin;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.core.rpc.protocol.common.Language.JAVA;
 
 class ServerPluginDownloadMediumTests {
@@ -40,6 +48,11 @@ class ServerPluginDownloadMediumTests {
   private static final String PROJECT_KEY = "projectKey";
   private static final String PLUGIN_DOWNLOAD_URL = "/plugins/java/versions/" + TestPlugin.JAVA.getHash() + ".jar";
 
+  @RegisterExtension
+  static WireMockExtension fakeCdn = WireMockExtension.newInstance()
+    .options(wireMockConfig().dynamicPort())
+    .build();
+
   @SonarLintTest
   void failed_server_plugin_download_should_not_trigger_infinite_reload_loop_for_sonarqube_cloud_us_region(SonarLintTestHarness harness) {
     var server = harness.newFakeSonarCloudServer()
@@ -48,9 +61,15 @@ class ServerPluginDownloadMediumTests {
       .start();
     // Keep the failing response in flight briefly so a regression would have time to rearm
     // another download attempt while the first one is still completing.
-    server.getMockServer().stubFor(get(urlEqualTo(PLUGIN_DOWNLOAD_URL))
-      .atPriority(1)
+    fakeCdn.stubFor(get(urlEqualTo(PLUGIN_DOWNLOAD_URL))
       .willReturn(aResponse().withStatus(404).withFixedDelay(200)));
+    var fakeClient = harness.newFakeClient().build();
+    when(fakeClient.selectProxies(any())).thenAnswer(invocation -> {
+      var uri = invocation.getArgument(0, URI.class);
+      return "scanner.localhost".equals(uri.getHost())
+        ? List.of(new ProxyDto(Proxy.Type.HTTP, "localhost", fakeCdn.getPort()))
+        : List.of(ProxyDto.NO_PROXY);
+    });
 
     var backend = harness.newBackend()
       .withSonarQubeCloudUsRegionUri(server.baseUrl())
@@ -61,20 +80,20 @@ class ServerPluginDownloadMediumTests {
           .withMainBranch("main")))
       .withBoundConfigScope(CONFIG_SCOPE_ID, CONNECTION_ID, PROJECT_KEY)
       .withExtraEnabledLanguagesInConnectedMode(JAVA)
-      .start();
+      .start(fakeClient);
 
     try {
       // We expect exactly one failed download attempt. The `during` window proves the count stays
       // stable for a while instead of entering the old reload/download loop.
       await().during(2, SECONDS).atMost(15, SECONDS)
-        .untilAsserted(() -> assertThat(countPluginDownloadRequests(server)).isEqualTo(1));
+        .untilAsserted(() -> assertThat(countPluginDownloadRequests()).isEqualTo(1));
     } finally {
       harness.shutdown(backend);
     }
   }
 
-  private static long countPluginDownloadRequests(ServerFixture.Server server) {
-    return server.getMockServer().getAllServeEvents().stream()
+  private static long countPluginDownloadRequests() {
+    return fakeCdn.getAllServeEvents().stream()
       .filter(event -> PLUGIN_DOWNLOAD_URL.equals(event.getRequest().getUrl()))
       .count();
   }

--- a/medium-tests/src/test/java/mediumtest/plugin/ServerPluginDownloadMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/plugin/ServerPluginDownloadMediumTests.java
@@ -38,7 +38,7 @@ class ServerPluginDownloadMediumTests {
   private static final String CONNECTION_ID = "connectionId";
   private static final String ORGANIZATION_KEY = "org";
   private static final String PROJECT_KEY = "projectKey";
-  private static final String PLUGIN_DOWNLOAD_URL = "/api/plugins/download?plugin=java";
+  private static final String PLUGIN_DOWNLOAD_URL = "/plugins/java/versions/" + TestPlugin.JAVA.getHash() + ".jar";
 
   @SonarLintTest
   void failed_server_plugin_download_should_not_trigger_infinite_reload_loop_for_sonarqube_cloud_us_region(SonarLintTestHarness harness) {

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/ServerFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/ServerFixture.java
@@ -928,7 +928,10 @@ public class ServerFixture {
       pluginsByKey.forEach((pluginKey, plugin) -> {
         try {
           var pluginContent = Files.exists(plugin.jarPath) ? Files.readAllBytes(plugin.jarPath) : new byte[0];
-          mockServer.stubFor(get("/api/plugins/download?plugin=" + pluginKey)
+          var pluginDownloadPath = serverKind == ServerKind.SONARCLOUD
+            ? "/plugins/" + pluginKey + "/versions/" + plugin.hash + ".jar"
+            : "/api/plugins/download?plugin=" + pluginKey;
+          mockServer.stubFor(get(pluginDownloadPath)
             .willReturn(aResponse().withStatus(responseCodes.statusCode).withBody(pluginContent)));
         } catch (IOException e) {
           throw new RuntimeException(e);

--- a/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/ServerFixture.java
+++ b/test-utils/src/main/java/org/sonarsource/sonarlint/core/test/utils/server/ServerFixture.java
@@ -929,8 +929,8 @@ public class ServerFixture {
         try {
           var pluginContent = Files.exists(plugin.jarPath) ? Files.readAllBytes(plugin.jarPath) : new byte[0];
           var pluginDownloadPath = serverKind == ServerKind.SONARCLOUD
-            ? "/plugins/" + pluginKey + "/versions/" + plugin.hash + ".jar"
-            : "/api/plugins/download?plugin=" + pluginKey;
+            ? ("/plugins/" + pluginKey + "/versions/" + plugin.hash + ".jar")
+            : ("/api/plugins/download?plugin=" + pluginKey);
           mockServer.stubFor(get(pluginDownloadPath)
             .willReturn(aResponse().withStatus(responseCodes.statusCode).withBody(pluginContent)));
         } catch (IOException e) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Plugin download migration:**
    - Updated `PluginsApi` to download SonarQube Cloud plugins from CloudFront CDN using `scanner.` host prefix and plugin hash
    - Added `buildSonarCloudPluginDownloadUrl` method to construct CDN download URLs and updated corresponding tests and fixtures

<sub>This will update automatically on new commits.</sub>