### PR TITLE
SLCORE-2544 Bump dependencies versions to remove risks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <!-- Override the Jackson transitively pulled by flyway-core (2.19.1): 11.20.3 is the last Flyway release
          on Jackson 2.x, later versions move flyway-core itself to Jackson 3.x (tools.jackson.core) -->
     <jackson.version>2.22.1</jackson.version>
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <!-- Override the Jetty transitively pulled by wiremock-jetty12:3.13.2 (test scope, 12.0.30):
          fixes CVE-2026-10050 (jetty-security/jetty-client Digest auth bypass), wiremock-jetty12 has no newer release yet -->
     <jetty.version>12.0.38</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <kotlin.version>1.9.25</kotlin.version>
     <lsp4j.version>0.24.0</lsp4j.version>
     <slf4j.version>2.0.17</slf4j.version>
-    <logback.version>1.5.32</logback.version>
+    <logback.version>1.5.35</logback.version>
     <version.surefire.plugin>3.1.2</version.surefire.plugin>
     <system.stubs.version>2.1.8</system.stubs.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,9 @@
     <!-- Override the Jetty transitively pulled by wiremock-jetty12:3.13.2 (test scope, 12.0.30):
          fixes CVE-2026-10050 (jetty-security/jetty-client Digest auth bypass), wiremock-jetty12 has no newer release yet -->
     <jetty.version>12.0.38</jetty.version>
+    <!-- Override the Handlebars transitively pulled by wiremock-jetty12:3.13.2 (response templating, 4.3.1):
+         fixes CVE-2026-55760 (path traversal via FileTemplateLoader/ClassPathTemplateLoader), wiremock-jetty12 has no newer release yet -->
+    <handlebars.version>4.5.3</handlebars.version>
     <!-- On-demand plugin versions -->
     <cfamily.version>6.83.0.100813</cfamily.version>
     <csharp.version>10.31.0.145097</csharp.version>
@@ -126,6 +129,11 @@
         <version>${jetty.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.github.jknack</groupId>
+        <artifactId>handlebars</artifactId>
+        <version>${handlebars.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
     <!-- Override the Jetty transitively pulled by wiremock-jetty12:3.13.2 (test scope, 12.0.30):
          fixes CVE-2026-10050 (jetty-security/jetty-client Digest auth bypass), wiremock-jetty12 has no newer release yet -->
     <jetty.version>12.0.38</jetty.version>
-    <!-- Override the Handlebars transitively pulled by wiremock-jetty12:3.13.2 (response templating, 4.3.1):
-         fixes CVE-2026-55760 (path traversal via FileTemplateLoader/ClassPathTemplateLoader), wiremock-jetty12 has no newer release yet -->
+    <!-- Override the Handlebars transitively pulled by wiremock-jetty12:3.13.2 (4.3.1):
+         wiremock-jetty12 has no newer release yet -->
     <handlebars.version>4.5.3</handlebars.version>
     <!-- On-demand plugin versions -->
     <cfamily.version>6.83.0.100813</cfamily.version>

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>io.github.hakky54</groupId>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -75,6 +75,14 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
     </dependency>
+    <!-- Force the Handlebars artifact affected by CVE-2026-55760 and pinned in the root pom's
+         dependencyManagement to be a direct dependency here, otherwise the pin never propagates to consumers
+         of sonarlint-core-test-utils: wiremock-jetty12 is a direct dependency here and transitively pulls its
+         own older, vulnerable Handlebars version for response templating. -->
+    <dependency>
+      <groupId>com.github.jknack</groupId>
+      <artifactId>handlebars</artifactId>
+    </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
       <artifactId>mockwebserver3</artifactId>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -75,10 +75,8 @@
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-security</artifactId>
     </dependency>
-    <!-- Force the Handlebars artifact affected by CVE-2026-55760 and pinned in the root pom's
-         dependencyManagement to be a direct dependency here, otherwise the pin never propagates to consumers
-         of sonarlint-core-test-utils: wiremock-jetty12 is a direct dependency here and transitively pulls its
-         own older, vulnerable Handlebars version for response templating. -->
+    <!-- Force the Handlebars version pinned in the root pom to be a direct dependency here, otherwise the
+         pin never propagates to consumers of sonarlint-core-test-utils. -->
     <dependency>
       <groupId>com.github.jknack</groupId>
       <artifactId>handlebars</artifactId>


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Dependency updates:**
    - Updated `logback` version to `1.5.35` and `httpclient5` to `5.6.3` in `pom.xml`
    - Bumped `bouncycastle` version to `1.85`
- **Security fixes:**
    - Overrode transitive `Handlebars` to `4.5.3` to fix `CVE-2026-55760` in `pom.xml` and `test-utils/pom.xml`

<sub>This will update automatically on new commits.</sub>