### PR TITLE
SLCORE-2538 Retry establishing a WebSocket connection to SQC on failure

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocket.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocket.java
@@ -81,7 +81,7 @@ public class SonarCloudWebSocket {
   private final CompletableFuture<?> webSocketInputClosed = new CompletableFuture<>();
 
   public static SonarCloudWebSocket create(URI webSocketsEndpointUri, WebSocketClient webSocketClient, Consumer<SonarServerEvent> serverEventConsumer,
-    Runnable connectionEndedRunnable) {
+    Runnable connectionEndedRunnable, Runnable onConnectionSucceeded, Runnable onConnectionFailed) {
     var webSocket = new SonarCloudWebSocket();
     var currentThreadOutput = SonarLintLogger.get().getTargetForCopy();
     LOG.info("Creating WebSocket connection to " + webSocketsEndpointUri);
@@ -97,10 +97,16 @@ public class SonarCloudWebSocket {
       webSocket.sonarCloudWebSocketScheduler.scheduleAtFixedRate(webSocket::cleanUpMessageHistory, 0, 5, TimeUnit.MINUTES);
       webSocket.sonarCloudWebSocketScheduler.schedule(connectionEndedRunnable, 119, TimeUnit.MINUTES);
       webSocket.sonarCloudWebSocketScheduler.scheduleAtFixedRate(() -> keepAlive(ws), 9, 9, TimeUnit.MINUTES);
+      if (!webSocket.closingInitiated.get()) {
+        onConnectionSucceeded.run();
+      }
     });
     webSocket.wsFuture.exceptionally(t -> {
       SonarLintLogger.get().setTarget(currentThreadOutput);
       LOG.error("Error while trying to create WebSocket connection for " + webSocketsEndpointUri, t);
+      if (!webSocket.closingInitiated.get()) {
+        onConnectionFailed.run();
+      }
       return null;
     });
     return webSocket;
@@ -255,6 +261,10 @@ public class SonarCloudWebSocket {
     }
     var ws = wsFuture.getNow(null);
     return ws != null && !ws.isInputClosed() && !ws.isOutputClosed();
+  }
+
+  public boolean isConnecting() {
+    return wsFuture != null && !wsFuture.isDone();
   }
 
   private static class WebSocketEvent {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
@@ -106,11 +106,18 @@ public class WebSocketManager {
    * @return the connection if it was or has been opened, else empty
    */
   public Optional<SonarCloudWebSocket> createConnectionIfNeeded(String connectionId) {
+    return createConnectionIfNeeded(connectionId, true);
+  }
+
+  private Optional<SonarCloudWebSocket> createConnectionIfNeeded(String connectionId, boolean resetAttempt) {
     connectionIdsInterestedInNotifications.add(connectionId);
     if (hasOpenConnection() || isConnectionPending()) {
       return Optional.of(sonarCloudWebSocket);
     }
     cancelPendingRetry();
+    if (resetAttempt) {
+      currentAttempt.set(new Attempt());
+    }
     try {
       return sonarQubeClientManager.getValidWebSocketClient(connectionId)
         .map(webSocketClient -> {
@@ -129,7 +136,6 @@ public class WebSocketManager {
 
   public void reopenConnection(String connectionId, String reason) {
     cancelPendingRetry();
-    currentAttempt.set(new Attempt());
     closeSocketIfPresent(reason);
     createConnectionIfNeeded(connectionId)
       .ifPresent(connection -> resubscribeAll());
@@ -177,7 +183,7 @@ public class WebSocketManager {
   private void reopenConnectionWithoutResettingAttempt(String connectionId, String reason) {
     cancelPendingRetry();
     closeSocketIfPresent(reason);
-    createConnectionIfNeeded(connectionId)
+    createConnectionIfNeeded(connectionId, false)
       .ifPresent(connection -> resubscribeAll());
   }
 

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
@@ -55,7 +55,7 @@ public class WebSocketManager {
   private final ConfigurationRepository configurationRepository;
   private final URI websocketEndpointUri;
   private final AtomicReference<ScheduledFuture<?>> pendingRetry = new AtomicReference<>();
-  private Attempt currentAttempt = new Attempt();
+  private volatile Attempt currentAttempt = new Attempt();
 
   public WebSocketManager(ApplicationEventPublisher eventPublisher, SonarQubeClientManager sonarQubeClientManager, ConfigurationRepository configurationRepository,
     URI websocketEndpointUri) {
@@ -115,9 +115,9 @@ public class WebSocketManager {
       return sonarQubeClientManager.getValidWebSocketClient(connectionId)
         .map(webSocketClient -> {
           closeSocketIfPresent("Creating a new WebSocket connection");
-          this.sonarCloudWebSocket = SonarCloudWebSocket.create(this.websocketEndpointUri, webSocketClient, this::handleSonarServerEvent, this::reopenConnectionOnClose,
-            this::onConnectionSucceeded, this::onConnectionFailed);
           this.connectionIdUsedToCreateConnection = connectionId;
+          this.sonarCloudWebSocket = SonarCloudWebSocket.create(this.websocketEndpointUri, webSocketClient, this::handleSonarServerEvent, this::reopenConnectionOnClose,
+            this::onConnectionSucceeded, () -> onConnectionFailed(connectionId));
           return sonarCloudWebSocket;
         });
     } catch (Exception e) {
@@ -152,8 +152,7 @@ public class WebSocketManager {
     });
   }
 
-  private void onConnectionFailed() {
-    var connectionId = connectionIdUsedToCreateConnection;
+  private void onConnectionFailed(String connectionId) {
     executorService.execute(() -> scheduleRetryAfterFailure(connectionId));
   }
 

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
@@ -26,8 +26,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.sonarsource.sonarlint.core.SonarQubeClientManager;
 import org.sonarsource.sonarlint.core.commons.Binding;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogger;
@@ -37,25 +39,37 @@ import org.sonarsource.sonarlint.core.repository.config.ConfigurationRepository;
 import org.sonarsource.sonarlint.core.serverapi.push.SonarServerEvent;
 import org.springframework.context.ApplicationEventPublisher;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 public class WebSocketManager {
   private static final SonarLintLogger LOG = SonarLintLogger.get();
+  public static final String RETRY_INITIAL_DELAY_PROPERTY = "sonarlint.internal.websocket.retry.initialDelay";
 
   private SonarCloudWebSocket sonarCloudWebSocket;
   private final Set<String> connectionIdsInterestedInNotifications = new HashSet<>();
   private String connectionIdUsedToCreateConnection;
   private final Map<String, String> subscribedProjectKeysByConfigScopes = new HashMap<>();
-  private final ExecutorService executorService = FailSafeExecutors.newSingleThreadExecutor("sonarlint-websocket-subscriber");
+  private final ScheduledExecutorService executorService;
   private final ApplicationEventPublisher eventPublisher;
   private final SonarQubeClientManager sonarQubeClientManager;
   private final ConfigurationRepository configurationRepository;
   private final URI websocketEndpointUri;
+  private final AtomicReference<ScheduledFuture<?>> pendingRetry = new AtomicReference<>();
+  private Attempt currentAttempt = new Attempt();
 
   public WebSocketManager(ApplicationEventPublisher eventPublisher, SonarQubeClientManager sonarQubeClientManager, ConfigurationRepository configurationRepository,
     URI websocketEndpointUri) {
+    this(eventPublisher, sonarQubeClientManager, configurationRepository, websocketEndpointUri,
+      FailSafeExecutors.newSingleThreadScheduledExecutor("sonarlint-websocket-subscriber"));
+  }
+
+  WebSocketManager(ApplicationEventPublisher eventPublisher, SonarQubeClientManager sonarQubeClientManager, ConfigurationRepository configurationRepository,
+    URI websocketEndpointUri, ScheduledExecutorService executorService) {
     this.eventPublisher = eventPublisher;
     this.sonarQubeClientManager = sonarQubeClientManager;
     this.configurationRepository = configurationRepository;
     this.websocketEndpointUri = websocketEndpointUri;
+    this.executorService = executorService;
   }
 
   private void handleSonarServerEvent(SonarServerEvent event) {
@@ -93,24 +107,30 @@ public class WebSocketManager {
    */
   public Optional<SonarCloudWebSocket> createConnectionIfNeeded(String connectionId) {
     connectionIdsInterestedInNotifications.add(connectionId);
-    if (hasOpenConnection()) {
+    if (hasOpenConnection() || isConnectionPending()) {
       return Optional.of(sonarCloudWebSocket);
     }
+    cancelPendingRetry();
     try {
       return sonarQubeClientManager.getValidWebSocketClient(connectionId)
         .map(webSocketClient -> {
-          this.sonarCloudWebSocket = SonarCloudWebSocket.create(this.websocketEndpointUri, webSocketClient, this::handleSonarServerEvent, this::reopenConnectionOnClose);
+          closeSocketIfPresent("Creating a new WebSocket connection");
+          this.sonarCloudWebSocket = SonarCloudWebSocket.create(this.websocketEndpointUri, webSocketClient, this::handleSonarServerEvent, this::reopenConnectionOnClose,
+            this::onConnectionSucceeded, this::onConnectionFailed);
           this.connectionIdUsedToCreateConnection = connectionId;
           return sonarCloudWebSocket;
         });
     } catch (Exception e) {
       LOG.error("Error while creating WebSocket connection", e);
+      scheduleRetryAfterFailure(connectionId);
       return Optional.empty();
     }
   }
 
   public void reopenConnection(String connectionId, String reason) {
-    closeSocket(reason);
+    cancelPendingRetry();
+    currentAttempt = new Attempt();
+    closeSocketIfPresent(reason);
     createConnectionIfNeeded(connectionId)
       .ifPresent(connection -> resubscribeAll());
   }
@@ -123,6 +143,56 @@ public class WebSocketManager {
         this.reopenConnection(connectionId, "WebSocket was closed by server or reached EOL");
       }
     });
+  }
+
+  private void onConnectionSucceeded() {
+    executorService.execute(() -> {
+      cancelPendingRetry();
+      currentAttempt = new Attempt();
+    });
+  }
+
+  private void onConnectionFailed() {
+    var connectionId = connectionIdUsedToCreateConnection;
+    executorService.execute(() -> scheduleRetryAfterFailure(connectionId));
+  }
+
+  private void scheduleRetryAfterFailure(String connectionId) {
+    if (connectionId == null || !connectionIdsInterestedInNotifications.contains(connectionId)) {
+      return;
+    }
+    if (currentAttempt.isMax()) {
+      LOG.debug("Cannot connect to SonarCloud WebSocket, stop retrying");
+      return;
+    }
+    var retryDelay = currentAttempt.delay;
+    LOG.debug("Cannot connect to SonarCloud WebSocket, retrying in " + retryDelay + "s");
+    var nextAttempt = currentAttempt.next();
+    scheduleRetry(() -> {
+      currentAttempt = nextAttempt;
+      reopenConnectionWithoutResettingAttempt(connectionId, "Retrying after connection failure");
+    }, retryDelay);
+  }
+
+  private void reopenConnectionWithoutResettingAttempt(String connectionId, String reason) {
+    cancelPendingRetry();
+    closeSocketIfPresent(reason);
+    createConnectionIfNeeded(connectionId)
+      .ifPresent(connection -> resubscribeAll());
+  }
+
+  private void scheduleRetry(Runnable task, long delayInSeconds) {
+    if (!executorService.isShutdown()) {
+      cancelPendingRetry();
+      pendingRetry.set(executorService.schedule(task, delayInSeconds, SECONDS));
+    }
+  }
+
+  private void cancelPendingRetry() {
+    var pendingRetryOrNull = pendingRetry.getAndSet(null);
+    if (pendingRetryOrNull != null) {
+      pendingRetryOrNull.cancel(true);
+    }
   }
 
   public void closeSocketIfNoMoreNeeded() {
@@ -151,6 +221,12 @@ public class WebSocketManager {
   }
 
   public void closeSocket(String reason) {
+    cancelPendingRetry();
+    currentAttempt = new Attempt();
+    closeSocketIfPresent(reason);
+  }
+
+  private void closeSocketIfPresent(String reason) {
     if (this.sonarCloudWebSocket != null) {
       var socket = this.sonarCloudWebSocket;
       this.sonarCloudWebSocket = null;
@@ -161,6 +237,10 @@ public class WebSocketManager {
 
   public boolean hasOpenConnection() {
     return sonarCloudWebSocket != null && sonarCloudWebSocket.isOpen();
+  }
+
+  private boolean isConnectionPending() {
+    return sonarCloudWebSocket != null && sonarCloudWebSocket.isConnecting();
   }
 
   public void forget(String configScopeId) {
@@ -184,6 +264,35 @@ public class WebSocketManager {
     connectionIdsInterestedInNotifications.clear();
     if (!MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS)) {
       LOG.warn("Unable to stop websocket manager executor service in a timely manner");
+    }
+  }
+
+  static class Attempt {
+    private static final int BACK_OFF_MULTIPLIER = 2;
+    private static final int MAX_ATTEMPTS = 10;
+
+    private final long delay;
+    private final int attemptNumber;
+
+    public Attempt() {
+      this(initialDelaySeconds(), 1);
+    }
+
+    public Attempt(long delay, int attemptNumber) {
+      this.delay = delay;
+      this.attemptNumber = attemptNumber;
+    }
+
+    public Attempt next() {
+      return new Attempt(delay * BACK_OFF_MULTIPLIER, attemptNumber + 1);
+    }
+
+    public boolean isMax() {
+      return attemptNumber == MAX_ATTEMPTS;
+    }
+
+    private static long initialDelaySeconds() {
+      return Long.parseLong(System.getProperty(RETRY_INITIAL_DELAY_PROPERTY, "60"));
     }
   }
 }

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
@@ -103,7 +103,7 @@ public class WebSocketManager {
   }
 
   /**
-   * @return the connection if it was or has been opened, else empty
+   * @return the open or pending connection, a newly created one, or empty if creation is not possible
    */
   public Optional<SonarCloudWebSocket> createConnectionIfNeeded(String connectionId) {
     return createConnectionIfNeeded(connectionId, true);

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketManager.java
@@ -55,7 +55,7 @@ public class WebSocketManager {
   private final ConfigurationRepository configurationRepository;
   private final URI websocketEndpointUri;
   private final AtomicReference<ScheduledFuture<?>> pendingRetry = new AtomicReference<>();
-  private volatile Attempt currentAttempt = new Attempt();
+  private final AtomicReference<Attempt> currentAttempt = new AtomicReference<>(new Attempt());
 
   public WebSocketManager(ApplicationEventPublisher eventPublisher, SonarQubeClientManager sonarQubeClientManager, ConfigurationRepository configurationRepository,
     URI websocketEndpointUri) {
@@ -129,7 +129,7 @@ public class WebSocketManager {
 
   public void reopenConnection(String connectionId, String reason) {
     cancelPendingRetry();
-    currentAttempt = new Attempt();
+    currentAttempt.set(new Attempt());
     closeSocketIfPresent(reason);
     createConnectionIfNeeded(connectionId)
       .ifPresent(connection -> resubscribeAll());
@@ -148,7 +148,7 @@ public class WebSocketManager {
   private void onConnectionSucceeded() {
     executorService.execute(() -> {
       cancelPendingRetry();
-      currentAttempt = new Attempt();
+      currentAttempt.set(new Attempt());
     });
   }
 
@@ -157,18 +157,19 @@ public class WebSocketManager {
   }
 
   private void scheduleRetryAfterFailure(String connectionId) {
-    if (connectionId == null || !connectionIdsInterestedInNotifications.contains(connectionId)) {
+    if (!connectionIdsInterestedInNotifications.contains(connectionId)) {
       return;
     }
-    if (currentAttempt.isMax()) {
+    var attempt = currentAttempt.get();
+    if (attempt.isMax()) {
       LOG.debug("Cannot connect to SonarCloud WebSocket, stop retrying");
       return;
     }
-    var retryDelay = currentAttempt.delay;
+    var retryDelay = attempt.delay;
     LOG.debug("Cannot connect to SonarCloud WebSocket, retrying in " + retryDelay + "s");
-    var nextAttempt = currentAttempt.next();
+    var nextAttempt = attempt.next();
     scheduleRetry(() -> {
-      currentAttempt = nextAttempt;
+      currentAttempt.set(nextAttempt);
       reopenConnectionWithoutResettingAttempt(connectionId, "Retrying after connection failure");
     }, retryDelay);
   }
@@ -221,7 +222,7 @@ public class WebSocketManager {
 
   public void closeSocket(String reason) {
     cancelPendingRetry();
-    currentAttempt = new Attempt();
+    currentAttempt.set(new Attempt());
     closeSocketIfPresent(reason);
   }
 

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocketTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/SonarCloudWebSocketTests.java
@@ -54,6 +54,8 @@ class SonarCloudWebSocketTests {
   private CompletableFuture<WebSocket> wsFuture;
   private Consumer<SonarServerEvent> serverEventConsumer;
   private Runnable connectionEndedRunnable;
+  private Runnable onConnectionSucceeded;
+  private Runnable onConnectionFailed;
   private SonarCloudWebSocket sonarCloudWebSocket;
   private URI testUri;
 
@@ -64,7 +66,13 @@ class SonarCloudWebSocketTests {
     wsFuture = new CompletableFuture<>();
     serverEventConsumer = mock(Consumer.class);
     connectionEndedRunnable = mock(Runnable.class);
+    onConnectionSucceeded = mock(Runnable.class);
+    onConnectionFailed = mock(Runnable.class);
     testUri = URI.create("wss://test.example.com/websocket");
+  }
+
+  private SonarCloudWebSocket createWebSocket() {
+    return SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable, onConnectionSucceeded, onConnectionFailed);
   }
 
   @Test
@@ -72,23 +80,27 @@ class SonarCloudWebSocketTests {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
     when(mockWebSocket.sendText(anyString(), eq(true))).thenReturn(CompletableFuture.completedFuture(null));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     assertThat(sonarCloudWebSocket).isNotNull();
     verify(webSocketClient).createWebSocketConnection(eq(testUri), any(Consumer.class), any(Runnable.class));
     assertThat(logTester.logs()).anyMatch(log -> log.contains("Creating WebSocket connection to " + testUri));
+    verify(onConnectionSucceeded).run();
+    verify(onConnectionFailed, never()).run();
   }
 
   @Test
   void should_handle_connection_failure_with_generic_exception() {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.completeExceptionally(new RuntimeException("Generic error"));
 
     assertThat(sonarCloudWebSocket).isNotNull();
     assertThat(logTester.logs(LogOutput.Level.ERROR)).anyMatch(log -> log.contains("Error while trying to create WebSocket connection for " + testUri));
+    verify(onConnectionFailed).run();
+    verify(onConnectionSucceeded, never()).run();
   }
 
   @Test
@@ -97,7 +109,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.sendText(anyString(), eq(true))).thenReturn(CompletableFuture.completedFuture(null));
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
     when(mockWebSocket.sendClose(anyInt(), anyString())).thenReturn(CompletableFuture.completedFuture(null));
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
     var onClosedCaptor = ArgumentCaptor.forClass(Runnable.class);
     verify(webSocketClient).createWebSocketConnection(any(URI.class), any(Consumer.class), onClosedCaptor.capture());
@@ -120,7 +132,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
     when(mockWebSocket.sendClose(anyInt(), anyString())).thenReturn(CompletableFuture.failedFuture(new RuntimeException("Close failed")));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     sonarCloudWebSocket.close("Test reason");
@@ -136,7 +148,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
     when(mockWebSocket.sendClose(anyInt(), anyString())).thenReturn(CompletableFuture.failedFuture(new UnresolvedAddressException()));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     // Capture the onClosedRunnable callback and complete it to avoid timeout
@@ -157,7 +169,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
     when(mockWebSocket.sendClose(anyInt(), anyString())).thenReturn(CompletableFuture.failedFuture(new IOException("Output closed")));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     // Capture the onClosedRunnable callback and complete it to avoid timeout
@@ -178,7 +190,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
     when(mockWebSocket.sendClose(anyInt(), anyString())).thenReturn(CompletableFuture.failedFuture(new IOException("closed output")));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     // Capture the onClosedRunnable callback and complete it to avoid timeout
@@ -199,7 +211,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
     when(mockWebSocket.sendClose(anyInt(), anyString())).thenReturn(CompletableFuture.failedFuture(new IOException("Connection reset")));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     // Capture the onClosedRunnable callback and complete it to avoid timeout
@@ -219,7 +231,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.sendText(anyString(), eq(true))).thenReturn(CompletableFuture.completedFuture(null));
     when(mockWebSocket.isOutputClosed()).thenReturn(true);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     sonarCloudWebSocket.close("Test reason");
@@ -231,7 +243,7 @@ class SonarCloudWebSocketTests {
   void should_handle_failed_websocket_future() {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.completeExceptionally(new RuntimeException("Connection failed"));
 
     sonarCloudWebSocket.close("Test reason");
@@ -244,7 +256,7 @@ class SonarCloudWebSocketTests {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class)))
       .thenReturn(wsFuture);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
 
     sonarCloudWebSocket.close("Test reason");
 
@@ -258,7 +270,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.isInputClosed()).thenReturn(false);
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     assertThat(sonarCloudWebSocket.isOpen()).isTrue();
@@ -271,7 +283,7 @@ class SonarCloudWebSocketTests {
     when(mockWebSocket.isInputClosed()).thenReturn(true);
     when(mockWebSocket.isOutputClosed()).thenReturn(false);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     assertThat(sonarCloudWebSocket.isOpen()).isFalse();
@@ -281,16 +293,28 @@ class SonarCloudWebSocketTests {
   void should_return_false_when_websocket_future_is_not_done() {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
 
     assertThat(sonarCloudWebSocket.isOpen()).isFalse();
+    assertThat(sonarCloudWebSocket.isConnecting()).isTrue();
+  }
+
+  @Test
+  void should_not_call_failure_callback_when_closing_initiated_before_failure() {
+    when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
+
+    sonarCloudWebSocket = createWebSocket();
+    sonarCloudWebSocket.close("Test reason");
+    wsFuture.completeExceptionally(new RuntimeException("Connection failed"));
+
+    verify(onConnectionFailed, never()).run();
   }
 
   @Test
   void should_return_false_when_websocket_future_failed() {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.completeExceptionally(new RuntimeException("Connection failed"));
 
     assertThat(sonarCloudWebSocket.isOpen()).isFalse();
@@ -300,7 +324,7 @@ class SonarCloudWebSocketTests {
   void should_return_false_when_websocket_future_is_cancelled() {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.cancel(true);
 
     assertThat(sonarCloudWebSocket.isOpen()).isFalse();
@@ -311,7 +335,7 @@ class SonarCloudWebSocketTests {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
     when(mockWebSocket.sendText(anyString(), eq(true))).thenReturn(CompletableFuture.completedFuture(null));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     var onClosedCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -328,7 +352,7 @@ class SonarCloudWebSocketTests {
     when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
     when(mockWebSocket.sendText(anyString(), eq(true))).thenReturn(CompletableFuture.completedFuture(null));
 
-    sonarCloudWebSocket = SonarCloudWebSocket.create(testUri, webSocketClient, serverEventConsumer, connectionEndedRunnable);
+    sonarCloudWebSocket = createWebSocket();
     wsFuture.complete(mockWebSocket);
 
     // Close the connection first

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
@@ -1,0 +1,205 @@
+/*
+ * SonarLint Core - Implementation
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.websocket;
+
+import java.net.URI;
+import java.net.http.WebSocket;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+import org.sonarsource.sonarlint.core.SonarQubeClientManager;
+import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
+import org.sonarsource.sonarlint.core.http.WebSocketClient;
+import org.sonarsource.sonarlint.core.repository.config.ConfigurationRepository;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.sonarsource.sonarlint.core.websocket.WebSocketManager.RETRY_INITIAL_DELAY_PROPERTY;
+
+class WebSocketManagerTests {
+
+  @RegisterExtension
+  private static final SonarLintLogTester logTester = new SonarLintLogTester();
+
+  private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+  private final SonarQubeClientManager sonarQubeClientManager = mock(SonarQubeClientManager.class);
+  private final ConfigurationRepository configurationRepository = mock(ConfigurationRepository.class);
+  private final ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+  private final WebSocketClient webSocketClient = mock(WebSocketClient.class);
+  private final URI websocketEndpointUri = URI.create("wss://test.example.com/websocket");
+  private WebSocketManager webSocketManager;
+
+  @BeforeEach
+  void setUp() {
+    System.setProperty(RETRY_INITIAL_DELAY_PROPERTY, "60");
+    doAnswer(invocation -> {
+      ((Runnable) invocation.getArgument(0)).run();
+      return null;
+    }).when(executor).execute(any(Runnable.class));
+    when(sonarQubeClientManager.getValidWebSocketClient("connectionId")).thenReturn(Optional.of(webSocketClient));
+    webSocketManager = new WebSocketManager(eventPublisher, sonarQubeClientManager, configurationRepository, websocketEndpointUri, executor);
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(RETRY_INITIAL_DELAY_PROPERTY);
+  }
+
+  @Test
+  void should_schedule_retry_when_connection_fails() {
+    var wsFuture = failingConnection();
+    var scheduledFuture = mock(ScheduledFuture.class);
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+
+    webSocketManager.createConnectionIfNeeded("connectionId");
+    wsFuture.completeExceptionally(new RuntimeException("connection failed"));
+
+    verify(executor).schedule(any(Runnable.class), eq(60L), eq(TimeUnit.SECONDS));
+    assertThat(logTester.logs()).contains("Cannot connect to SonarCloud WebSocket, retrying in 60s");
+  }
+
+  @Test
+  void should_use_exponential_backoff_between_retries() {
+    var scheduledFuture = mock(ScheduledFuture.class);
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+
+    var firstFuture = failingConnection();
+    webSocketManager.createConnectionIfNeeded("connectionId");
+    firstFuture.completeExceptionally(new RuntimeException("connection failed"));
+    assertThat(logTester.logs()).contains("Cannot connect to SonarCloud WebSocket, retrying in 60s");
+
+    runScheduledRetry(scheduledFuture);
+    assertThat(logTester.logs()).contains("Cannot connect to SonarCloud WebSocket, retrying in 120s");
+
+    runScheduledRetry(scheduledFuture);
+    assertThat(logTester.logs()).contains("Cannot connect to SonarCloud WebSocket, retrying in 240s");
+    verify(executor).schedule(any(Runnable.class), eq(240L), eq(TimeUnit.SECONDS));
+  }
+
+  @Test
+  void should_stop_retrying_after_max_attempts() {
+    var scheduledFuture = mock(ScheduledFuture.class);
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+
+    var firstFuture = failingConnection();
+    webSocketManager.createConnectionIfNeeded("connectionId");
+    firstFuture.completeExceptionally(new RuntimeException("connection failed"));
+
+    for (int attemptNumber = 0; attemptNumber < 8; attemptNumber++) {
+      runScheduledRetry(scheduledFuture);
+    }
+
+    ArgumentCaptor<Runnable> lastRetryCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor).schedule(lastRetryCaptor.capture(), anyLong(), any());
+    clearInvocations(executor);
+    var lastWsFuture = failingConnection();
+    lastRetryCaptor.getValue().run();
+    lastWsFuture.completeExceptionally(new RuntimeException("connection failed"));
+
+    verify(executor, never()).schedule(any(Runnable.class), anyLong(), any());
+    assertThat(logTester.logs()).contains(
+      "Cannot connect to SonarCloud WebSocket, retrying in 15360s",
+      "Cannot connect to SonarCloud WebSocket, stop retrying");
+  }
+
+  @Test
+  void should_cancel_pending_retry_when_shutting_down() {
+    var wsFuture = failingConnection();
+    var scheduledFuture = mock(ScheduledFuture.class);
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+
+    webSocketManager.createConnectionIfNeeded("connectionId");
+    wsFuture.completeExceptionally(new RuntimeException("connection failed"));
+
+    webSocketManager.shutdown();
+
+    verify(scheduledFuture).cancel(true);
+  }
+
+  @Test
+  void should_reset_attempt_counter_after_successful_connection() {
+    var failingFuture = failingConnection();
+    var scheduledFuture = mock(ScheduledFuture.class);
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+
+    webSocketManager.createConnectionIfNeeded("connectionId");
+    failingFuture.completeExceptionally(new RuntimeException("connection failed"));
+
+    ArgumentCaptor<Runnable> retryCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor).schedule(retryCaptor.capture(), eq(60L), eq(TimeUnit.SECONDS));
+    clearInvocations(executor);
+
+    var succeedingFuture = new CompletableFuture<WebSocket>();
+    var mockWebSocket = mock(WebSocket.class);
+    when(mockWebSocket.isInputClosed()).thenReturn(false);
+    when(mockWebSocket.isOutputClosed()).thenReturn(false);
+    ArgumentCaptor<Runnable> onClosedCaptor = ArgumentCaptor.forClass(Runnable.class);
+    when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), onClosedCaptor.capture())).thenReturn(succeedingFuture);
+    when(mockWebSocket.sendClose(any(Integer.class), any())).thenAnswer(invocation -> {
+      onClosedCaptor.getValue().run();
+      return CompletableFuture.completedFuture(null);
+    });
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+    retryCaptor.getValue().run();
+    succeedingFuture.complete(mockWebSocket);
+    assertThat(webSocketManager.hasOpenConnection()).isTrue();
+
+    clearInvocations(executor);
+    var reopenFuture = failingConnection();
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+    webSocketManager.reopenConnection("connectionId", "force reopen");
+    reopenFuture.completeExceptionally(new RuntimeException("connection failed again"));
+
+    verify(executor).schedule(any(Runnable.class), eq(60L), eq(TimeUnit.SECONDS));
+  }
+
+  private CompletableFuture<WebSocket> failingConnection() {
+    var wsFuture = new CompletableFuture<WebSocket>();
+    when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
+    return wsFuture;
+  }
+
+  private void runScheduledRetry(ScheduledFuture scheduledFuture) {
+    ArgumentCaptor<Runnable> retryCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor).schedule(retryCaptor.capture(), anyLong(), any());
+    clearInvocations(executor);
+    var nextFuture = failingConnection();
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+    retryCaptor.getValue().run();
+    nextFuture.completeExceptionally(new RuntimeException("connection failed"));
+  }
+}

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
@@ -27,9 +27,9 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.sonarsource.sonarlint.core.SonarQubeClientManager;
@@ -37,6 +37,9 @@ import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.http.WebSocketClient;
 import org.sonarsource.sonarlint.core.repository.config.ConfigurationRepository;
 import org.springframework.context.ApplicationEventPublisher;
+import uk.org.webcompere.systemstubs.jupiter.SystemStub;
+import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
+import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -50,10 +53,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.sonarsource.sonarlint.core.websocket.WebSocketManager.RETRY_INITIAL_DELAY_PROPERTY;
 
+@ExtendWith(SystemStubsExtension.class)
 class WebSocketManagerTests {
 
   @RegisterExtension
   private static final SonarLintLogTester logTester = new SonarLintLogTester();
+
+  @SystemStub
+  private SystemProperties systemProperties;
 
   private final ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
   private final SonarQubeClientManager sonarQubeClientManager = mock(SonarQubeClientManager.class);
@@ -65,18 +72,13 @@ class WebSocketManagerTests {
 
   @BeforeEach
   void setUp() {
-    System.setProperty(RETRY_INITIAL_DELAY_PROPERTY, "60");
+    systemProperties.set(RETRY_INITIAL_DELAY_PROPERTY, "60");
     doAnswer(invocation -> {
       ((Runnable) invocation.getArgument(0)).run();
       return null;
     }).when(executor).execute(any(Runnable.class));
     when(sonarQubeClientManager.getValidWebSocketClient("connectionId")).thenReturn(Optional.of(webSocketClient));
     webSocketManager = new WebSocketManager(eventPublisher, sonarQubeClientManager, configurationRepository, websocketEndpointUri, executor);
-  }
-
-  @AfterEach
-  void tearDown() {
-    System.clearProperty(RETRY_INITIAL_DELAY_PROPERTY);
   }
 
   @Test

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
@@ -93,6 +93,20 @@ class WebSocketManagerTests {
   }
 
   @Test
+  void should_schedule_retry_when_connection_fails_synchronously() {
+    var wsFuture = new CompletableFuture<WebSocket>();
+    wsFuture.completeExceptionally(new RuntimeException("connection failed"));
+    when(webSocketClient.createWebSocketConnection(any(URI.class), any(Consumer.class), any(Runnable.class))).thenReturn(wsFuture);
+    var scheduledFuture = mock(ScheduledFuture.class);
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+
+    webSocketManager.createConnectionIfNeeded("connectionId");
+
+    verify(executor).schedule(any(Runnable.class), eq(60L), eq(TimeUnit.SECONDS));
+    assertThat(logTester.logs()).contains("Cannot connect to SonarCloud WebSocket, retrying in 60s");
+  }
+
+  @Test
   void should_use_exponential_backoff_between_retries() {
     var scheduledFuture = mock(ScheduledFuture.class);
     when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/websocket/WebSocketManagerTests.java
@@ -151,6 +151,37 @@ class WebSocketManagerTests {
   }
 
   @Test
+  void should_reset_attempt_counter_on_new_independent_connection_attempt_after_exhaustion() {
+    var scheduledFuture = mock(ScheduledFuture.class);
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+
+    var firstFuture = failingConnection();
+    webSocketManager.createConnectionIfNeeded("connectionId");
+    firstFuture.completeExceptionally(new RuntimeException("connection failed"));
+
+    for (int attemptNumber = 0; attemptNumber < 8; attemptNumber++) {
+      runScheduledRetry(scheduledFuture);
+    }
+
+    ArgumentCaptor<Runnable> lastRetryCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(executor).schedule(lastRetryCaptor.capture(), anyLong(), any());
+    clearInvocations(executor);
+    var lastWsFuture = failingConnection();
+    lastRetryCaptor.getValue().run();
+    lastWsFuture.completeExceptionally(new RuntimeException("connection failed"));
+    verify(executor, never()).schedule(any(Runnable.class), anyLong(), any());
+
+    clearInvocations(executor);
+    var newAttemptFuture = failingConnection();
+    when(executor.schedule(any(Runnable.class), anyLong(), any())).thenReturn(scheduledFuture);
+    webSocketManager.createConnectionIfNeeded("connectionId");
+    newAttemptFuture.completeExceptionally(new RuntimeException("connection failed again"));
+
+    verify(executor).schedule(any(Runnable.class), eq(60L), eq(TimeUnit.SECONDS));
+    assertThat(logTester.logs()).contains("Cannot connect to SonarCloud WebSocket, retrying in 60s");
+  }
+
+  @Test
   void should_cancel_pending_retry_when_shutting_down() {
     var wsFuture = failingConnection();
     var scheduledFuture = mock(ScheduledFuture.class);

--- a/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
@@ -48,6 +48,7 @@ import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTest;
 import org.sonarsource.sonarlint.core.test.utils.junit5.SonarLintTestHarness;
 import org.sonarsource.sonarlint.core.test.utils.server.websockets.WebSocketConnection;
 import org.sonarsource.sonarlint.core.test.utils.server.websockets.WebSocketServer;
+import org.sonarsource.sonarlint.core.websocket.WebSocketManager;
 
 import static java.util.Collections.emptyList;
 import static mediumtest.websockets.WebSocketMediumTests.WebSocketPayloadBuilder.webSocketPayloadBuilder;
@@ -518,26 +519,32 @@ class WebSocketMediumTests {
 
     @SonarLintTest
     void should_log_failure_and_reconnect_later_if_server_unavailable(SonarLintTestHarness harness) {
-      var client = harness.newFakeClient()
-        .withToken("connectionId", "token")
-        .build();
-      webSocketServerEU.stop();
-      var backend = newBackendWithWebSockets(harness)
-        .withBoundConfigScope("configScope", "connectionId", "projectKey")
-        .start(client);
+      System.setProperty(WebSocketManager.RETRY_INITIAL_DELAY_PROPERTY, "1");
+      try {
+        var client = harness.newFakeClient()
+          .withToken("connectionId", "token")
+          .build();
+        webSocketServerEU.stop();
+        var backend = newBackendWithWebSockets(harness)
+          .withBoundConfigScope("configScope", "connectionId", "projectKey")
+          .start(client);
 
-      backend.getConnectionService()
-        .didUpdateConnections(new DidUpdateConnectionsParams(emptyList(), List.of(new SonarCloudConnectionConfigurationDto("connectionId", "orgKey", SonarCloudRegion.EU, false))));
+        backend.getConnectionService()
+          .didUpdateConnections(new DidUpdateConnectionsParams(emptyList(), List.of(new SonarCloudConnectionConfigurationDto("connectionId", "orgKey", SonarCloudRegion.EU, false))));
 
-      await().untilAsserted(() -> assertThat(client.getLogMessages()).contains("Error while trying to create WebSocket connection for " + webSocketServerEU.getUri()));
+        await().untilAsserted(() -> assertThat(client.getLogMessages())
+          .contains(
+            "Error while trying to create WebSocket connection for " + webSocketServerEU.getUri(),
+            "Cannot connect to SonarCloud WebSocket, retrying in 1s"));
 
-      webSocketServerEU.restart();
-      // Emulate a change on the connection to force WebSocket service to reconnect
-      backend.getConnectionService().didChangeCredentials(new DidChangeCredentialsParams("connectionId"));
+        webSocketServerEU.restart();
 
-      await().untilAsserted(() -> assertThat(webSocketServerEU.getConnections())
-        .extracting(WebSocketConnection::isOpened, WebSocketConnection::getReceivedMessages)
-        .containsExactly(tuple(true, webSocketPayloadBuilder().subscribeWithProjectKey("projectKey").build())));
+        await().untilAsserted(() -> assertThat(webSocketServerEU.getConnections())
+          .extracting(WebSocketConnection::isOpened, WebSocketConnection::getReceivedMessages)
+          .containsExactly(tuple(true, webSocketPayloadBuilder().subscribeWithProjectKey("projectKey").build())));
+      } finally {
+        System.clearProperty(WebSocketManager.RETRY_INITIAL_DELAY_PROPERTY);
+      }
     }
   }
 

--- a/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/websockets/WebSocketMediumTests.java
@@ -61,6 +61,7 @@ import static org.sonarsource.sonarlint.core.test.utils.SonarLintBackendFixture.
 import static org.sonarsource.sonarlint.core.test.utils.storage.ServerIssueFixtures.aServerIssue;
 import static org.sonarsource.sonarlint.core.test.utils.storage.ServerSecurityHotspotFixture.aServerHotspot;
 import static org.sonarsource.sonarlint.core.test.utils.storage.ServerTaintIssueFixtures.aServerTaintIssue;
+import static uk.org.webcompere.systemstubs.SystemStubs.restoreSystemProperties;
 
 class WebSocketMediumTests {
 
@@ -518,9 +519,9 @@ class WebSocketMediumTests {
     }
 
     @SonarLintTest
-    void should_log_failure_and_reconnect_later_if_server_unavailable(SonarLintTestHarness harness) {
-      System.setProperty(WebSocketManager.RETRY_INITIAL_DELAY_PROPERTY, "1");
-      try {
+    void should_log_failure_and_reconnect_later_if_server_unavailable(SonarLintTestHarness harness) throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(WebSocketManager.RETRY_INITIAL_DELAY_PROPERTY, "1");
         var client = harness.newFakeClient()
           .withToken("connectionId", "token")
           .build();
@@ -542,9 +543,7 @@ class WebSocketMediumTests {
         await().untilAsserted(() -> assertThat(webSocketServerEU.getConnections())
           .extracting(WebSocketConnection::isOpened, WebSocketConnection::getReceivedMessages)
           .containsExactly(tuple(true, webSocketPayloadBuilder().subscribeWithProjectKey("projectKey").build())));
-      } finally {
-        System.clearProperty(WebSocketManager.RETRY_INITIAL_DELAY_PROPERTY);
-      }
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
* Retry SonarCloud WebSocket handshake failures with exponential backoff (60s × 2, max 10 attempts), matching the existing SSE `EventStream` pattern
* Reset the attempt counter on successful connect or intentional reopen; cancel pending retries on close/shutdown
* Cover the behavior with `WebSocketManagerTests` and update the medium test to assert automatic reconnect without a manual credentials change