### PR TITLE
SLCORE-2539 Remove the SQC events polling fallback mechanism

### DIFF
--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/SmartNotifications.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/smartnotifications/SmartNotifications.java
@@ -43,7 +43,6 @@ import org.sonarsource.sonarlint.core.event.SonarServerEventReceivedEvent;
 import org.sonarsource.sonarlint.core.repository.config.ConfigurationRepository;
 import org.sonarsource.sonarlint.core.repository.connection.AbstractConnectionConfiguration;
 import org.sonarsource.sonarlint.core.repository.connection.ConnectionConfigurationRepository;
-import org.sonarsource.sonarlint.core.repository.connection.SonarCloudConnectionConfiguration;
 import org.sonarsource.sonarlint.core.rpc.protocol.SonarLintRpcClient;
 import org.sonarsource.sonarlint.core.rpc.protocol.backend.initialize.InitializeParams;
 import org.sonarsource.sonarlint.core.rpc.protocol.client.smartnotification.ShowSmartNotificationParams;
@@ -51,7 +50,6 @@ import org.sonarsource.sonarlint.core.serverapi.ServerApi;
 import org.sonarsource.sonarlint.core.serverapi.developers.SearchEventsResponseDto;
 import org.sonarsource.sonarlint.core.storage.StorageService;
 import org.sonarsource.sonarlint.core.telemetry.TelemetryService;
-import org.sonarsource.sonarlint.core.websocket.WebSocketService;
 import org.sonarsource.sonarlint.core.websocket.events.SmartNotificationEvent;
 import org.springframework.context.event.EventListener;
 
@@ -68,20 +66,18 @@ public class SmartNotifications {
   private final SonarQubeClientManager sonarQubeClientManager;
   private final SonarLintRpcClient client;
   private final TelemetryService telemetryService;
-  private final WebSocketService webSocketService;
   private final InitializeParams params;
   private final LastEventPolling lastEventPollingService;
   private ExecutorServiceShutdownWatchable<ScheduledExecutorService> smartNotificationsPolling;
 
   @Inject
   public SmartNotifications(ConfigurationRepository configurationRepository, ConnectionConfigurationRepository connectionRepository, SonarQubeClientManager sonarQubeClientManager,
-    SonarLintRpcClient client, StorageService storageService, TelemetryService telemetryService, WebSocketService webSocketService, InitializeParams params) {
+    SonarLintRpcClient client, StorageService storageService, TelemetryService telemetryService, InitializeParams params) {
     this.configurationRepository = configurationRepository;
     this.connectionRepository = connectionRepository;
     this.sonarQubeClientManager = sonarQubeClientManager;
     this.client = client;
     this.telemetryService = telemetryService;
-    this.webSocketService = webSocketService;
     this.params = params;
     lastEventPollingService = new LastEventPolling(storageService);
   }
@@ -136,12 +132,9 @@ public class SmartNotifications {
       .forEach(projectKey -> lastEventPollingService.setLastEventPolling(ZonedDateTime.now(ZoneId.systemDefault()), connectionId, projectKey));
   }
 
-  private boolean shouldSkipPolling(AbstractConnectionConfiguration connection) {
-    if (connection.getKind() == ConnectionKind.SONARCLOUD) {
-      var region = ((SonarCloudConnectionConfiguration) connection).getRegion();
-      return webSocketService.hasOpenConnection(region);
-    }
-    return false;
+  private static boolean shouldSkipPolling(AbstractConnectionConfiguration connection) {
+    // SonarCloud events are delivered via WebSocket only; HTTP polling is SonarQube Server only
+    return connection.getKind() == ConnectionKind.SONARCLOUD;
   }
 
   private static long getPollPeriod() {

--- a/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketService.java
+++ b/backend/core/src/main/java/org/sonarsource/sonarlint/core/websocket/WebSocketService.java
@@ -252,10 +252,6 @@ public class WebSocketService {
     return false;
   }
 
-  public boolean hasOpenConnection(SonarCloudRegion region) {
-    return webSocketsByRegion.get(region).hasOpenConnection();
-  }
-
   @PreDestroy
   public void shutdown() {
     if (!MoreExecutors.shutdownAndAwaitTermination(executorService, 1, TimeUnit.SECONDS)) {

--- a/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
+++ b/medium-tests/src/test/java/mediumtest/smartnotifications/SmartNotificationsMediumTests.java
@@ -19,6 +19,7 @@
  */
 package mediumtest.smartnotifications;
 
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -274,7 +275,7 @@ class SmartNotificationsMediumTests {
   }
 
   @SonarLintTest
-  void it_should_send_notification_handled_by_sonarcloud_websocket_as_fallback(SonarLintTestHarness harness) {
+  void it_should_not_poll_notifications_for_sonarcloud_connections(SonarLintTestHarness harness) {
     var fakeClient = harness.newFakeClient().build();
     mockWebServerExtension.addResponse("/api/developers/search_events?projects=&from=", new MockResponse.Builder().code(200).build());
     mockWebServerExtension.addStringResponse("/api/developers/search_events?projects=" + PROJECT_KEY + "&from=" +
@@ -287,15 +288,11 @@ class SmartNotificationsMediumTests {
       .withBackendCapability(SMART_NOTIFICATIONS)
       .start(fakeClient);
 
-    await().until(() -> !fakeClient.getSmartNotificationsToShow().isEmpty());
-
-    var notificationsResult = fakeClient.getSmartNotificationsToShow();
-    assertThat(notificationsResult).hasSize(1);
-    assertThat(notificationsResult.element().getScopeIds()).hasSize(1).contains("scopeId");
+    await().during(Duration.ofSeconds(2)).untilAsserted(() -> assertThat(fakeClient.getSmartNotificationsToShow()).isEmpty());
   }
 
   @SonarLintTest
-  void it_should_skip_polling_notifications_when_sonarcloud_websocket_opened(SonarLintTestHarness harness) {
+  void it_should_receive_sonarcloud_notifications_via_websocket(SonarLintTestHarness harness) {
     webSocketServer = new WebSocketServer();
     webSocketServer.start();
     var fakeClient = harness.newFakeClient().withToken(CONNECTION_ID, "token")
@@ -314,14 +311,13 @@ class SmartNotificationsMediumTests {
 
     await().until(() -> webSocketServer.getConnections().size() == 1);
 
-    var notificationsResult = fakeClient.getSmartNotificationsToShow();
-    assertThat(notificationsResult).isEmpty();
+    assertThat(fakeClient.getSmartNotificationsToShow()).isEmpty();
 
     webSocketServer.getConnections().get(0).sendMessage(NEW_ISSUES_EVENT);
 
     await().untilAsserted(() -> assertThat(fakeClient.getSmartNotificationsToShow()).isNotEmpty());
 
-    notificationsResult = fakeClient.getSmartNotificationsToShow();
+    var notificationsResult = fakeClient.getSmartNotificationsToShow();
     assertThat(notificationsResult).hasSize(1);
     assertThat(notificationsResult.element().getScopeIds()).hasSize(1).contains("scopeId");
   }

--- a/spec/smart_notifications.adoc
+++ b/spec/smart_notifications.adoc
@@ -8,7 +8,9 @@ Smart notifications, sometimes called dev notifications, allow developers using 
 * the Quality Gate status (failed/success) of a project open in the IDE changes
 * a SonarQube or SonarCloud analysis raises new xref:glossary.adoc#finding[findings] introduced by this developer in a project open in the IDE
 
-SonarLint will poll SonarQube or SonarCloud every minute to retrieve any new notifications up to 1 day old. When the polling has been done, the timestamp of the polling date is stored and will be used next time as a reference, so the client cannot retrieve the same notification later.
+For SonarQube Server, SonarLint polls every minute to retrieve any new notifications up to 1 day old. When the polling has been done, the timestamp of the polling date is stored and will be used next time as a reference, so the client cannot retrieve the same notification later.
+
+For SonarCloud, notifications are delivered exclusively through the WebSocket channel. There is no HTTP polling fallback.
 
 == Activate/deactivate notifications
 
@@ -16,17 +18,23 @@ The activation or deactivation of notifications must be done individually by eac
 
 == Algorithm
 
-=== Retrieve and send notifications
+=== Retrieve and send notifications (SonarQube Server)
 
-1. Retrieve all `configScopeId` per `projectKey`, for each `connectionId` where the xref:glossary.adoc#binding[binding] is valid, then for each xref:glossary.adoc#connection[connection]:
+1. Retrieve all `configScopeId` per `projectKey`, for each `connectionId` where the xref:glossary.adoc#binding[binding] is valid, then for each SonarQube xref:glossary.adoc#connection[connection]:
 * 2. Make sure the connection is valid and that the smart notifications are enabled
 * 3. Group all the project keys inside this connection and retrieve the last event polling timestamp stored locally for each. This enables SonarLint to request the server only once for a given connection
 * 4. Send a request to `api/developers/search_events?projects=&from=` with the list of project keys and the last event polling timestamp previously retrieved. As a result, we get a list of `ServerNotification`
 * 5. Send each notification to the client  using the method `showSmartNotification(ShowSmartNotificationParams params)`. For each notification, all the xref:glossary.adoc#configuration_scope[configuration scope ids] for the project key where this notification is linked should be gathered. This will be used on the client side to display the notification.
 
-=== Polling mechanism
+=== Polling mechanism (SonarQube Server)
 
 To avoid retrieving already sent notifications, every 60 seconds, the backend will try to retrieve all new notifications since the last polling. This last polling information is stored as a timestamp - later used as a `ZonedDateTime` -  inside a protobuf file under `connectionId/projectKey/last_event_polling.pb`.
+
+SonarCloud connections are skipped by this poller.
+
+=== WebSocket delivery (SonarCloud)
+
+When a smart notification event is received on the SonarCloud WebSocket, the backend forwards it to the client with `showSmartNotification(ShowSmartNotificationParams params)`, gathering all configuration scope ids bound to the project.
 
 === Displaying notifications
 


### PR DESCRIPTION
## Summary
* Stop polling `api/developers/search_events` for SonarCloud connections; SQC smart notifications are WebSocket-only
* Keep HTTP polling for SonarQube Server connections
* Update medium tests and smart notifications spec accordingly