### PR TITLE
SLCORE-2537 Fix race when concurrently creating shared machine id

### DIFF
--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProvider.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProvider.java
@@ -20,7 +20,9 @@
 package org.sonarsource.sonarlint.core.telemetry;
 
 import java.io.IOException;
-import java.nio.file.FileAlreadyExistsException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -35,6 +37,8 @@ public class MachineIdProvider {
 
   private static final SonarLintLogger LOG = SonarLintLogger.get();
   private static final String USER_FILE_NAME = "user";
+  // File locks are JVM-wide; serialize in-process callers before locking the shared file.
+  private static final Object CREATE_LOCK = new Object();
 
   private final TelemetryUserSetting userSetting;
   private boolean resolved;
@@ -73,22 +77,37 @@ public class MachineIdProvider {
   }
 
   private static String createOrReadWinner(Path userFile) throws IOException {
-    var candidate = UUID.randomUUID().toString();
-    try {
-      return writeExclusively(userFile, candidate);
-    } catch (FileAlreadyExistsException e) {
-      var winner = tryRead(userFile);
-      if (winner != null) {
-        return winner;
+    synchronized (CREATE_LOCK) {
+      try (var channel = FileChannel.open(userFile, StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+        var lock = channel.lock()) {
+        var existing = readAll(channel).trim();
+        if (!existing.isEmpty()) {
+          return existing;
+        }
+        var candidate = UUID.randomUUID().toString();
+        var bytes = candidate.getBytes(StandardCharsets.UTF_8);
+        channel.truncate(0);
+        channel.position(0);
+        channel.write(ByteBuffer.wrap(bytes));
+        channel.force(true);
+        return candidate;
       }
-      Files.deleteIfExists(userFile);
-      return writeExclusively(userFile, candidate);
     }
   }
 
-  private static String writeExclusively(Path userFile, String id) throws IOException {
-    Files.writeString(userFile, id, StandardOpenOption.CREATE_NEW);
-    return id;
+  private static String readAll(FileChannel channel) throws IOException {
+    var size = channel.size();
+    if (size == 0) {
+      return "";
+    }
+    var buffer = ByteBuffer.allocate((int) size);
+    channel.position(0);
+    while (buffer.hasRemaining()) {
+      if (channel.read(buffer) < 0) {
+        break;
+      }
+    }
+    return new String(buffer.array(), 0, buffer.position(), StandardCharsets.UTF_8);
   }
 
   @CheckForNull

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProviderTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProviderTests.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -135,16 +136,33 @@ class MachineIdProviderTests {
   void concurrent_creation_should_converge_on_the_same_value(@TempDir Path tempDir) throws InterruptedException {
     environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
     var userSetting = telemetryEnabled(true);
-    var results = new String[10];
-    ExecutorService pool = Executors.newFixedThreadPool(10);
+    var threadCount = 20;
+    var results = new String[threadCount];
+    var ready = new CountDownLatch(threadCount);
+    var start = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(threadCount);
     for (var i = 0; i < results.length; i++) {
       var index = i;
-      pool.submit(() -> results[index] = new MachineIdProvider(userSetting).getMachineId());
+      pool.submit(() -> {
+        ready.countDown();
+        try {
+          start.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        results[index] = new MachineIdProvider(userSetting).getMachineId();
+      });
     }
+    assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+    start.countDown();
     pool.shutdown();
-    pool.awaitTermination(10, TimeUnit.SECONDS);
+    assertThat(pool.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
 
-    assertThat(results).isNotNull().allSatisfy(id -> assertThat(id).isEqualTo(results[0]));
+    var expected = results[0];
+    assertThat(expected).isNotBlank();
+    assertThat(results).containsOnly(expected);
+    assertThat(tempDir.resolve("user")).hasContent(expected);
   }
 
   private static TelemetryUserSetting telemetryEnabled(boolean enabled) {


### PR DESCRIPTION
## Summary
* Fix a race in `MachineIdProvider` where concurrent creators could return divergent UUIDs or `null` (CREATE_NEW left an empty file briefly; blank-file delete/rewrite raced; same-JVM file locks overlapped)
* Serialize in-process creation with a static lock, then take an exclusive file lock and write under it so callers converge on one on-disk value
* Harden the concurrent test with a start barrier and stronger assertions