### PR TITLE
SLCORE-2537 Fix intra-process race in MachineIdProvider

### DIFF
--- a/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProvider.java
+++ b/backend/telemetry/src/main/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProvider.java
@@ -35,6 +35,9 @@ public class MachineIdProvider {
 
   private static final SonarLintLogger LOG = SonarLintLogger.get();
   private static final String USER_FILE_NAME = "user";
+  private static final int MAX_CREATE_ATTEMPTS = 2;
+  // Prevents same-JVM callers from racing each other; cross-process races are still possible.
+  private static final Object CREATE_LOCK = new Object();
 
   private final TelemetryUserSetting userSetting;
   private boolean resolved;
@@ -72,17 +75,23 @@ public class MachineIdProvider {
     }
   }
 
+  @CheckForNull
   private static String createOrReadWinner(Path userFile) throws IOException {
-    var candidate = UUID.randomUUID().toString();
-    try {
-      return writeExclusively(userFile, candidate);
-    } catch (FileAlreadyExistsException e) {
-      var winner = tryRead(userFile);
-      if (winner != null) {
-        return winner;
+    synchronized (CREATE_LOCK) {
+      var candidate = UUID.randomUUID().toString();
+      for (var attempt = 1; attempt <= MAX_CREATE_ATTEMPTS; attempt++) {
+        try {
+          return writeExclusively(userFile, candidate);
+        } catch (FileAlreadyExistsException e) {
+          var winner = tryRead(userFile);
+          if (winner != null) {
+            return winner;
+          }
+          Files.deleteIfExists(userFile);
+        }
       }
-      Files.deleteIfExists(userFile);
-      return writeExclusively(userFile, candidate);
+      // All attempts lost the race; read the winner instead of returning null or an unpersisted candidate.
+      return tryRead(userFile);
     }
   }
 

--- a/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProviderTests.java
+++ b/backend/telemetry/src/test/java/org/sonarsource/sonarlint/core/telemetry/MachineIdProviderTests.java
@@ -20,9 +20,12 @@
 package org.sonarsource.sonarlint.core.telemetry;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -30,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Answers;
 import org.sonarsource.sonarlint.core.commons.SonarUserHome;
 import org.sonarsource.sonarlint.core.commons.log.SonarLintLogTester;
 import org.sonarsource.sonarlint.core.telemetry.common.TelemetryUserSetting;
@@ -38,7 +42,10 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(SystemStubsExtension.class)
@@ -98,6 +105,30 @@ class MachineIdProviderTests {
   }
 
   @Test
+  void should_read_the_winner_id_when_every_create_attempt_loses_the_race(@TempDir Path tempDir) {
+    environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
+    var userFile = tempDir.resolve("user");
+    var winnerId = UUID.randomUUID().toString();
+    var userSetting = telemetryEnabled(true);
+
+    try (var filesMock = mockStatic(Files.class, Answers.CALLS_REAL_METHODS)) {
+      filesMock.when(() -> Files.writeString(eq(userFile), any(), eq(StandardOpenOption.CREATE_NEW)))
+        .thenThrow(new FileAlreadyExistsException(userFile.toString()));
+      filesMock.when(() -> Files.deleteIfExists(userFile))
+        .thenReturn(false)
+        .thenAnswer(invocation -> {
+          // Simulate the winner's write becoming visible on disk right after our last losing attempt.
+          Files.writeString(userFile, winnerId);
+          return false;
+        });
+
+      var machineId = new MachineIdProvider(userSetting).getMachineId();
+
+      assertThat(machineId).isEqualTo(winnerId);
+    }
+  }
+
+  @Test
   void should_return_null_when_the_shared_home_cannot_be_created(@TempDir Path tempDir) {
     var unwritableParent = tempDir.resolve("not-a-directory");
     unwritableParent.toFile().getParentFile().mkdirs();
@@ -135,16 +166,33 @@ class MachineIdProviderTests {
   void concurrent_creation_should_converge_on_the_same_value(@TempDir Path tempDir) throws InterruptedException {
     environmentVariables.set(SonarUserHome.SONAR_USER_HOME_ENV, tempDir.toString());
     var userSetting = telemetryEnabled(true);
-    var results = new String[10];
-    ExecutorService pool = Executors.newFixedThreadPool(10);
+    var threadCount = 30;
+    var results = new String[threadCount];
+    var ready = new CountDownLatch(threadCount);
+    var start = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(threadCount);
     for (var i = 0; i < results.length; i++) {
       var index = i;
-      pool.submit(() -> results[index] = new MachineIdProvider(userSetting).getMachineId());
+      pool.submit(() -> {
+        ready.countDown();
+        try {
+          start.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        results[index] = new MachineIdProvider(userSetting).getMachineId();
+      });
     }
+    assertThat(ready.await(10, TimeUnit.SECONDS)).isTrue();
+    start.countDown();
     pool.shutdown();
-    pool.awaitTermination(10, TimeUnit.SECONDS);
+    assertThat(pool.awaitTermination(10, TimeUnit.SECONDS)).isTrue();
 
-    assertThat(results).isNotNull().allSatisfy(id -> assertThat(id).isEqualTo(results[0]));
+    var expected = results[0];
+    assertThat(expected).isNotBlank();
+    assertThat(results).containsOnly(expected);
+    assertThat(tempDir.resolve("user")).hasContent(expected);
   }
 
   private static TelemetryUserSetting telemetryEnabled(boolean enabled) {


### PR DESCRIPTION
----
## Summary by Gitar

- **Fixed bugs:**
    - Added synchronization lock in `MachineIdProvider` to prevent intra-process race conditions during machine ID creation
- **Tests:**
    - Enhanced concurrent tests in `MachineIdProviderTests` with latch synchronization and increased thread count

<sub>This will update automatically on new commits.</sub>