### PR TITLE
SLCORE-2551 Update omnisharp

### DIFF
--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
@@ -93,9 +93,9 @@ class BinariesArtifactTest {
 
   @Test
   void should_return_omnisharp_version_from_properties() {
-    assertThat(BinariesArtifact.OMNISHARP_MONO.version()).isEqualTo("1.39.15");
-    assertThat(BinariesArtifact.OMNISHARP_NET472.version()).isEqualTo("1.39.15");
-    assertThat(BinariesArtifact.OMNISHARP_NET6.version()).isEqualTo("1.39.15");
+    assertThat(BinariesArtifact.OMNISHARP_MONO.version()).isEqualTo("1.39.15.1-sonar");
+    assertThat(BinariesArtifact.OMNISHARP_NET472.version()).isEqualTo("1.39.15.1-sonar");
+    assertThat(BinariesArtifact.OMNISHARP_NET6.version()).isEqualTo("1.39.15.1-sonar");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <!-- On-demand plugin versions -->
     <cfamily.version>6.84.0.101652</cfamily.version>
     <csharp.version>10.31.0.145097</csharp.version>
-    <omnisharp.version>1.39.15</omnisharp.version>
+    <omnisharp.version>1.39.15.1-sonar</omnisharp.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Dependency updates:**
    - Updated `omnisharp.version` property and corresponding test assertions to `1.39.15.1-sonar` in `pom.xml` and `BinariesArtifactTest.java`

<sub>This will update automatically on new commits.</sub>