### PR TITLE
SLCORE-2555 Prevent overflows in comparators

### DIFF
--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisQueue.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisQueue.java
@@ -195,9 +195,9 @@ public class AnalysisQueue {
       var otherCommand = otherQueuedCommand.command;
       var commandRank = COMMAND_TYPES_ORDERED.get(command.getClass());
       var otherCommandRank = COMMAND_TYPES_ORDERED.get(otherCommand.getClass());
-      return !Objects.equals(commandRank, otherCommandRank) ? (commandRank - otherCommandRank) :
+      return !Objects.equals(commandRank, otherCommandRank) ? Integer.compare(commandRank, otherCommandRank) :
       // for same command types, respect insertion order
-        (int) (command.getSequenceNumber() - otherCommand.getSequenceNumber());
+        Long.compare(command.getSequenceNumber(), otherCommand.getSequenceNumber());
     }
   }
 

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisQueue.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/AnalysisQueue.java
@@ -134,7 +134,7 @@ public class AnalysisQueue {
       }
       LOG.debug("Batching {} analyses", removedCommands.size() + 1);
       return Stream.concat(Stream.of(analyzeCommand), removedCommands.stream())
-        .sorted((c1, c2) -> (int) (c1.getSequenceNumber() - c2.getSequenceNumber()))
+        .sorted((c1, c2) -> Long.compare(c1.getSequenceNumber(), c2.getSequenceNumber()))
         .reduce(AnalyzeCommand::mergeWith)
         // this last clause should never occur
         .orElse(analyzeCommand);

--- a/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/AbstractFilePredicate.java
+++ b/backend/analysis-engine/src/main/java/org/sonarsource/sonarlint/core/analysis/container/analysis/filesystem/AbstractFilePredicate.java
@@ -49,7 +49,7 @@ public abstract class AbstractFilePredicate implements OptimizedFilePredicate {
 
   @Override
   public final int compareTo(OptimizedFilePredicate o) {
-    return o.priority() - priority();
+    return Integer.compare(o.priority(), priority());
   }
 
 }


### PR DESCRIPTION
Part of DEX-16

----
## Summary by Gitar

- **Bug fixes:**
    - Prevent potential integer overflow issues in comparators within `AnalysisQueue` and `AbstractFilePredicate` by using safe comparison methods

<sub>This will update automatically on new commits.</sub>