### PR TITLE
SLCORE-2443 Fix incorrect decoding of percent-encoded characters in file URIs

### DIFF
--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
@@ -45,7 +45,6 @@ public class FileUtils {
    */
   public static Path getFilePathFromUri(URI uri) {
     try {
-      // Path.of(URI) correctly decodes percent-encoded sequences (e.g. "%2B" -> "+"), unlike URI.getPath() below
       return Path.of(uri);
     } catch (IllegalArgumentException e) {
       // Works around JDK-8162518: Path.of(URI) throws "Bad escape" for raw non-ASCII characters in the URI.

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
@@ -19,7 +19,6 @@
  */
 package org.sonarsource.sonarlint.core.commons.util;
 
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Path;
 
@@ -30,10 +29,15 @@ public class FileUtils {
    * characters in the process (so a directory literally named {@code c%2B%2B} always means {@code c++}, never a
    * raw {@code %2B%2B}, per the URI spec).
    *
-   * @throws IllegalArgumentException if {@code uri} is not a valid, absolute, hierarchical {@code file} URI
-   *                                   without a query or fragment component (e.g. a URI with a non-empty
-   *                                   authority/host, such as a UNC path), or contains raw non-ASCII characters
-   *                                   that are not percent-encoded (works around JDK-8162518)
+   * @throws IllegalArgumentException if {@code uri} has no hierarchical path component at all (e.g. an opaque
+   *                                   URI such as {@code mailto:x@y}). A URI with an authority component (UNC
+   *                                   path), a query/fragment component, or raw non-percent-encoded non-ASCII
+   *                                   characters does <em>not</em> throw: those are handled by falling back to
+   *                                   {@link URI#getPath()}, which decodes percent-encoding but, unlike
+   *                                   {@link Path#of(URI)}, silently drops the authority and any query/fragment.
+   *                                   This fallback works around JDK-8162518, where {@code Path.of(URI)} throws
+   *                                   {@code IllegalArgumentException: Bad escape} for raw non-ASCII characters
+   *                                   in a {@code file:///...} URI.
    * @throws java.nio.file.FileSystemNotFoundException if {@code uri}'s scheme is not {@code file} and has no
    *                                                     installed {@link java.nio.file.spi.FileSystemProvider}
    *                                                     (e.g. the {@code temp} scheme used by IntelliJ or the
@@ -41,16 +45,16 @@ public class FileUtils {
    */
   public static Path getFilePathFromUri(URI uri) {
     try {
-      // Path.of(URI) correctly decodes percent-encoded sequences (e.g. "%2B" -> "+"), unlike URL.getPath() below
+      // Path.of(URI) correctly decodes percent-encoded sequences (e.g. "%2B" -> "+"), unlike URI.getPath() below
       return Path.of(uri);
     } catch (IllegalArgumentException e) {
       // Works around JDK-8162518: Path.of(URI) throws "Bad escape" for raw non-ASCII characters in the URI.
-      // URL.getPath() does not decode percent-encoded sequences, so it must only be used as a last resort.
-      try {
-        return Path.of(uri.toURL().getPath());
-      } catch (MalformedURLException ex) {
-        throw new IllegalArgumentException(ex);
+      // URI.getPath() decodes percent-encoded sequences while keeping raw non-ASCII characters as-is.
+      var decodedPath = uri.getPath();
+      if (decodedPath == null) {
+        throw e;
       }
+      return Path.of(decodedPath);
     }
   }
 

--- a/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
+++ b/backend/commons/src/main/java/org/sonarsource/sonarlint/core/commons/util/FileUtils.java
@@ -19,17 +19,38 @@
  */
 package org.sonarsource.sonarlint.core.commons.util;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Path;
 
 public class FileUtils {
 
+  /**
+   * Converts a file URI (e.g. as sent by an IDE client) to a local {@link Path}, decoding any percent-encoded
+   * characters in the process (so a directory literally named {@code c%2B%2B} always means {@code c++}, never a
+   * raw {@code %2B%2B}, per the URI spec).
+   *
+   * @throws IllegalArgumentException if {@code uri} is not a valid, absolute, hierarchical {@code file} URI
+   *                                   without a query or fragment component (e.g. a URI with a non-empty
+   *                                   authority/host, such as a UNC path), or contains raw non-ASCII characters
+   *                                   that are not percent-encoded (works around JDK-8162518)
+   * @throws java.nio.file.FileSystemNotFoundException if {@code uri}'s scheme is not {@code file} and has no
+   *                                                     installed {@link java.nio.file.spi.FileSystemProvider}
+   *                                                     (e.g. the {@code temp} scheme used by IntelliJ or the
+   *                                                     {@code rse} scheme used by Eclipse Remote System Explorer)
+   */
   public static Path getFilePathFromUri(URI uri) {
     try {
-      // In case the path contains non-ASCII characters, Path.of() will fail, we should first try to encode the path via toURL()
-      return Path.of(uri.toURL().getPath());
-    } catch (Exception e) {
+      // Path.of(URI) correctly decodes percent-encoded sequences (e.g. "%2B" -> "+"), unlike URL.getPath() below
       return Path.of(uri);
+    } catch (IllegalArgumentException e) {
+      // Works around JDK-8162518: Path.of(URI) throws "Bad escape" for raw non-ASCII characters in the URI.
+      // URL.getPath() does not decode percent-encoded sequences, so it must only be used as a last resort.
+      try {
+        return Path.of(uri.toURL().getPath());
+      } catch (MalformedURLException ex) {
+        throw new IllegalArgumentException(ex);
+      }
     }
   }
 

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/FileUtilsTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/FileUtilsTests.java
@@ -21,38 +21,29 @@ package org.sonarsource.sonarlint.core.commons.util;
 
 import java.net.URI;
 import java.nio.file.Path;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class FileUtilsTests {
 
-  @Test
-  void shouldDecodePercentEncodedPlusSignsInUri() {
-    var uri = URI.create("file:///home/user/src/c%2B%2B/main.cpp");
+  @ParameterizedTest
+  @MethodSource("uris")
+  void shouldDecodeUriToFilePath(String uri, String expectedPath) {
+    var path = FileUtils.getFilePathFromUri(URI.create(uri));
 
-    var path = FileUtils.getFilePathFromUri(uri);
-
-    assertThat(path).isEqualTo(Path.of("/home/user/src/c++/main.cpp"));
+    assertThat(path).isEqualTo(Path.of(expectedPath));
   }
 
-  @Test
-  void shouldDecodePercentEncodedSpacesInUri() {
-    var uri = URI.create("file:///home/user/my%20project/main.cpp");
-
-    var path = FileUtils.getFilePathFromUri(uri);
-
-    assertThat(path).isEqualTo(Path.of("/home/user/my project/main.cpp"));
-  }
-
-  @Test
-  void shouldFallBackToUrlPathForUriWithRawNonAsciiCharacters() {
-    // JDK-8162518: Path.of(URI) throws "Bad escape" for a hierarchical URI with an empty authority
-    // component (e.g. "file:///...") containing raw, non-percent-encoded non-ASCII characters
-    var uri = URI.create("file:///home/user/src/español/main.cpp");
-
-    var path = FileUtils.getFilePathFromUri(uri);
-
-    assertThat(path).isEqualTo(Path.of("/home/user/src/español/main.cpp"));
+  private static Stream<Arguments> uris() {
+    return Stream.of(
+      Arguments.of("file:///home/user/src/c%2B%2B/main.cpp", "/home/user/src/c++/main.cpp"),
+      Arguments.of("file:///home/user/my%20project/main.cpp", "/home/user/my project/main.cpp"),
+      // JDK-8162518: Path.of(URI) throws "Bad escape" for a hierarchical URI with an empty authority component
+      // (e.g. "file:///...") containing raw, non-percent-encoded non-ASCII characters; falls back to URL.getPath()
+      Arguments.of("file:///home/user/src/español/main.cpp", "/home/user/src/español/main.cpp"));
   }
 }

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/FileUtilsTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/FileUtilsTests.java
@@ -1,0 +1,58 @@
+/*
+ * SonarLint Core - Commons
+ * Copyright (C) SonarSource Sàrl
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonarsource.sonarlint.core.commons.util;
+
+import java.net.URI;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileUtilsTests {
+
+  @Test
+  void shouldDecodePercentEncodedPlusSignsInUri() {
+    var uri = URI.create("file:///home/user/src/c%2B%2B/main.cpp");
+
+    var path = FileUtils.getFilePathFromUri(uri);
+
+    assertThat(path).isEqualTo(Path.of("/home/user/src/c++/main.cpp"));
+  }
+
+  @Test
+  void shouldDecodePercentEncodedSpacesInUri() {
+    var uri = URI.create("file:///home/user/my%20project/main.cpp");
+
+    var path = FileUtils.getFilePathFromUri(uri);
+
+    assertThat(path).isEqualTo(Path.of("/home/user/my project/main.cpp"));
+  }
+
+  @Test
+  void shouldFallBackToUrlPathForUriWithRawNonAsciiCharacters() {
+    // JDK-8162518: Path.of(URI) throws "Bad escape" for a hierarchical URI with an empty authority
+    // component (e.g. "file:///...") containing raw, non-percent-encoded non-ASCII characters
+    var uri = URI.create("file:///home/user/src/español/main.cpp");
+
+    var path = FileUtils.getFilePathFromUri(uri);
+
+    assertThat(path).isEqualTo(Path.of("/home/user/src/español/main.cpp"));
+  }
+}

--- a/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/FileUtilsTests.java
+++ b/backend/commons/src/test/java/org/sonarsource/sonarlint/core/commons/util/FileUtilsTests.java
@@ -43,7 +43,10 @@ class FileUtilsTests {
       Arguments.of("file:///home/user/src/c%2B%2B/main.cpp", "/home/user/src/c++/main.cpp"),
       Arguments.of("file:///home/user/my%20project/main.cpp", "/home/user/my project/main.cpp"),
       // JDK-8162518: Path.of(URI) throws "Bad escape" for a hierarchical URI with an empty authority component
-      // (e.g. "file:///...") containing raw, non-percent-encoded non-ASCII characters; falls back to URL.getPath()
-      Arguments.of("file:///home/user/src/español/main.cpp", "/home/user/src/español/main.cpp"));
+      // (e.g. "file:///...") containing raw, non-percent-encoded non-ASCII characters; falls back to URI.getPath()
+      Arguments.of("file:///home/user/src/español/main.cpp", "/home/user/src/español/main.cpp"),
+      // Same JDK-8162518 fallback, but the path also contains a percent-encoded segment: URI.getPath() must
+      // decode "%2B" while leaving the raw "é" alone
+      Arguments.of("file:///home/user/josé/c%2B%2B/main.cpp", "/home/user/josé/c++/main.cpp"));
   }
 }

--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/analysis/BackendInputFileTests.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/analysis/BackendInputFileTests.java
@@ -51,4 +51,15 @@ class BackendInputFileTests {
     assertThat(inputFile.getPath().replace(File.separatorChar, '/')).endsWith(pathAsString);
   }
 
+  @Test
+  void uri_encoded_plus_signs_in_path_segments_should_be_decoded() {
+    var path = Path.of("/test/src/c++/main.cpp");
+    var pathAsString = path.toString().replace(File.separatorChar, '/');
+    var clientFile = new ClientFile(URI.create("file:///test/src/c%2B%2B/main.cpp"), "configScopeId", path, false, null, null, null, true);
+
+    var inputFile = new BackendInputFile(clientFile);
+
+    assertThat(inputFile.getPath().replace(File.separatorChar, '/')).endsWith(pathAsString);
+  }
+
 }


### PR DESCRIPTION
## Summary

- `FileUtils.getFilePathFromUri` tried `Path.of(uri.toURL().getPath())` first, but `URL.getPath()` does not decode percent-encoded sequences. A file in a directory named `c++` (sent as `file:///.../c%2B%2B/main.cpp`) or containing `@` (sent as `%40`) resolved to a literal, non-existent path, so SonarQube for IDE silently skipped the file instead of analyzing it.
- Swap the try/catch order: try `Path.of(uri)` first (correctly decodes percent-encoded sequences, including `%2B`), and only fall back to the old `URL`-based approach for the JDK-8162518 case — a `file:///...` URI containing raw, non-percent-encoded non-ASCII characters, which `Path.of(URI)` rejects with `IllegalArgumentException: Bad escape`.
- Added a short Javadoc on the method documenting its two unchecked-exception exit paths (`IllegalArgumentException` for malformed/non-hierarchical URIs, `FileSystemNotFoundException` for unsupported schemes such as IntelliJ's `temp:` or Eclipse's `rse:`), since none of its four callers handle it the same way.

Fixes USER-2137, SLCORE-2443.

## Test plan

- [x] `FileUtilsTests` (new): covers `%2B%2B` decoding, `%20` decoding, and the JDK-8162518 raw-non-ASCII fallback path.
- [x] `BackendInputFileTests` (updated): added a case reproducing the exact `c%2B%2B` scenario from the linked support reproducer, through the real `ClientFile` → `BackendInputFile` path.
- [x] `mvn -pl backend/commons test` — 154/154 pass.
- [x] `mvn -pl backend/core -am test -Dtest=BackendInputFileTests` — 3/3 pass, including the pre-existing non-ASCII test (confirms the JDK-8162518 fallback still works).
- [x] Manually verified end-to-end in SonarQube for VS Code with a local build (sonarlint-core → sonarlint-language-server → sonarlint-vscode): a C/C++ reproducer with `compile_commands.json` covering `c++/main.cpp` and `user@example.com/main.cpp` directories confirmed the issue reproduces on the released build and is resolved by this fix.

After:

<img width="1067" height="566" alt="after" src="https://github.com/user-attachments/assets/557134c7-661c-4f74-beaa-5502678fb56c" />

Before:

<img width="1532" height="801" alt="before" src="https://github.com/user-attachments/assets/a8a2fd3c-c100-4633-bda7-ea97d6f8c2f9" />
