### PR TITLE
SLCORE-2558 Bump jackson-databind to 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <flyway.version>11.20.3</flyway.version>
     <!-- Override the Jackson transitively pulled by flyway-core (2.19.1): 11.20.3 is the last Flyway release
          on Jackson 2.x, later versions move flyway-core itself to Jackson 3.x (tools.jackson.core) -->
-    <jackson.version>2.22.1</jackson.version>
+    <jackson.version>2.22.2</jackson.version>
     <bouncycastle.version>1.85</bouncycastle.version>
     <!-- Override the Jetty transitively pulled by wiremock-jetty12:3.13.2 (test scope, 12.0.30):
          fixes CVE-2026-10050 (jetty-security/jetty-client Digest auth bypass), wiremock-jetty12 has no newer release yet -->


### PR DESCRIPTION
## Summary
- Bump the shared `jackson.version` property in the root `pom.xml` from `2.22.1` to `2.22.2` to address a dependency risk on `jackson-databind`.
- This also bumps `jackson-core` (same property), which has a matching `2.22.2` release.
- `jackson-annotations` stays pinned at `2.22` — Maven Central has no `2.22.2` release for that module.

## Test plan
- [x] `mvn dependency:tree -Dincludes=com.fasterxml.jackson.core` confirms resolved versions: `jackson-databind:2.22.2`, `jackson-core:2.22.2`, `jackson-annotations:2.22`.
- [x] Full reactor build (`mvn install -Dmaven.test.skip=true`) succeeds across all modules.
- [x] `server-connection` module tests pass (direct `ObjectMapper`/`EntityMapper` usage).
- [x] Full `mvn test` suite run across the reactor (see CI / follow-up comment for result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)