### PR TITLE
SLCORE-2534 Update analyzer test dependencies to latest versions

### DIFF
--- a/backend/analysis-engine/pom.xml
+++ b/backend/analysis-engine/pom.xml
@@ -81,7 +81,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.python</groupId>
                   <artifactId>sonar-python-plugin</artifactId>
-                  <version>5.18.0.31561</version>
+                  <version>5.31.0.36502</version>
                   <type>jar</type>
                 </artifactItem>
               </artifactItems>

--- a/backend/rule-extractor/pom.xml
+++ b/backend/rule-extractor/pom.xml
@@ -80,55 +80,55 @@
                 <artifactItem>
                   <groupId>org.sonarsource.java</groupId>
                   <artifactId>sonar-java-plugin</artifactId>
-                  <version>8.25.0.42802</version>
+                  <version>8.41.0.47177</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>11.8.0.37897</version>
+                  <version>13.8.0.44569</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.php</groupId>
                   <artifactId>sonar-php-plugin</artifactId>
-                  <version>3.55.0.15704</version>
+                  <version>3.60.0.16641</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.python</groupId>
                   <artifactId>sonar-python-plugin</artifactId>
-                  <version>5.18.0.31561</version>
+                  <version>5.31.0.36502</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.kotlin</groupId>
                   <artifactId>sonar-kotlin-plugin</artifactId>
-                  <version>3.4.0.8957</version>
+                  <version>3.9.0.9809</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.slang</groupId>
                   <artifactId>sonar-ruby-plugin</artifactId>
-                  <version>1.22.0.1992</version>
+                  <version>1.25.0.2597</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.slang</groupId>
                   <artifactId>sonar-scala-plugin</artifactId>
-                  <version>1.21.0.1997</version>
+                  <version>1.24.0.2554</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.html</groupId>
                   <artifactId>sonar-html-plugin</artifactId>
-                  <version>3.24.0.7341</version>
+                  <version>3.28.0.8018</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.xml</groupId>
                   <artifactId>sonar-xml-plugin</artifactId>
-                  <version>2.16.0.7616</version>
+                  <version>2.19.0.8138</version>
                   <type>jar</type>
                 </artifactItem>
               </artifactItems>
@@ -168,55 +168,55 @@
                     <artifactItem>
                       <groupId>com.sonarsource.abap</groupId>
                       <artifactId>sonar-abap-plugin</artifactId>
-                      <version>3.17.0.7722</version>
+                      <version>3.22.0.8389</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.cpp</groupId>
                       <artifactId>sonar-cfamily-plugin</artifactId>
-                      <version>6.78.0.96395</version>
+                      <version>6.84.0.101652</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.cobol</groupId>
                       <artifactId>sonar-cobol-plugin</artifactId>
-                      <version>5.11.0.10062</version>
+                      <version>5.14.0.11418</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.pli</groupId>
                       <artifactId>sonar-pli-plugin</artifactId>
-                      <version>1.21.0.7212</version>
+                      <version>1.25.0.7689</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.plsql</groupId>
                       <artifactId>sonar-plsql-plugin</artifactId>
-                      <version>3.18.1.230</version>
+                      <version>3.24.0.9611</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.rpg</groupId>
                       <artifactId>sonar-rpg-plugin</artifactId>
-                      <version>3.13.0.7515</version>
+                      <version>3.18.0.8642</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.swift</groupId>
                       <artifactId>sonar-swift-plugin</artifactId>
-                      <version>5.1.0.12421</version>
+                      <version>5.8.0.13396</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.slang</groupId>
                       <artifactId>sonar-apex-plugin</artifactId>
-                      <version>1.24.0.2040</version>
+                      <version>1.25.0.2398</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>com.sonarsource.tsql</groupId>
                       <artifactId>sonar-tsql-plugin</artifactId>
-                      <version>1.16.1.9133</version>
+                      <version>1.20.0.9447</version>
                       <type>jar</type>
                     </artifactItem>
                   </artifactItems>

--- a/backend/rule-extractor/pom.xml
+++ b/backend/rule-extractor/pom.xml
@@ -86,7 +86,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>13.8.0.44569</version>
+                  <version>11.8.0.37897</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/backend/rule-extractor/src/test/java/mediumtests/RuleExtractorMediumTests.java
+++ b/backend/rule-extractor/src/test/java/mediumtests/RuleExtractorMediumTests.java
@@ -50,11 +50,11 @@ class RuleExtractorMediumTests {
   private static final SonarLintLogTester logTester = new SonarLintLogTester();
 
   private static final int COMMERCIAL_RULE_TEMPLATES_COUNT = 11;
-  private static final int NON_COMMERCIAL_RULE_TEMPLATES_COUNT = 16;
-  private static final int COMMERCIAL_SECURITY_HOTSPOTS_COUNT = 82;
-  private static final int NON_COMMERCIAL_SECURITY_HOTSPOTS_COUNT = 298;
-  private static final int ALL_RULES_COUNT_WITHOUT_COMMERCIAL = 2732;
-  private static final int ALL_RULES_COUNT_WITH_COMMERCIAL = 4823;
+  private static final int NON_COMMERCIAL_RULE_TEMPLATES_COUNT = 20;
+  private static final int COMMERCIAL_SECURITY_HOTSPOTS_COUNT = 0;
+  private static final int NON_COMMERCIAL_SECURITY_HOTSPOTS_COUNT = 124;
+  private static final int ALL_RULES_COUNT_WITHOUT_COMMERCIAL = 3107;
+  private static final int ALL_RULES_COUNT_WITH_COMMERCIAL = 5279;
   // commercial plugins might not be available
   // (if you pass -Dcommercial to maven, a profile will be activated that downloads the commercial plugins)
   private static final boolean COMMERCIAL_ENABLED = System.getProperty("commercial") != null;

--- a/its/tests/pom.xml
+++ b/its/tests/pom.xml
@@ -170,25 +170,25 @@
                 <artifactItem>
                   <groupId>com.sonarsource.cpp</groupId>
                   <artifactId>sonar-cfamily-plugin</artifactId>
-                  <version>6.75.1.93101</version>
+                  <version>6.84.0.101652</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.go</groupId>
                   <artifactId>sonar-go-plugin</artifactId>
-                  <version>1.31.0.4938</version>
+                  <version>1.43.0.7704</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.iac</groupId>
                   <artifactId>sonar-iac-plugin</artifactId>
-                  <version>2.2.0.18377</version>
+                  <version>2.15.0.22475</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>11.7.1.36988</version>
+                  <version>13.8.0.44569</version>
                   <type>jar</type>
                 </artifactItem>
               </artifactItems>

--- a/its/tests/pom.xml
+++ b/its/tests/pom.xml
@@ -188,7 +188,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>13.8.0.44569</version>
+                  <version>11.8.0.37897</version>
                   <type>jar</type>
                 </artifactItem>
               </artifactItems>

--- a/its/tests/src/test/java/its/utils/PluginLocator.java
+++ b/its/tests/src/test/java/its/utils/PluginLocator.java
@@ -26,19 +26,19 @@ import java.util.Map;
 public class PluginLocator {
 
   public static Path getCppPluginPath() {
-    return getPluginPath("sonar-cfamily-plugin-6.75.1.93101.jar");
+    return getPluginPath("sonar-cfamily-plugin-6.84.0.101652.jar");
   }
 
   public static Path getGoPluginPath() {
-    return getPluginPath("sonar-go-plugin-1.31.0.4938.jar");
+    return getPluginPath("sonar-go-plugin-1.43.0.7704.jar");
   }
 
   public static Path getIacPluginPath() {
-    return getPluginPath("sonar-iac-plugin-2.2.0.18377.jar");
+    return getPluginPath("sonar-iac-plugin-2.15.0.22475.jar");
   }
 
   public static Path getJavascriptPluginPath() {
-    return getPluginPath("sonar-javascript-plugin-11.7.1.36988.jar");
+    return getPluginPath("sonar-javascript-plugin-13.8.0.44569.jar");
   }
 
   public static Map<String, Path> getEmbeddedPluginsByKeyForTests() {

--- a/its/tests/src/test/java/its/utils/PluginLocator.java
+++ b/its/tests/src/test/java/its/utils/PluginLocator.java
@@ -38,7 +38,7 @@ public class PluginLocator {
   }
 
   public static Path getJavascriptPluginPath() {
-    return getPluginPath("sonar-javascript-plugin-13.8.0.44569.jar");
+    return getPluginPath("sonar-javascript-plugin-11.8.0.37897.jar");
   }
 
   public static Map<String, Path> getEmbeddedPluginsByKeyForTests() {

--- a/medium-tests/pom.xml
+++ b/medium-tests/pom.xml
@@ -124,7 +124,7 @@
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>13.8.0.44569</version>
+                  <version>11.8.0.37897</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>

--- a/medium-tests/pom.xml
+++ b/medium-tests/pom.xml
@@ -118,43 +118,43 @@
                 <artifactItem>
                   <groupId>org.sonarsource.java</groupId>
                   <artifactId>sonar-java-plugin</artifactId>
-                  <version>8.25.0.42802</version>
+                  <version>8.41.0.47177</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.javascript</groupId>
                   <artifactId>sonar-javascript-plugin</artifactId>
-                  <version>11.8.0.37897</version>
+                  <version>13.8.0.44569</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.php</groupId>
                   <artifactId>sonar-php-plugin</artifactId>
-                  <version>3.55.0.15704</version>
+                  <version>3.60.0.16641</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.python</groupId>
                   <artifactId>sonar-python-plugin</artifactId>
-                  <version>5.18.0.31561</version>
+                  <version>5.31.0.36502</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.xml</groupId>
                   <artifactId>sonar-xml-plugin</artifactId>
-                  <version>2.16.0.7616</version>
+                  <version>2.19.0.8138</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.text</groupId>
                   <artifactId>sonar-text-plugin</artifactId>
-                  <version>2.41.0.10709</version>
+                  <version>2.49.0.12346</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.sonarsource.kotlin</groupId>
                   <artifactId>sonar-kotlin-plugin</artifactId>
-                  <version>3.4.0.8957</version>
+                  <version>3.9.0.9809</version>
                   <type>jar</type>
                 </artifactItem>
                 <artifactItem>
@@ -235,13 +235,13 @@
                     <artifactItem>
                       <groupId>com.sonarsource.cpp</groupId>
                       <artifactId>sonar-cfamily-plugin</artifactId>
-                      <version>6.78.0.96395</version>
+                      <version>6.84.0.101652</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>
                       <groupId>org.sonarsource.java</groupId>
                       <artifactId>sonar-java-symbolic-execution-plugin</artifactId>
-                      <version>8.19.0.1586</version>
+                      <version>8.16.4.1912</version>
                       <type>jar</type>
                     </artifactItem>
                     <artifactItem>

--- a/medium-tests/src/test/java/utils/PluginLocator.java
+++ b/medium-tests/src/test/java/utils/PluginLocator.java
@@ -26,7 +26,7 @@ import java.nio.file.Paths;
 public class PluginLocator {
   public static final String SONAR_JAVA_PLUGIN_VERSION = "8.41.0.47177";
   public static final String SONAR_JAVA_PLUGIN_JAR = "sonar-java-plugin-" + SONAR_JAVA_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_JAVA_PLUGIN_JAR_HASH = "fa425ffda3272aef1abc137941a64772";
+  public static final String SONAR_JAVA_PLUGIN_JAR_HASH = "XXX";
   public static final String SONAR_JAVA_SE_PLUGIN_VERSION = "8.16.4.1912";
   public static final String SONAR_JAVA_SE_PLUGIN_JAR = "sonar-java-symbolic-execution-plugin-" + SONAR_JAVA_SE_PLUGIN_VERSION + ".jar";
   public static final String SONAR_JAVA_SE_PLUGIN_JAR_HASH = "unused";
@@ -38,17 +38,17 @@ public class PluginLocator {
   public static final String SONAR_DBD_JAVA_PLUGIN_JAR = "sonar-dbd-java-frontend-plugin-" + SONAR_DBD_JAVA_PLUGIN_VERSION + ".jar";
   public static final String SONAR_DBD_JAVA_PLUGIN_JAR_HASH = "unused";
 
-  public static final String SONAR_JAVASCRIPT_PLUGIN_VERSION = "13.8.0.44569";
+  public static final String SONAR_JAVASCRIPT_PLUGIN_VERSION = "11.8.0.37897";
   public static final String SONAR_JAVASCRIPT_PLUGIN_JAR = "sonar-javascript-plugin-" + SONAR_JAVASCRIPT_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_JAVASCRIPT_PLUGIN_JAR_HASH = "2fab92be44e07f1d367f891a55258736";
+  public static final String SONAR_JAVASCRIPT_PLUGIN_JAR_HASH = "XXX";
 
   public static final String SONAR_PHP_PLUGIN_VERSION = "3.60.0.16641";
   public static final String SONAR_PHP_PLUGIN_JAR = "sonar-php-plugin-" + SONAR_PHP_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_PHP_PLUGIN_JAR_HASH = "88ddaa391f3176891a62375e98b76ae9";
+  public static final String SONAR_PHP_PLUGIN_JAR_HASH = "XXX";
 
   public static final String SONAR_PYTHON_PLUGIN_VERSION = "5.31.0.36502";
   public static final String SONAR_PYTHON_PLUGIN_JAR = "sonar-python-plugin-" + SONAR_PYTHON_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_PYTHON_PLUGIN_JAR_HASH = "e1cff9e38811ab71e6efbff087743367";
+  public static final String SONAR_PYTHON_PLUGIN_JAR_HASH = "XXX";
 
   public static final String SONAR_KOTLIN_PLUGIN_VERSION = "3.9.0.9809";
   public static final String SONAR_KOTLIN_PLUGIN_JAR = "sonar-kotlin-plugin-" + SONAR_KOTLIN_PLUGIN_VERSION + ".jar";
@@ -68,7 +68,7 @@ public class PluginLocator {
 
   public static final String SONAR_TEXT_PLUGIN_VERSION = "2.49.0.12346";
   public static final String SONAR_TEXT_PLUGIN_JAR = "sonar-text-plugin-" + SONAR_TEXT_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_TEXT_PLUGIN_JAR_HASH = "f679af4c0e2992c3cec281d6a9cd5062";
+  public static final String SONAR_TEXT_PLUGIN_JAR_HASH = "XXX";
 
   public static final String SONAR_CFAMILY_PLUGIN_VERSION = "6.84.0.101652";
   private static final String SONAR_CFAMILY_PLUGIN_JAR = "sonar-cfamily-plugin-" + SONAR_CFAMILY_PLUGIN_VERSION + ".jar";

--- a/medium-tests/src/test/java/utils/PluginLocator.java
+++ b/medium-tests/src/test/java/utils/PluginLocator.java
@@ -24,10 +24,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class PluginLocator {
-  public static final String SONAR_JAVA_PLUGIN_VERSION = "8.25.0.42802";
+  public static final String SONAR_JAVA_PLUGIN_VERSION = "8.41.0.47177";
   public static final String SONAR_JAVA_PLUGIN_JAR = "sonar-java-plugin-" + SONAR_JAVA_PLUGIN_VERSION + ".jar";
   public static final String SONAR_JAVA_PLUGIN_JAR_HASH = "fa425ffda3272aef1abc137941a64772";
-  public static final String SONAR_JAVA_SE_PLUGIN_VERSION = "8.19.0.1586";
+  public static final String SONAR_JAVA_SE_PLUGIN_VERSION = "8.16.4.1912";
   public static final String SONAR_JAVA_SE_PLUGIN_JAR = "sonar-java-symbolic-execution-plugin-" + SONAR_JAVA_SE_PLUGIN_VERSION + ".jar";
   public static final String SONAR_JAVA_SE_PLUGIN_JAR_HASH = "unused";
 
@@ -38,19 +38,19 @@ public class PluginLocator {
   public static final String SONAR_DBD_JAVA_PLUGIN_JAR = "sonar-dbd-java-frontend-plugin-" + SONAR_DBD_JAVA_PLUGIN_VERSION + ".jar";
   public static final String SONAR_DBD_JAVA_PLUGIN_JAR_HASH = "unused";
 
-  public static final String SONAR_JAVASCRIPT_PLUGIN_VERSION = "11.8.0.37897";
+  public static final String SONAR_JAVASCRIPT_PLUGIN_VERSION = "13.8.0.44569";
   public static final String SONAR_JAVASCRIPT_PLUGIN_JAR = "sonar-javascript-plugin-" + SONAR_JAVASCRIPT_PLUGIN_VERSION + ".jar";
   public static final String SONAR_JAVASCRIPT_PLUGIN_JAR_HASH = "2fab92be44e07f1d367f891a55258736";
 
-  public static final String SONAR_PHP_PLUGIN_VERSION = "3.55.0.15704";
+  public static final String SONAR_PHP_PLUGIN_VERSION = "3.60.0.16641";
   public static final String SONAR_PHP_PLUGIN_JAR = "sonar-php-plugin-" + SONAR_PHP_PLUGIN_VERSION + ".jar";
   public static final String SONAR_PHP_PLUGIN_JAR_HASH = "88ddaa391f3176891a62375e98b76ae9";
 
-  public static final String SONAR_PYTHON_PLUGIN_VERSION = "5.18.0.31561";
+  public static final String SONAR_PYTHON_PLUGIN_VERSION = "5.31.0.36502";
   public static final String SONAR_PYTHON_PLUGIN_JAR = "sonar-python-plugin-" + SONAR_PYTHON_PLUGIN_VERSION + ".jar";
   public static final String SONAR_PYTHON_PLUGIN_JAR_HASH = "e1cff9e38811ab71e6efbff087743367";
 
-  public static final String SONAR_KOTLIN_PLUGIN_VERSION = "3.4.0.8957";
+  public static final String SONAR_KOTLIN_PLUGIN_VERSION = "3.9.0.9809";
   public static final String SONAR_KOTLIN_PLUGIN_JAR = "sonar-kotlin-plugin-" + SONAR_KOTLIN_PLUGIN_VERSION + ".jar";
   public static final String SONAR_KOTLIN_PLUGIN_JAR_HASH = "XXX";
 
@@ -62,15 +62,15 @@ public class PluginLocator {
   public static final String SONAR_OMNISHARP_PLUGIN_JAR = "sonarlint-omnisharp-plugin-" + SONAR_OMNISHARP_PLUGIN_VERSION + ".jar";
   public static final String SONAR_OMNISHARP_PLUGIN_JAR_HASH = "XXX";
 
-  public static final String SONAR_XML_PLUGIN_VERSION = "2.16.0.7616";
+  public static final String SONAR_XML_PLUGIN_VERSION = "2.19.0.8138";
   public static final String SONAR_XML_PLUGIN_JAR = "sonar-xml-plugin-" + SONAR_XML_PLUGIN_VERSION + ".jar";
   public static final String SONAR_XML_PLUGIN_JAR_HASH = "XXX";
 
-  public static final String SONAR_TEXT_PLUGIN_VERSION = "2.41.0.10709";
+  public static final String SONAR_TEXT_PLUGIN_VERSION = "2.49.0.12346";
   public static final String SONAR_TEXT_PLUGIN_JAR = "sonar-text-plugin-" + SONAR_TEXT_PLUGIN_VERSION + ".jar";
   public static final String SONAR_TEXT_PLUGIN_JAR_HASH = "f679af4c0e2992c3cec281d6a9cd5062";
 
-  public static final String SONAR_CFAMILY_PLUGIN_VERSION = "6.78.0.96395";
+  public static final String SONAR_CFAMILY_PLUGIN_VERSION = "6.84.0.101652";
   private static final String SONAR_CFAMILY_PLUGIN_JAR = "sonar-cfamily-plugin-" + SONAR_CFAMILY_PLUGIN_VERSION + ".jar";
   public static final String SONAR_CFAMILY_PLUGIN_JAR_HASH = "XXX";
 

--- a/medium-tests/src/test/java/utils/PluginLocator.java
+++ b/medium-tests/src/test/java/utils/PluginLocator.java
@@ -26,7 +26,7 @@ import java.nio.file.Paths;
 public class PluginLocator {
   public static final String SONAR_JAVA_PLUGIN_VERSION = "8.41.0.47177";
   public static final String SONAR_JAVA_PLUGIN_JAR = "sonar-java-plugin-" + SONAR_JAVA_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_JAVA_PLUGIN_JAR_HASH = "XXX";
+  public static final String SONAR_JAVA_PLUGIN_JAR_HASH = "e2f9198bdc82a87541444f0c02ad5c36";
   public static final String SONAR_JAVA_SE_PLUGIN_VERSION = "8.16.4.1912";
   public static final String SONAR_JAVA_SE_PLUGIN_JAR = "sonar-java-symbolic-execution-plugin-" + SONAR_JAVA_SE_PLUGIN_VERSION + ".jar";
   public static final String SONAR_JAVA_SE_PLUGIN_JAR_HASH = "unused";
@@ -40,15 +40,15 @@ public class PluginLocator {
 
   public static final String SONAR_JAVASCRIPT_PLUGIN_VERSION = "11.8.0.37897";
   public static final String SONAR_JAVASCRIPT_PLUGIN_JAR = "sonar-javascript-plugin-" + SONAR_JAVASCRIPT_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_JAVASCRIPT_PLUGIN_JAR_HASH = "XXX";
+  public static final String SONAR_JAVASCRIPT_PLUGIN_JAR_HASH = "27f28ae953480c4353e36a02dd06aef1";
 
   public static final String SONAR_PHP_PLUGIN_VERSION = "3.60.0.16641";
   public static final String SONAR_PHP_PLUGIN_JAR = "sonar-php-plugin-" + SONAR_PHP_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_PHP_PLUGIN_JAR_HASH = "XXX";
+  public static final String SONAR_PHP_PLUGIN_JAR_HASH = "5809bf29e3ec4195e79dc220ed065fd9";
 
   public static final String SONAR_PYTHON_PLUGIN_VERSION = "5.31.0.36502";
   public static final String SONAR_PYTHON_PLUGIN_JAR = "sonar-python-plugin-" + SONAR_PYTHON_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_PYTHON_PLUGIN_JAR_HASH = "XXX";
+  public static final String SONAR_PYTHON_PLUGIN_JAR_HASH = "cd860626dfc10508e137b76540cfc64e";
 
   public static final String SONAR_KOTLIN_PLUGIN_VERSION = "3.9.0.9809";
   public static final String SONAR_KOTLIN_PLUGIN_JAR = "sonar-kotlin-plugin-" + SONAR_KOTLIN_PLUGIN_VERSION + ".jar";
@@ -68,7 +68,7 @@ public class PluginLocator {
 
   public static final String SONAR_TEXT_PLUGIN_VERSION = "2.49.0.12346";
   public static final String SONAR_TEXT_PLUGIN_JAR = "sonar-text-plugin-" + SONAR_TEXT_PLUGIN_VERSION + ".jar";
-  public static final String SONAR_TEXT_PLUGIN_JAR_HASH = "XXX";
+  public static final String SONAR_TEXT_PLUGIN_JAR_HASH = "9be350ba174d0364a5258eafeedd1a01";
 
   public static final String SONAR_CFAMILY_PLUGIN_VERSION = "6.84.0.101652";
   private static final String SONAR_CFAMILY_PLUGIN_JAR = "sonar-cfamily-plugin-" + SONAR_CFAMILY_PLUGIN_VERSION + ".jar";


### PR DESCRIPTION
## Summary
Bumps the analyzer plugin versions used in test/rule-extraction dependencies (`rule-extractor`, `medium-tests`, `its/tests`, `analysis-engine`) to their latest available releases: java, php, python, kotlin, ruby, scala, html, xml, text, go, iac, abap, cfamily, cobol, pli, plsql, rpg, swift, apex, tsql.

`sonar-javascript-plugin` is intentionally kept at `11.8.0.37897` (not bumped). Version 13.x breaks rule loading in `RulesDefinitionExtractor` (JS drops out of the enabled languages, ~400 rules go missing) and fails a live SonarCloud javascript taint-vulnerability IT — it needs a newer plugin-api than sonarlint-core currently implements (tracked separately in SLCORE-2079).

`sonar-java-symbolic-execution-plugin` is set to `8.16.4.1912` to match the version currently pinned across the SonarLint IDE repos (see JAVASE-227).

`RuleExtractorMediumTests`'s expected rule/hotspot/template counts were updated to match what the new analyzer set actually produces.

## Test plan
- [x] Affected modules compile (`rule-extractor`, `analysis-engine`, `medium-tests`, `its/tests`)
- [x] `RuleExtractorMediumTests` passes locally against the real jars, with and without the commercial profile
- [x] CI (Linux/Windows unit tests, SonarCloud EU/US ITs)