### PR TITLE
DEX-105 Use agentic-sdlc-development-experience-squad as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/remediation-ide-experience-squad
+.github/CODEOWNERS @sonarsource/agentic-sdlc-development-experience-squad


### PR DESCRIPTION
## Summary
- Replace `@SonarSource/remediation-ide-experience-squad` / `@sonarsource/remediation-ide-experience-squad` with `@sonarsource/agentic-sdlc-development-experience-squad` in CODEOWNERS