### PR TITLE
SLCORE-2574 11.10 analyzer updates

### DIFF
--- a/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
+++ b/backend/core/src/test/java/org/sonarsource/sonarlint/core/plugin/source/BinariesArtifactTest.java
@@ -58,7 +58,7 @@ class BinariesArtifactTest {
   @Test
   void should_return_versions_from_properties() {
     assertThat(BinariesArtifact.CFAMILY_PLUGIN.version()).isEqualTo("6.85.0.102562");
-    assertThat(BinariesArtifact.CSHARP_OSS.version()).isEqualTo("10.31.0.145097");
+    assertThat(BinariesArtifact.CSHARP_OSS.version()).isEqualTo("10.34.0.3385");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <handlebars.version>4.5.3</handlebars.version>
     <!-- On-demand plugin versions -->
     <cfamily.version>6.85.0.102562</cfamily.version>
-    <csharp.version>10.31.0.145097</csharp.version>
+    <csharp.version>10.34.0.3385</csharp.version>
     <omnisharp.version>1.39.15.1-sonar</omnisharp.version>
   </properties>
 


### PR DESCRIPTION
Analyzer updates for the 11.10 release.

- SLCORE-2574 Update dotnet-enterprise to 10.34.0.3385

🤖 Generated with [Claude Code](https://claude.com/claude-code)