### PR TITLE
SONARSEC-8851 Fix SQDogfood taint IT failures after SonarSecurity message rework

### DIFF
--- a/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
+++ b/its/tests/src/test/java/its/SonarQubeDeveloperEditionTests.java
@@ -773,6 +773,10 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
       var request = new PostRequest("api/projects/bulk_delete");
       request.setParam("projects", PROJECT_KEY_JAVA_TAINT);
       try (var response = adminWsClient.wsConnector().call(request)) {
+        assertThat(response.code())
+          .withFailMessage(() -> "Failed to delete project '" + PROJECT_KEY_JAVA_TAINT + "', got HTTP " + response.code()
+            + ". Leftover taint issues on the server can cause the next run of this test to see duplicated/stale vulnerabilities.")
+          .isBetween(200, 399);
       }
     }
 
@@ -845,7 +849,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
       assertThat(firstTaintChangedEvent.getAddedTaintVulnerabilities())
         .extracting(TaintVulnerabilityDto::getSonarServerKey, TaintVulnerabilityDto::isResolved, TaintVulnerabilityDto::getRuleKey, TaintVulnerabilityDto::getMessage,
           TaintVulnerabilityDto::getIdeFilePath, TaintVulnerabilityDto::isOnNewCode)
-        .containsExactly(tuple(issueKey, false, "javasecurity:S3649", "Change this code to not construct SQL queries directly from user-controlled data.",
+        .containsExactly(tuple(issueKey, false, "javasecurity:S3649", "SQL Injection via unsanitized user input in DbHelper.executeQuery()",
           Paths.get("src/main/java/foo/DbHelper.java"), true));
       assertThat(firstTaintChangedEvent.getAddedTaintVulnerabilities())
         .flatExtracting("flows")
@@ -866,7 +870,7 @@ class SonarQubeDeveloperEditionTests extends AbstractConnectedTests {
       assertThat(taintIssues)
         .extracting(TaintVulnerabilityDto::getSonarServerKey, TaintVulnerabilityDto::isResolved, TaintVulnerabilityDto::getRuleKey, TaintVulnerabilityDto::getMessage,
           TaintVulnerabilityDto::getIdeFilePath, TaintVulnerabilityDto::isOnNewCode)
-        .containsExactly(tuple(issueKey, false, "javasecurity:S3649", "Change this code to not construct SQL queries directly from user-controlled data.",
+        .containsExactly(tuple(issueKey, false, "javasecurity:S3649", "SQL Injection via unsanitized user input in DbHelper.executeQuery()",
           Paths.get("src/main/java/foo/DbHelper.java"), true));
       assertThat(taintIssues)
         .flatExtracting("flows")


### PR DESCRIPTION
## Summary
- `SONARSEC-8714` reworked taint issue messages in SonarSecurity from the old canned text to the new `<Vulnerability> via <vector> in <method>()` format. This broke the hardcoded message assertions in `SonarQubeDeveloperEditionTests$TaintVulnerabilities`, which have been failing consistently on `QA (SQDogfood)` since PR #2262.
- Hardened the `@AfterEach` cleanup to assert the `api/projects/bulk_delete` call actually succeeds (matching the existing pattern in `SonarCloudTests`), instead of silently swallowing the response. A silently failed delete can leave a stale, old-message taint issue on the server that the message-based matching no longer recognizes as the same issue as a freshly-analyzed one — which is the likely cause of the `shouldSyncTaintVulnerabilities` test also seeing 2 vulnerabilities instead of 1 on `QA (SQDogfood)`.

## Test plan
- [x] `mvn -Pits -pl its/tests -am test-compile` passes locally.
- [ ] `QA (SQDogfood)` CI job goes green (may still require the shared `sample-java-taint` project's stale data on the dogfood server to be manually cleared once, since this fix only prevents future recurrence).